### PR TITLE
Add support for rows attribute

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -2,6 +2,11 @@
 
 :where(lexxy-editor) {
   --lexxy-editor-padding: 1ch;
+  --lexxy-editor-rows: 8lh;
+  @supports (min-block-size: attr(rows lh)) {
+    --lexxy-editor-rows: attr(rows lh, 8lh);
+  }
+
   --lexxy-toolbar-gap: 2px;
 
   border: 1px solid var(--lexxy-color-ink-lighter);
@@ -63,7 +68,7 @@
 }
 
 :where(.lexxy-editor__content) {
-  min-block-size: 8lh;
+  min-block-size: var(--lexxy-editor-rows);
   outline: 0;
   padding: var(--lexxy-editor-padding);
 }


### PR DESCRIPTION
This PR updates the lexxy editor CSS to allow the editor’s `min-block-size` to be set using the standard HTML `rows` attribute, with a fallback to a custom property for older browsers (`--lexxy-editor-rows`).

**Details:**

- By default, the editor uses a custom property `--lexxy-editor-rows` to set its `min-block-size`.
- If the browser supports the CSS `attr()` function with [`attr-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/attr#attr-type), the editor will use the value of the rows HTML attribute to set its `min-block-size`.
- If the browser does not support `attr-type`, the default value is used, preserving previous behaviour.
- Developers who need to support older browsers can set the custom property directly, either via CSS or JavaScript, to control the editor’s `min-block-size`.

**Why this is needed:**

- Enables a declarative, HTML-native way to set editor height using the familiar `rows` attribute.
- Maintains compatibility with older browsers by providing a sensible default and a custom property fallback.
- Improves developer experience and accessibility by supporting both modern and legacy approaches.

**Benefits:**

- No breaking changes: the default behavior remains unchanged for unsupported browsers.
- Easy integration: developers can use either the `rows` attribute or the custom property `--lexxy-editor-rows`.
- Future-proof: leverages new CSS features where available, while providing robust fallbacks.

Thanks for the great editor!