### PR TITLE
Forward-compat with Rails 8.2

### DIFF
--- a/lib/lexxy/action_text_tag.rb
+++ b/lib/lexxy/action_text_tag.rb
@@ -10,7 +10,7 @@ module Lexxy
       options = @options.stringify_keys
 
       add_default_name_and_id(options)
-      options["input"] ||= dom_id(object, [ options["id"], :trix_input ].compact.join("_")) if object
+      options["input"] ||= @template_object.dom_id(object, [ options["id"], :trix_input ].compact.join("_")) if object
       html_tag = @template_object.lexxy_rich_textarea_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"), &@block)
       error_wrapping(html_tag)
     end

--- a/test/helpers/action_text_tag_test.rb
+++ b/test/helpers/action_text_tag_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class ActionTextTagTest < ActionView::TestCase
+  include ActionText::TagHelper
+  include ActionView::Helpers::FormHelper
+  include ActionView::RecordIdentifier
+
+  setup do
+    @post = posts(:hello_world)
+  end
+
+  test "rich_textarea renders with object (uses dom_id path)" do
+    @post = posts(:hello_world)
+
+    html = rich_textarea(:post, :body)
+
+    assert_match(/trix-editor|lexxy-editor/, html)
+    assert_match(/post\[body\]/, html)
+  end
+
+  test "rich_textarea renders with object and block (uses dom_id path)" do
+    @post = posts(:hello_world)
+
+    html = rich_textarea(:post, :body) do
+      "<lexxy-prompt>test</lexxy-prompt>".html_safe
+    end
+
+    assert_match(/trix-editor|lexxy-editor/, html)
+    assert_match(/post\[body\]/, html)
+  end
+
+  test "rich_textarea renders without object" do
+    html = rich_textarea(:message, :content)
+
+    assert_match(/trix-editor|lexxy-editor/, html)
+    assert_match(/message\[content\]/, html)
+  end
+end


### PR DESCRIPTION
Rails 8.2 removed the `dom_id` method from the ActionText tag in https://github.com/rails/rails/pull/51238, breaking Lexxy's override.

Use `@template_object.dom_id` instead which works in all releases. (`@template_object` is the view context and always has access to `RecordIdentifier` helpers, including `dom_id`.)

This is obviated by #484 but allows Rails 8.2 apps to not break before adopting the adapter setup.