### PR TITLE
Fix link button SVG being invisible

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -89,6 +89,7 @@
   position: relative;
 
   button[data-command],
+  button[data-dialog-target],
   summary {
     aspect-ratio: 1;
     block-size: 2lh;


### PR DESCRIPTION
The link button's SVG isn't visible because the selector only targets `button[data-command]` and `summary` elements. 

This adds `button[data-dialog-target]` as a selector which fixes the issue. It should also be helpful in the future if other buttons open dialogs.

Reported in #172