### PR TITLE
Fix dom_id delegation for Rails 8.2 compatibility

### DIFF
--- a/lib/lexxy/action_text_tag.rb
+++ b/lib/lexxy/action_text_tag.rb
@@ -1,5 +1,11 @@
 module Lexxy
   module ActionTextTag
+    extend ActiveSupport::Concern
+
+    prepended do
+      delegate :dom_id, to: ActionView::RecordIdentifier
+    end
+
     def initialize(object_name, method_name, template_object, options = {}, &block)
       super
 


### PR DESCRIPTION
## Summary

When using Lexxy 0.1.23.beta with Rails 8.2.0.alpha, the `lexxy_rich_text_area` helper raises:

```
NoMethodError: undefined method 'dom_id' for an instance of ActionView::Helpers::Tags::ActionText
```

This happens because when `Lexxy::ActionTextTag` is prepended to `ActionView::Helpers::Tags::ActionText`, the `dom_id` method (which Rails delegates to `ActionView::RecordIdentifier`) isn't accessible from within the prepended module's methods.

## Fix

Add an explicit delegation using `ActiveSupport::Concern`'s `prepended` block, which runs when the module is prepended and sets up the delegation on the target class.

## Test plan

- Existing system tests in `form_test.rb` exercise the form helper which uses `dom_id`
- Tested manually with a Rails 8.2.0.alpha application