### PR TITLE
Fix image captions with colons being stripped by DOMPurify

### DIFF
--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -42,6 +42,7 @@ export function buildConfig() {
   return {
     ALLOWED_TAGS: ALLOWED_HTML_TAGS.concat(Lexxy.global.get("attachmentTagName")),
     ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
+    ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
     SAFE_FOR_XML: false // So that it does not strip attributes that contains serialized HTML (like content)
   }
 }


### PR DESCRIPTION
DOMPurify validates attribute values against a URI regex unless the attribute is marked as "URI safe". The `caption` attribute was in `ALLOWED_ATTR` but not in `URI_SAFE_ATTRIBUTES`, causing values like "photographer: name" to be stripped because the colon made it look like an unknown protocol scheme.

Adding `caption` and `filename` to `ADD_URI_SAFE_ATTR` prevents this validation, allowing any text content in these attributes.