### PR TITLE
Local CI with ActiveSupport::ContinuousIntegration

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require "active_support/continuous_integration"
+
+CI = ActiveSupport::ContinuousIntegration
+require_relative "../config/ci.rb"

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,0 +1,13 @@
+# Run using bin/ci
+
+CI.run do
+  step "Style: Ruby", "bin/rubocop -f github"
+  step "Style: JavaScript", "yarn lint"
+
+  step "Tests: prepare", "env RAILS_ENV=test bin/rails db:test:prepare"
+  step "Tests: run", "env RAILS_ENV=test bin/rails test:all -d"
+
+  unless success?
+    failure "Signoff: CI failed.", "Fix the issues and try again."
+  end
+end


### PR DESCRIPTION
Conveniently run the CI flow locally with `bin/ci` before pushing to Github