### PR TITLE
Add support for `ActionText::Content`

### DIFF
--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -31,7 +31,7 @@ module Lexxy
         else
             value.to_s
         end
-  
+
         if html.presence
           Nokogiri::HTML.fragment(html).tap do |fragment|
             fragment.css("action-text-attachment").each do |node|


### PR DESCRIPTION
Refactored the HTML rendering logic for `ActionText` to support also `ActionText::Content` alongside `ActionText::RichText` without silently hiding errors.

This allows usage of `ActionText`'s content handling without the dedicated polymorphic tables by serializing the content directly in existing model's field. This is a much simpler approach if you want to keep your data in the same table and don't need additional logic that comes from storing rich texts in dedicated model `ActionText::RichText` (like attachments or handling N+1 loading).

Example:
```ruby
class Post < ApplicationRecord
  # Serialize the field to store ActionText::Content instead of calling `has_rich_text :content`
  serialize :content, coder: ActionText::Content # Table `posts` contains `content` field

  ...
end
```

I haven't added any tests since this comment indicates that this part of code + related parts in `ActionText` will have to be refactored. But suggestions are welcomed how and where to test this.