### PR TITLE
Add support for remote videos

### DIFF
--- a/app/views/action_text/attachables/_remote_video.html.erb
+++ b/app/views/action_text/attachables/_remote_video.html.erb
@@ -1,0 +1,10 @@
+<figure class="attachment attachment--preview attachment--video">
+  <video controls<%= " width=\"#{remote_video.width}\"" if remote_video.width %><%= " height=\"#{remote_video.height}\"" if remote_video.height %>>
+    <source src="<%= remote_video.url %>" type="<%= remote_video.content_type %>">
+  </video>
+  <% if caption = remote_video.try(:caption) %>
+    <figcaption class="attachment__caption">
+      <%= caption %>
+    </figcaption>
+  <% end %>
+</figure>

--- a/lib/action_text/attachables/remote_video.rb
+++ b/lib/action_text/attachables/remote_video.rb
@@ -1,0 +1,46 @@
+module ActionText
+  module Attachables
+    class RemoteVideo
+      extend ActiveModel::Naming
+
+      class << self
+        def from_node(node)
+          if node["url"] && content_type_is_video?(node["content-type"])
+            new(attributes_from_node(node))
+          end
+        end
+
+        private
+          def content_type_is_video?(content_type)
+            content_type.to_s.match?(/^video(\/.+|$)/)
+          end
+
+          def attributes_from_node(node)
+            { url: node["url"],
+              content_type: node["content-type"],
+              width: node["width"],
+              height: node["height"],
+              filename: node["filename"] }
+          end
+      end
+
+      attr_reader :url, :content_type, :width, :height, :filename
+
+      def initialize(attributes = {})
+        @url = attributes[:url]
+        @content_type = attributes[:content_type]
+        @width = attributes[:width]
+        @height = attributes[:height]
+        @filename = attributes[:filename]
+      end
+
+      def attachable_plain_text_representation(caption)
+        "[#{caption || filename || "Video"}]"
+      end
+
+      def to_partial_path
+        "action_text/attachables/remote_video"
+      end
+    end
+  end
+end

--- a/lib/lexxy/attachable.rb
+++ b/lib/lexxy/attachable.rb
@@ -1,0 +1,15 @@
+require "action_text/attachables/remote_video"
+
+module Lexxy
+  module Attachable
+    def from_node(node)
+      attachable = super
+
+      if attachable.is_a?(ActionText::Attachables::MissingAttachable)
+        ActionText::Attachables::RemoteVideo.from_node(node) || attachable
+      else
+        attachable
+      end
+    end
+  end
+end

--- a/lib/lexxy/engine.rb
+++ b/lib/lexxy/engine.rb
@@ -2,6 +2,7 @@ require_relative "rich_text_area_tag"
 require_relative "form_helper"
 require_relative "form_builder"
 require_relative "action_text_tag"
+require_relative "attachable"
 
 require "active_storage/blob_with_preview_url"
 
@@ -19,6 +20,7 @@ module Lexxy
         ActionView::Helpers::FormHelper.prepend(Lexxy::FormHelper)
         ActionView::Helpers::FormBuilder.prepend(Lexxy::FormBuilder)
         ActionView::Helpers::Tags::ActionText.prepend(Lexxy::ActionTextTag)
+        ActionText::Attachable.singleton_class.prepend(Lexxy::Attachable)
 
         Lexxy.override_action_text_defaults if app.config.lexxy.override_action_text_defaults
       end

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -49,6 +49,22 @@ export class ActionTextAttachmentNode extends DecoratorNode {
           }),
           priority: 1
         }
+      },
+      "video": (video) => {
+        const videoSource = video.getAttribute("src") || video.querySelector("source")?.src
+        const fileName = videoSource?.split("/")?.pop()
+        const contentType = video.querySelector("source")?.getAttribute("content-type") || "video/*"
+
+        return {
+          conversion: () => ({
+            node: new ActionTextAttachmentNode({
+              src: videoSource,
+              fileName: fileName,
+              contentType: contentType
+            })
+          }),
+          priority: 1
+        }
       }
     }
   }
@@ -166,10 +182,13 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     const figcaption = createElement("figcaption", { className: "attachment__caption" })
 
     const nameTag = createElement("strong", { className: "attachment__name", textContent: this.caption || this.fileName })
-    const sizeSpan = createElement("span", { className: "attachment__size", textContent: bytesToHumanSize(this.fileSize) })
 
     figcaption.appendChild(nameTag)
-    figcaption.appendChild(sizeSpan)
+
+    if (this.fileSize) {
+      const sizeSpan = createElement("span", { className: "attachment__size", textContent: bytesToHumanSize(this.fileSize) })
+      figcaption.appendChild(sizeSpan)
+    }
 
     return figcaption
   }


### PR DESCRIPTION
This supports editing remote videos in Lexxy included in the HTML with code like:

```html
<video>
  <source src="https://developer.mozilla.org/shared-assets/videos/flower.mp4" type="video/mp4">
</video>
```

The implementation patches Action Text to support a new type of `RemoteVideo` attachment similar to `RemoteImage`. We should upstream this to ActionText.

Notice that Lexxy already supported uploading videos and showing their preview in editing mode. This new feature is meant to be able to include videos in content to be edited with Lexxy.