### PR TITLE
Lexxy is visible when toolbar is disabled

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -11,10 +11,6 @@
   position: relative;
   transition: opacity 150ms;
 
-  &:not(:has(lexxy-toolbar)) {
-    opacity: 0;
-  }
-
   input,
   button {
     &:focus-visible {


### PR DESCRIPTION
When toolbar is set to false, Lexxy was displayed with 0 opacity. This PR removes that code.