### PR TITLE
Use collection partial rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ end
 And the action would just list the prompt items:
 
 ```erb
-<% render partial: "people/prompt_item", collection: @people %>
+<%= render partial: "people/prompt_item", collection: @people %>
 ```
 
 ### Free HTML attachments


### PR DESCRIPTION
was poking through how Lexxy handles prompts and noticed it using loop rendering instead of collection rendering for the example.

I know its "just an example", but probably good to steer people away from rendering in loops especially on something like `<Model>.all`