### PR TITLE
Hide "Choose files" input created for attachments

### DIFF
--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -177,6 +177,7 @@ export class CommandDispatcher {
     const input = createElement("input", {
       type: "file",
       multiple: true,
+      style: "display: none;",
       onchange: ({ target }) => {
         const files = Array.from(target.files)
         if (!files.length) return
@@ -187,7 +188,7 @@ export class CommandDispatcher {
       }
     })
 
-    document.body.appendChild(input) // Append and remove just for the sake of making it testeable
+    this.editorElement.appendChild(input) // Append and remove just for the sake of making it testable
     input.click()
     setTimeout(() => input.remove(), 1000)
   }


### PR DESCRIPTION
* Append the element to lexxy-editor rather than body
* use `display: none;`

cc @jzimdars 