### PR TITLE
Add support for EncryptedRichText

### DIFF
--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -24,13 +24,14 @@ module Lexxy
       # Temporary: we need to *adaptarize* action text
       def render_custom_attachments_in(value)
         if value.respond_to?(:body)
-          if html = value.body_before_type_cast.presence
+          if html = value.body&.to_html.presence
             self.prefix_partial_path_with_controller_namespace = false if respond_to?(:prefix_partial_path_with_controller_namespace=)
             ActionText::Fragment.wrap(html).replace(ActionText::Attachment.tag_name) do |node|
               if node["url"].blank?
                 attachment = ActionText::Attachment.from_node(node)
                 node["content"] = render_action_text_attachment(attachment).to_json
               end
+
               node
             end
           end


### PR DESCRIPTION
Hi, all.

I’ve been building a new product, and I want to use Lexxy as my default rich text editor.

I’m encrypting almost everything in my app by default, but it seems the temporary rendering method did not support encrypted ActionText fields.

I know this will likely be sorted upstream once ActionText supports adapters, but in the meantime, I need Lexxy to work with encrypted fields.

Switching to `to_html` seems to work, and the test suite is all green. I’ve added one test to explicitly hit the encrypted field path. Otherwise, I’m not entirely certain what other tests would be valuable here. (I was mostly concerned whether I broke attachment functionality.)

This commit can likely be trimmed down if we don’t need to do testing beyond the fact that Lexxy can handle encrypted fields.

Also, not sure how to handle encryption-related secrets in a friendly manner for testing purposes in this context. Hard-coding in `config/application.rb` offends my sensibilities. But this feels like a higher-level CI decision beyond the scope of this PR.

Your feedback is welcome.