### PR TITLE
Render attachments with Action Text utilities

### DIFF
--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -24,14 +24,13 @@ module Lexxy
       # Tempoary: we need to *adaptarize* action text
       def render_custom_attachments_in(value)
         if html = value.try(:body_before_type_cast).presence
-          Nokogiri::HTML.fragment(html).tap do |fragment|
-            fragment.css("action-text-attachment").each do |node|
-              if node["url"].blank?
-                attachment = ActionText::Attachment.from_node(node)
-                node["content"] = render_action_text_attachment(attachment).to_json
-              end
+          ActionText::Fragment.wrap(html).replace(ActionText::Attachment.tag_name) do |node|
+            if node["url"].blank?
+              attachment = ActionText::Attachment.from_node(node)
+              node["content"] = render_action_text_attachment(attachment).to_json
             end
-          end.to_html
+            node
+          end
         end
       end
   end

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -3,3 +3,9 @@ hello_world:
   name: body
   body:
     <p>Hello everyone</p>
+
+hello_james:
+  record: hello_james (Post)
+  name: body
+  body:
+    <p>Hello <%= ActionText::FixtureSet.attachment("people", :james) %></p>

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -3,3 +3,6 @@ empty:
 
 hello_world:
   title: "Hello World"
+
+hello_james:
+  title: "Hello James"

--- a/test/helpers/lexxy/tag_helper_test.rb
+++ b/test/helpers/lexxy/tag_helper_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class Lexxy::TagHelperTest < ActionView::TestCase
+  helper ActionText::ContentHelper
+
+  test "#lexxy_rich_textarea_tag renders <action-text-attachment> elements" do
+    render inline: <<~ERB, locals: { post: posts(:hello_james) }
+      <%= lexxy_rich_textarea_tag :body, post.body %>
+    ERB
+
+    assert_dom "lexxy-editor", count: 1 do |lexxy_editor, *|
+      assert_dom fragment(lexxy_editor["value"]), "div" do |div|
+        attachment = div.at("action-text-attachment")
+
+        assert_equal "Hello ", div.text
+        assert_equal "<em>James Anderson</em> (<strong>JA</strong>)", JSON.parse(attachment["content"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit includes changes that implement the private `#render_custom_attachments_in` method in terms of existing `ActionText`-provided classes like `Fragment` and `Attachment`.

Namely, this commit replaces `Nokogiri`-scope classes and methods with `ActionText`-scoped alternatives. The content-encoding approach that Lexxy takes shares similarities with the
`.fragment_by_converting_trix_attachments` class method defined by the [ActionText::Attachments::TrixConversion][] concern:

```ruby
def fragment_by_converting_trix_attachments(content)
  Fragment.wrap(content).replace(TrixAttachment::SELECTOR) do |node|
    from_trix_attachment(TrixAttachment.new(node))
  end
end
```

It constructs `<action-text-attachment>` nodes from `<figure data-trix-attachment="…">` nodes. Lexxy is implemented to circumvent that transformation. Given the similarity in approach (find elements, replace or modify their content), I wonder what will constitute the divergence in behavior between the Trix Action Text adapter and the Lexxy Action Text adapter.

If this were implemented in an object (rather than a private view helper method), I wonder what the interface might entail?

```ruby
class TrixEditor
  def replace_attachment(content)
    Fragment.wrap(content).replace("[data-trix-attachment]") do |node|
      trix_attachment = TrixAttachment.new(node)

      Attachment.from_attributes(trix_attachment.attributes)
    end
  end
end

class LexxyEditor
  def replace_attachment(content)
    Fragment.wrap(html).replace(Attachment.tag_name) do |node|
      if node["url"].blank?
        attachment = Attachment.from_node(node)
        node["content"] = render_action_text_attachment(attachment).to_json
      end

      node
    end
  end
end
```

[ActionText::Fragment#replace]: https://github.com/rails/rails/blob/v8.0.3/actiontext/lib/action_text/fragment.rb#L41-L48
[ActionText::Attachments::TrixConversion]: https://github.com/rails/rails/blob/v8.0.3/actiontext/lib/action_text/attachments/trix_conversion.rb#L13-L17