### PR TITLE
Fix lexxy_rich_textarea_tag not passing value to <lexxy-editor>

### DIFF
--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -31,6 +31,8 @@ module Lexxy
             end
             node
           end
+        else
+          value
         end
       end
   end

--- a/test/helpers/lexxy/tag_helper_test.rb
+++ b/test/helpers/lexxy/tag_helper_test.rb
@@ -17,4 +17,15 @@ class Lexxy::TagHelperTest < ActionView::TestCase
       end
     end
   end
+
+  test "#lexxy_rich_textarea_tag renders passed in value" do
+    render inline: <<~ERB
+      <%= lexxy_rich_textarea_tag :body, "<p>Sample Content</p>" %>
+    ERB
+    assert_dom "lexxy-editor", count: 1 do |lexxy_editor, *|
+      assert_dom fragment(lexxy_editor["value"]), "div" do |div|
+        assert_equal "<p>Sample Content</p>", div.inner_html
+      end
+    end
+  end
 end


### PR DESCRIPTION
fixes https://github.com/basecamp/lexxy/issues/415 