### PR TITLE
Remove active sleeps in tests

### DIFF
--- a/test/system/editor_to_string_test.rb
+++ b/test/system/editor_to_string_test.rb
@@ -26,13 +26,11 @@ class EditorValueMethodsTest < ApplicationSystemTestCase
     attach_file file_fixture("example.png") do
       click_on "Upload file"
     end
-    sleep 0.1
 
     assert_editor_plain_text "[example.png]\n\n"
 
     find("figcaption textarea").click.send_keys("Example Image")
     find_editor.click
-    sleep 0.1
 
     assert_editor_plain_text "[Example Image]\n\n"
   end

--- a/test/test_helpers/editor_handler.rb
+++ b/test/test_helpers/editor_handler.rb
@@ -15,7 +15,6 @@ class EditorHandler
   def value=(value)
     editor_element.set value
     editor_element.execute_script "this.value = `#{value}`"
-    sleep 0.1
   end
 
   def plain_text_value
@@ -92,7 +91,6 @@ class EditorHandler
         }
       }
     JS
-    sleep 0.1
   end
 
   def select_all
@@ -105,7 +103,6 @@ class EditorHandler
       sel.removeAllRanges()
       sel.addRange(range)
     JS
-    sleep 0.1
   end
 
   def focus

--- a/test/test_helpers/editor_helper.rb
+++ b/test/test_helpers/editor_helper.rb
@@ -9,7 +9,13 @@ module EditorHelper
   end
 
   def assert_editor_plain_text(value)
-    assert_equal value, find_editor.plain_text_value
+    wait_until { find_editor.plain_text_value == value }
+  end
+
+  def wait_until(timeout: Capybara.default_max_wait_time)
+    Timeout.timeout(timeout) do
+      sleep 0.05 until yield
+    end
   end
 
   def assert_figure_attachment(content_type:, &block)


### PR DESCRIPTION
In general, active delays in tests are a bad practice. They slow the suite down, and they are unreliable.

Capybara comes with automatic waiting for the built-in helpers, we should always try to use those when possible. E.g: if something changes in the screen, assert with a selector the expected change, so that Capybara waits until it happens. 

I added a custom `wait_until` helper method for custom conditions that we can't cover with capybara.

I left a couple of sleeps after pressing keys, since I can't think of a way to avoid those.

