### PR TITLE
Fix CSP Violation for Inline Styles

### DIFF
--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -5,6 +5,7 @@ import {
   KEY_BACKSPACE_COMMAND, DecoratorNode, $createParagraphNode
 } from "lexical"
 import { nextFrame } from "../helpers/timing_helpers"
+import { getNonce } from "../helpers/csp_helper"
 import { getNearestListItemNode } from "../helpers/lexical_helper"
 
 export default class Selection {
@@ -352,6 +353,7 @@ export default class Selection {
     marker.style.width = "1px"
     marker.style.height = "1em"
     marker.style.lineHeight = "normal"
+    marker.setAttribute("nonce", getNonce())
     return marker
   }
 

--- a/src/elements/code_language_picker.js
+++ b/src/elements/code_language_picker.js
@@ -1,6 +1,7 @@
 import { $isCodeNode, CODE_LANGUAGE_FRIENDLY_NAME_MAP, normalizeCodeLang } from "@lexical/code"
 import { $getSelection, $isRangeSelection } from "lexical"
-import { createElement } from "../helpers/html_helper";
+import { createElement } from "../helpers/html_helper"
+import { getNonce } from "../helpers/csp_helper"
 
 export default class CodeLanguagePicker extends HTMLElement {
   connectedCallback() {
@@ -19,6 +20,7 @@ export default class CodeLanguagePicker extends HTMLElement {
     })
 
     this.languagePickerElement.style.position = "absolute"
+    this.languagePickerElement.setAttribute("nonce", getNonce())
     this.editorElement.appendChild(this.languagePickerElement)
   }
 

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -1,4 +1,5 @@
 import { createElement, generateDomId, parseHtml } from "../helpers/html_helper"
+import { getNonce } from "../helpers/csp_helper"
 import { COMMAND_PRIORITY_HIGH, KEY_ENTER_COMMAND, KEY_TAB_COMMAND, KEY_SPACE_COMMAND, $isTextNode, $isRangeSelection, $getSelection, $isNodeSelection, $getNodeByKey } from "lexical"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { isPath, isUrl } from "../helpers/string_helper"
@@ -311,6 +312,7 @@ export default class LexicalPromptElement extends HTMLElement {
     const popoverContainer = createElement("ul", { role: "listbox", id: generateDomId("prompt-popover") }) // Avoiding [popover] due to not being able to position at an arbitrary X, Y position.
     popoverContainer.classList.add("lexxy-prompt-menu")
     popoverContainer.style.position = "absolute"
+    popoverContainer.setAttribute("nonce", getNonce())
     popoverContainer.append(...(await this.source.buildListItems()))
     popoverContainer.addEventListener("click", this.#handlePopoverClick)
     this.#editorElement.appendChild(popoverContainer)

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -4,6 +4,7 @@ import {
   FORMAT_TEXT_COMMAND,
   $isTextNode
 } from "lexical"
+import { getNonce } from "../helpers/csp_helper"
 import { $isListNode, $isListItemNode } from "@lexical/list"
 import { $isQuoteNode, $isHeadingNode } from "@lexical/rich-text"
 import { $isCodeNode, $isCodeHighlightNode } from "@lexical/code"
@@ -182,7 +183,8 @@ export default class LexicalToolbarElement extends HTMLElement {
     this.#resetToolbar()
     this.#compactMenu()
 
-    this.#overflow.style.display = this.#overflowMenu.children.length ? "block" : "none";
+    this.#overflow.style.display = this.#overflowMenu.children.length ? "block" : "none"
+    this.#overflow.setAttribute("nonce", getNonce())
   }
 
   get #overflow() {

--- a/src/helpers/csp_helper.js
+++ b/src/helpers/csp_helper.js
@@ -1,0 +1,6 @@
+const getNonce = () => {
+  const element = document.head.querySelector("meta[name=csp-nonce]")
+  return element?.content
+}
+
+export { getNonce }


### PR DESCRIPTION
### Problem
Lexxy was triggering Content Security Policy (CSP) violations when applying inline styles, causing errors like:

```
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.
```

1. **Created `src/helpers/csp_helper.js`** - A utility function that retrieves the CSP nonce from the document's `<meta name="csp-nonce">` tag
2. **Updated 4 components** to apply the nonce to styled elements:
  - `src/elements/prompt.js` - Added nonce to popover element
  - `src/editor/selection.js` - Added nonce to cursor marker
  - `src/elements/code_language_picker.js` - Added nonce to language picker
  - `src/elements/toolbar.js` - Added nonce to overflow menu

Fixes #210 - Does lexxy need to support `csp-nonce` for inline styles?
