### PR TITLE
Improve Programmer Happiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test/dummy/tmp/
 /dist/
 /node_modules/
+/app/assets/javascript/*.js.map

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ export default [
   },
   js.configs.recommended,
   {
-    files: ["src/**/*.js"],
+    files: ["src/**/*.js", "app/*.*js"],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: "module",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "rollup -c",
     "build:npm": "rollup -c rollup.config.npm.mjs",
-    "watch": "rollup -wc",
+    "watch": "NODE_ENV=development rollup -wc --watch.onEnd=\"rails restart\"",
     "lint": "eslint",
     "prerelease": "yarn build:npm",
     "release": "yarn build:npm && yarn publish"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,9 +14,9 @@ export default [
     output: [
       {
         file: "./app/assets/javascript/lexxy.js",
-        format: "esm"
+        format: "esm",
+        sourcemap: process.env.NODE_ENV === "development" // eslint-disable-line no-undef
       },
-
       {
         file: "./app/assets/javascript/lexxy.min.js",
         format: "esm",


### PR DESCRIPTION
Adds 80% more developer happiness to `yarn watch` with no added js:

* Sets NODE_ENV=`development` to include the dev build of Lexical
* Build source maps for DevTools, ignored in git so they aren't pushed
* Restart rails on recompile via `rails restart`

All that's left is to <kbd>F5</kbd> the page.