### PR TITLE
Previewable blobs include the url script_name if present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: |
           bin/rails db:test:prepare
-          bin/rails test:system
+          bin/rails test:all
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/lib/active_storage/blob_with_preview_url.rb
+++ b/lib/active_storage/blob_with_preview_url.rb
@@ -8,7 +8,7 @@ module ActiveStorage
       if previewable?
         json["previewable"] = true
         json["url"] = Rails.application.routes.url_helpers.rails_representation_path(
-          preview(resize_to_limit: PREVIEW_SIZE), only_path: true
+          preview(resize_to_limit: PREVIEW_SIZE), ActiveStorage::Current.url_options.merge(only_path: true)
         )
       end
 

--- a/test/actiontext/blob_test.rb
+++ b/test/actiontext/blob_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class BlobTest < ActiveSupport::TestCase
+  setup do
+    @was_url_options, ActiveStorage::Current.url_options = ActiveStorage::Current.url_options, {}
+  end
+
+  teardown do
+    ActiveStorage::Current.url_options = @was_url_options
+  end
+
+  test "as_json does not include preview URL for non-previewable attachments" do
+    blob = create_blob "example.jpg", "image/jpeg"
+    assert_not blob.as_json.key?("previewable")
+    assert_not blob.as_json.key?("url")
+  end
+
+  test "as_json includes preview URL" do
+    blob = create_blob "example.pdf", "application/pdf"
+
+    assert blob.as_json["previewable"]
+    assert_match %r{^/rails/active_storage/representations/redirect/}, blob.as_json["url"]
+  end
+
+  test "as_json includes preview URL includes script_name if present" do
+    ActiveStorage::Current.url_options[:host] = "example.org" # Should not be present
+    ActiveStorage::Current.url_options[:script_name] = "/foo"
+
+    blob = create_blob "example.pdf", "application/pdf"
+
+    assert blob.as_json["previewable"]
+    assert_match %r{^/foo/rails/active_storage/representations/redirect/}, blob.as_json["url"]
+  end
+
+  private
+    def create_blob(filename, content_type)
+      ActiveStorage::Blob.create!(
+        filename: filename,
+        content_type: content_type,
+        checksum: "abc123",
+        byte_size: 1024
+      )
+    end
+end


### PR DESCRIPTION
Note that this PR introduces the first unit test, and so I've updated the CI workflow to run `bin/rails test:all`.

ref: https://fizzy.37signals.com/5986089/collections/2/cards/1004