### PR TITLE
Disable debug mode by default

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -24,7 +24,7 @@ import { TrixTextNode } from "../nodes/trix_text_node"
 
 export default class LexicalEditorElement extends HTMLElement {
   static formAssociated = true
-  static debug = true
+  static debug = false
   static commands = [ "bold", "italic", "strikethrough" ]
 
   static observedAttributes = [ "connected", "required" ]


### PR DESCRIPTION
Debug information is appearing in console output (eg. on Fizzy.do):

If you open a page with a Lexxy input you'll see see development logs. I think this should be disabled by default and enabled with the existing opt-in.

This is what you would see before this change:

```
HTML:  <p><br></p>
HTML:  <p>H</p>
HTML:  <p>He</p>
```

You can still enable this with `LexicalEditorElement.debug = true`.

<img width="1732" height="1326" alt="image" src="https://github.com/user-attachments/assets/a6672b0d-cc99-4b03-ad0f-07034e3382f5" />
