### PR TITLE
fixing toolbar overflow menu cut

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -167,6 +167,13 @@
   inset-inline-end: 0;
   padding: var(--lexxy-toolbar-gap);
   position: absolute;
+
+  @media (max-width: 380px) {
+    width: 60vw;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
 }
 
 /* Link dialog


### PR DESCRIPTION
This is regarding this reported issue: #428 
It looks like the easiest way for fixing this. 

