### PR TITLE
Add a rendered output section

### DIFF
--- a/test/dummy/app/assets/stylesheets/sandbox.css
+++ b/test/dummy/app/assets/stylesheets/sandbox.css
@@ -8,7 +8,7 @@
     --sandbox-background-color: oklch(15% 0 0);
     --sandbox-text-color: oklch(96% 0 0);
     --sandbox-code-color: #f7fafc;
-  
+
     /* Lexxy dark mode colors */
     --lexxy-color-ink: oklch(96% 0 0);
     --lexxy-color-ink-medium: oklch(75% 0 0);
@@ -73,6 +73,7 @@ section {
   &:last-child {
     background: rgba(100, 100, 100, 0.1);
     overflow: hidden;
+    grid-column: 1 / -1;
   }
 }
 

--- a/test/dummy/app/javascript/controllers/lexxy_output_controller.js
+++ b/test/dummy/app/javascript/controllers/lexxy_output_controller.js
@@ -4,7 +4,7 @@ import prettier from "prettier"
 import htmlParser from "prettier/parser-html"
 
 export default class extends Controller {
-  static targets = [ "editor", "output" ]
+  static targets = [ "editor", "rendered", "output" ]
 
   connect() {
     this.refresh()
@@ -12,6 +12,13 @@ export default class extends Controller {
 
   async refresh(event) {
     const code = this.editorTarget.value.trim()
+
+    // Show rendered HTML
+    if (this.hasRenderedTarget) {
+      this.renderedTarget.innerHTML = code
+    }
+
+    // Show formatted source code
     let formattedCode = await prettier.format(code, {
       parser: "html",
       plugins: [ htmlParser ],

--- a/test/dummy/app/views/sandbox/show.html.erb
+++ b/test/dummy/app/views/sandbox/show.html.erb
@@ -95,7 +95,12 @@
   </section>
 
   <section>
-    <h2>Output</h2>
+    <h2>Rendered Output</h2>
+    <div class="rendered-content" data-lexxy-output-target="rendered"></div>
+  </section>
+
+  <section>
+    <h2>HTML Source</h2>
     <div data-lexxy-output-target="output"></div>
   </section>
 </main>


### PR DESCRIPTION
This PR adds a rendered output display to the sandbox page to make it easier to visualize what it would look like:
<img width="3764" height="1968" alt="rendered output@2x" src="https://github.com/user-attachments/assets/0b087528-7d2c-4279-8d84-1ec94a8d2f89" />
It also makes the HTML output full width so we can see more code without scrolling.