### PR TITLE
Make overriding action text defaults optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ Then import it in your JavaScript entry point:
 import "@37signals/lexxy"
 ```
 
+### Override Action Text defaults
+
+By default, the gem overrides Action Text form helpers, so that if you use `form.rich_text_area`, it will render a Lexxy editor instead of the default Trix editor.
+
+You can opt out of this behavior by disabling this option in `application.rb`:
+
+```ruby# config/application.rb
+config.lexxy.override_action_text_defaults = false
+```
+
+If you do this, you can invoke Lexxy explicitly using the same helpers with a `lexxy_preffix`: `lexxy_rich_textarea_tag` and `form.lexxy_rich_text_area`.
+
+This path is meant to let you incrementally move to Lexxy, or to use it in specific places while keeping Trix in others.
+
 ### CSS Setup
 
 For the CSS, you can include it with the standard Rails helper:

--- a/lib/lexxy.rb
+++ b/lib/lexxy.rb
@@ -2,5 +2,20 @@ require "lexxy/version"
 require "lexxy/engine"
 
 module Lexxy
-  # Your code goes here...
+  def self.override_action_text_defaults
+    ActionText::TagHelper.module_eval do
+      alias_method :rich_textarea_tag, :lexxy_rich_textarea_tag
+      alias_method :rich_text_area_tag, :lexxy_rich_textarea_tag
+    end
+
+    ActionView::Helpers::FormHelper.module_eval do
+      alias_method :rich_textarea, :lexxy_rich_textarea
+      alias_method :rich_text_area, :lexxy_rich_textarea
+    end
+
+    ActionView::Helpers::FormBuilder.module_eval do
+      alias_method :rich_textarea, :lexxy_rich_textarea
+      alias_method :rich_text_area, :lexxy_rich_textarea
+    end
+  end
 end

--- a/lib/lexxy/action_text_tag.rb
+++ b/lib/lexxy/action_text_tag.rb
@@ -11,7 +11,7 @@ module Lexxy
 
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [ options["id"], :trix_input ].compact.join("_")) if object
-      html_tag = @template_object.rich_textarea_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"), &@block)
+      html_tag = @template_object.lexxy_rich_textarea_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"), &@block)
       error_wrapping(html_tag)
     end
   end

--- a/lib/lexxy/engine.rb
+++ b/lib/lexxy/engine.rb
@@ -9,6 +9,9 @@ module Lexxy
   class Engine < ::Rails::Engine
     isolate_namespace Lexxy
 
+    config.lexxy = ActiveSupport::OrderedOptions.new
+    config.lexxy.override_action_text_defaults = true
+
     initializer "lexxy.initialize" do |app|
       app.config.to_prepare do
         # TODO: We need to move these extensions to Action Text
@@ -16,6 +19,8 @@ module Lexxy
         ActionView::Helpers::FormHelper.prepend(Lexxy::FormHelper)
         ActionView::Helpers::FormBuilder.prepend(Lexxy::FormBuilder)
         ActionView::Helpers::Tags::ActionText.prepend(Lexxy::ActionTextTag)
+
+        Lexxy.override_action_text_defaults if app.config.lexxy.override_action_text_defaults
       end
     end
 

--- a/lib/lexxy/form_builder.rb
+++ b/lib/lexxy/form_builder.rb
@@ -1,9 +1,9 @@
 module Lexxy
   module FormBuilder
-    def rich_textarea(method, options = {}, &block)
-      @template.rich_textarea(@object_name, method, objectify_options(options), &block)
+    def lexxy_rich_textarea(method, options = {}, &block)
+      @template.lexxy_rich_textarea(@object_name, method, objectify_options(options), &block)
     end
 
-    alias_method :rich_text_area, :rich_textarea
+    alias_method :lexxy_rich_text_area, :lexxy_rich_textarea
   end
 end

--- a/lib/lexxy/form_helper.rb
+++ b/lib/lexxy/form_helper.rb
@@ -1,9 +1,9 @@
 module Lexxy
   module FormHelper
-    def rich_textarea(object_name, method, options = {}, &block)
+    def lexxy_rich_textarea(object_name, method, options = {}, &block)
       ActionView::Helpers::Tags::ActionText.new(object_name, method, self, options, &block).render
     end
 
-    alias_method :rich_text_area, :rich_textarea
+    alias_method :lexxy_rich_text_area, :lexxy_rich_textarea
   end
 end

--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -1,6 +1,6 @@
 module Lexxy
   module TagHelper
-    def rich_textarea_tag(name, value = nil, options = {}, &block)
+    def lexxy_rich_textarea_tag(name, value = nil, options = {}, &block)
       options = options.symbolize_keys
       form = options.delete(:form)
 
@@ -18,7 +18,7 @@ module Lexxy
       editor_tag
     end
 
-    alias_method :rich_text_area_tag, :rich_textarea_tag
+    alias_method :lexxy_rich_text_area_tag, :lexxy_rich_textarea_tag
 
     private
       # Tempoary: we need to *adaptarize* action text

--- a/test/dummy/app/views/posts/_form.html.erb
+++ b/test/dummy/app/views/posts/_form.html.erb
@@ -1,6 +1,6 @@
 
 
-<%= form_with model: post, data: { controller: "events-logger file-acceptance", 
+<%= form_with model: post, data: { controller: "events-logger file-acceptance",
   file_acceptance_type_value: params[:attachment_type],
   action: "lexxy:change->events-logger#log lexxy:file-accept->file-acceptance#acceptFile" } do |form| %>
   <div>


### PR DESCRIPTION
So that existing apps using Trix have an easier migration path.