### PR TITLE
Fix documentation for syntax highlighting Stimulus controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To apply syntax highlighting to rendered Action Text content, you need to call t
 
 ```javascript
 import { Controller } from "@hotwired/stimulus"
-import { highlightAll } from "lexxy"
+import { highlightAll } from "@37signals/lexxy"
 
 export default class extends Controller {
   connect() {


### PR DESCRIPTION
Trying Trixx, I'm using Vite and this is the correct import.

So far so good, great job!