### PR TITLE
Expose name attribute

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -76,6 +76,10 @@ export default class LexicalEditorElement extends HTMLElement {
     return this.internals.form
   }
 
+  get name() {
+    return this.getAttribute("name")
+  }
+
   get toolbarElement() {
     if (!this.#hasToolbar) return null
 


### PR DESCRIPTION
Expose the name attribute to the javascript API

@jorgemanrubia eventually I'd like to expose all the expected attributes to duck-type this as a text area; what do think?