### PR TITLE
Scope link dialog lookup within the toolbar

### DIFF
--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -59,7 +59,7 @@ export default class LexicalToolbarElement extends HTMLElement {
 
   // Not using popover because of CSS anchoring still not widely available.
   #toggleDialog(button) {
-    const dialog = document.getElementById(button.dataset.dialogTarget).parentNode
+    const dialog = this.querySelector("lexxy-link-dialog .link-dialog").parentNode
 
     if (dialog.open) {
       dialog.close()
@@ -235,7 +235,7 @@ export default class LexicalToolbarElement extends HTMLElement {
       </button>
 
       <lexxy-link-dialog class="lexxy-link-dialog">
-        <dialog id="link-dialog" closedby="any">
+        <dialog class="link-dialog" closedby="any">
           <form method="dialog">
             <input type="url" placeholder="Enter a URL…" class="input" required>
             <div class="lexxy-dialog-actions">


### PR DESCRIPTION
This allows the link dialog to work when there is more than one Lexxy instance on the page. Otherwise, it always opens the first. 