### PR TITLE
Refactor Tests

### DIFF
--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -41,7 +41,7 @@ class AttachmentsTest < ApplicationSystemTestCase
 
     assert_no_attachment content_type: "image/png"
 
-    assert_equal_html "<p><br></p>", find_editor.value
+    assert_editor_html "<p><br></p>"
   end
 
   test "disable attachments" do

--- a/test/system/escape_format_test.rb
+++ b/test/system/escape_format_test.rb
@@ -22,7 +22,7 @@ class EscapeFormatTest < ApplicationSystemTestCase
 
     find_editor.send "Outside quote"
 
-    assert_equal_html "<blockquote><ul><li>First line</li></ul></blockquote><p>Outside quote</p>", find_editor.value
+    assert_editor_html "<blockquote><ul><li>First line</li></ul></blockquote><p>Outside quote</p>"
   end
 
   test "split blockquote when escaping from middle" do
@@ -42,7 +42,7 @@ class EscapeFormatTest < ApplicationSystemTestCase
 
     find_editor.send "Middle content"
 
-    assert_equal_html "<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote><p>Middle content</p><blockquote><p>Third paragraph</p></blockquote>", find_editor.value
+    assert_editor_html "<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote><p>Middle content</p><blockquote><p>Third paragraph</p></blockquote>"
   end
 
   test "split blockquote when escaping from middle of list" do
@@ -65,7 +65,7 @@ class EscapeFormatTest < ApplicationSystemTestCase
 
     find_editor.send "Middle text"
 
-    assert_equal_html "<blockquote><ul><li>Item one</li><li>Item two</li></ul></blockquote><p>Middle text</p><blockquote><ul><li>Item three</li></ul></blockquote>", find_editor.value
+    assert_editor_html "<blockquote><ul><li>Item one</li><li>Item two</li></ul></blockquote><p>Middle text</p><blockquote><ul><li>Item three</li></ul></blockquote>"
   end
 
   test "escape without splitting when all nodes after are empty" do
@@ -83,6 +83,6 @@ class EscapeFormatTest < ApplicationSystemTestCase
 
     find_editor.send "After escape"
 
-    assert_equal_html "<blockquote><ul><li>Item one</li></ul></blockquote><p>After escape</p>", find_editor.value
+    assert_editor_html "<blockquote><ul><li>Item one</li></ul></blockquote><p>After escape</p>"
   end
 end

--- a/test/system/form_test.rb
+++ b/test/system/form_test.rb
@@ -12,7 +12,7 @@ class ActionTextLoadTest < ApplicationSystemTestCase
     click_on "Create Post"
     click_on "Edit this post"
 
-    assert_equal_html "<p>Hello</p><p>there</p>", find_editor.value
+    assert_editor_html "<p>Hello</p><p>there</p>"
   end
 
   test "edit existing records" do
@@ -24,7 +24,7 @@ class ActionTextLoadTest < ApplicationSystemTestCase
 
     click_on "Update Post"
 
-    assert_equal_html "<p>Hello</p><p>there</p>", find_editor.value
+    assert_editor_html "<p>Hello</p><p>there</p>"
   end
 
   test "resets editor to initial state when empty" do
@@ -39,7 +39,7 @@ class ActionTextLoadTest < ApplicationSystemTestCase
     click_on "Edit this post"
 
 
-    assert_equal_html "<p>That</p>", find_editor.value
+    assert_editor_html "<p>That</p>"
   end
 
   test "resets editor to initial state when form is reset" do
@@ -49,7 +49,7 @@ class ActionTextLoadTest < ApplicationSystemTestCase
 
     click_on "Reset"
 
-    assert_equal_html "<p>Hello everyone</p>", find_editor.value
+    assert_editor_html "<p>Hello everyone</p>"
   end
 
   test "supports required field" do
@@ -67,6 +67,6 @@ class ActionTextLoadTest < ApplicationSystemTestCase
 
     find_editor.value = ""
 
-    assert_editor_html_value "<p><br></p>"
+    assert_editor_html "<p><br></p>"
   end
 end

--- a/test/system/horizontal_divider_test.rb
+++ b/test/system/horizontal_divider_test.rb
@@ -15,7 +15,7 @@ class HorizontalDividerTest < ApplicationSystemTestCase
 
     find_editor.send "Some text after"
 
-    assert_equal_html "<p>Some text before</p><hr><p>Some text after</p>", find_editor.value
+    assert_editor_html "<p>Some text before</p><hr><p>Some text after</p>"
   end
 
   test "delete horizontal divider with keyboard" do
@@ -28,7 +28,7 @@ class HorizontalDividerTest < ApplicationSystemTestCase
     find_editor.send_key "Delete"
 
     assert_no_selector "figure.horizontal-divider"
-    assert_equal_html "<p>Text before</p><p>Text after</p>", find_editor.value
+    assert_editor_html "<p>Text before</p><p>Text after</p>"
   end
 
   test "horizontal divider with surrounding content" do
@@ -39,6 +39,6 @@ class HorizontalDividerTest < ApplicationSystemTestCase
     assert_selector "figure.horizontal-divider"
     assert_selector "figure.horizontal-divider hr"
 
-    assert_equal_html "<p>Before divider</p><hr><p>After divider</p>", find_editor.value
+    assert_editor_html "<p>Before divider</p><hr><p>After divider</p>"
   end
 end

--- a/test/system/load_html_test.rb
+++ b/test/system/load_html_test.rb
@@ -7,11 +7,14 @@ class LoadHtmlTest < ApplicationSystemTestCase
 
   test "load simple string" do
     find_editor.value = "Hello"
-    assert_equal_html "<p>Hello</p>", find_editor.value
+
+    assert_editor_html do
+      assert_selector "p", text: "Hello"
+    end
   end
 
   test "normalize loaded HTML" do
     find_editor.value = "<div>hello</div> <div>there</div>"
-    assert_equal_html "<p>hello</p><p>there</p>", find_editor.value
+    assert_editor_html "<p>hello</p><p>there</p>"
   end
 end

--- a/test/system/paste_test.rb
+++ b/test/system/paste_test.rb
@@ -7,20 +7,24 @@ class PasteTest < ApplicationSystemTestCase
 
   test "convert to markdown on paste" do
     find_editor.paste "Hello **there**"
-    assert_equal_html "<p>Hello <b><strong>there</strong></b></p>", find_editor.value
+    assert_editor_html "<p>Hello <b><strong>there</strong></b></p>"
   end
 
   test "create links when pasting URLs" do
     visit edit_post_path(posts(:hello_world))
     find_editor.select("everyone")
     find_editor.paste "https://37signals.com"
-    assert_equal_html %(<p>Hello <a href="https://37signals.com">everyone</a></p>), find_editor.value
+
+    assert_editor_html do
+      assert_selector %(a[href="https://37signals.com"]), text: "everyone"
+    end
   end
 
   test "keep content when pasting URLs" do
     visit edit_post_path(posts(:hello_world))
     find_editor.paste "https://37signals.com"
-    assert_equal_html %(<p><a href=\"https://37signals.com\">https://37signals.com</a>Hello everyone</p>), find_editor.value
+
+    assert_editor_html %(<p><a href=\"https://37signals.com\">https://37signals.com</a>Hello everyone</p>)
   end
 
   test "create links when pasting URLs keeps formatting" do
@@ -28,21 +32,26 @@ class PasteTest < ApplicationSystemTestCase
     find_editor.select("everyone")
     find_editor.toggle_command("bold")
     find_editor.paste "https://37signals.com"
-    assert_equal_html %(<p>Hello <a href="https://37signals.com"><b><strong>everyone</strong></b></a></p>), find_editor.value
+
+    assert_editor_html %(<p>Hello <a href="https://37signals.com"><b><strong>everyone</strong></b></a></p>)
   end
 
   test "don't convert markdown when pasting into code block" do
     find_editor.paste "some text"
     find_editor.toggle_command("insertCodeBlock")
     find_editor.paste "Hello **there**"
-    assert_includes find_editor.value, "**there**"
-    refute_includes find_editor.value, "<strong>there</strong>"
+
+    assert_editor_html do
+      assert_text "**there**"
+      assert_no_selector "strong", text: "there"
+    end
   end
 
   test "don't convert markdown when disabled" do
     visit edit_post_path(posts(:empty), markdown_disabled: true)
     find_editor.click
     find_editor.paste "Hello **there**"
-    assert_equal_html "<p>Hello **there**</p>", find_editor.value
+
+    assert_editor_html "<p>Hello **there**</p>"
   end
 end

--- a/test/system/plain_text_test.rb
+++ b/test/system/plain_text_test.rb
@@ -8,14 +8,15 @@ class PlainTextTest < ApplicationSystemTestCase
   test "markdown conversion on paste disabled in plain-text mode" do
     find_editor.select("Hello")
     find_editor.paste "**Hello**"
-    assert_equal_html "<p>**Hello** everyone</p>", find_editor.value
+
+    assert_editor_html "<p>**Hello** everyone</p>"
   end
 
   test "formatting shortcuts disabled in plain-text mode" do
     find_editor.select("Hello")
     find_editor.send_key("b", ctrl: true)
 
-    assert_equal_html "<p>Hello everyone</p>", find_editor.value
+    assert_editor_html "<p>Hello everyone</p>"
   end
 
   test "no toolbar in plaintext mode" do

--- a/test/system/single_line_test.rb
+++ b/test/system/single_line_test.rb
@@ -8,6 +8,6 @@ class SingleLineTest < ApplicationSystemTestCase
     find_editor.send :enter
     find_editor.send "there"
 
-    assert_equal_html "<p>Hellothere</p>", find_editor.value
+    assert_editor_html "<p>Hellothere</p>"
   end
 end

--- a/test/system/table_test.rb
+++ b/test/system/table_test.rb
@@ -16,9 +16,9 @@ class TableTest < ApplicationSystemTestCase
 
     find_editor.send "Test Cell"
 
-    html = find_editor.value
-    assert_match(/Test Cell/, html)
-    assert_match(/<table>.*?Test Cell.*?<\/table>/m, html)
+    within_table do
+      assert_selector "td", text: "Test Cell"
+    end
   end
 
   test "adding a new row" do
@@ -31,40 +31,47 @@ class TableTest < ApplicationSystemTestCase
   test "toggling header style on row" do
     find_editor.toggle_command("insertTable")
 
-    html_before = find_editor.value
-    initial_th_in_first_row = html_before.match(/<tr>.*?<\/tr>/m)&.to_s&.scan(/<th\b/).count || 0
+    header_row = "tr:has(th + th + th)"
+    single_hr_row = "tr:has(th + td + td)"
 
-    more_menu = open_table_more_menu
+    within_table do
+      assert_selector header_row, count: 1
+      assert_selector single_hr_row, count: 2
+    end
 
+    open_table_more_menu
     click_table_handler_button("Toggle row style")
 
-    html = find_editor.value
-    first_row_th_count = html.match(/<tr>.*?<\/tr>/m)&.to_s&.scan(/<th\b/).count || 0
-    assert_not_equal initial_th_in_first_row, first_row_th_count, "Row header style should have changed"
+    within_table do
+      assert_selector header_row, count: 0
+      assert_selector single_hr_row, count: 3
+    end
 
-    more_menu.click
+    open_table_more_menu
     click_table_handler_button("Toggle row style")
 
-    html = find_editor.value
-    final_th_in_first_row = html.match(/<tr>.*?<\/tr>/m)&.to_s&.scan(/<th\b/).count || 0
-    assert_equal initial_th_in_first_row, final_th_in_first_row, "Row header style should have reverted"
+    within_table do
+      assert_selector header_row, count: 1
+      assert_selector single_hr_row, count: 2
+    end
   end
 
   test "deleting a row" do
     find_editor.toggle_command("insertTable")
 
-    initial_rows = find_editor.value.scan(/<tr>/).count
+    within_table do
+      assert_selector "tr", count: 3
+    end
 
     click_table_handler_button("Remove row")
 
-    html = find_editor.value
-    rows = html.scan(/<tr>/).count
-    assert_equal initial_rows - 1, rows, "Expected one less row after deletion"
+    within_table do
+      assert_selector "tr", count: 2
+    end
   end
 
   test "adding a new column" do
     find_editor.toggle_command("insertTable")
-
     assert_editor_table_structure(3, 3)
 
     click_table_handler_button("Add column")
@@ -74,23 +81,23 @@ class TableTest < ApplicationSystemTestCase
   test "toggling header style on column" do
     find_editor.toggle_command("insertTable")
 
-    html_before = find_editor.value
-    initial_th_in_first_col = html_before.scan(/<tr>.*?<th\b/m).count
+    within_table do
+      assert_selector "tr > th:first-child", count: 3
+    end
 
-    more_menu = open_table_more_menu
-
+    open_table_more_menu
     click_table_handler_button("Toggle column style")
 
-    html = find_editor.value
-    th_in_first_col_after = html.scan(/<tr>.*?<th\b/m).count
-    assert_not_equal initial_th_in_first_col, th_in_first_col_after, "Column header style should have changed"
+    within_table do
+      assert_selector "tr > th:first-child", count: 1
+    end
 
-    more_menu.click
+    open_table_more_menu
     click_table_handler_button("Toggle column style")
 
-    html = find_editor.value
-    th_in_first_col_final = html.scan(/<tr>.*?<th\b/m).count
-    assert_equal initial_th_in_first_col, th_in_first_col_final, "Column header style should have reverted"
+    within_table do
+      assert_selector "tr > th:first-child", count: 3
+    end
   end
 
   test "deleting a column" do
@@ -105,14 +112,12 @@ class TableTest < ApplicationSystemTestCase
   test "deleting the table" do
     find_editor.toggle_command("insertTable")
 
-    assert_match(/<table>/, find_editor.value)
+    find_editor.value { has_table? }
 
     open_table_more_menu
-
     click_table_handler_button("Delete table")
 
-    html = find_editor.value
-    assert_no_match(/<table>/, html, "Table should be removed")
+    find_editor.value { has_no_table? }
   end
 
   test "tables render with action text" do
@@ -126,9 +131,17 @@ class TableTest < ApplicationSystemTestCase
   test "table is wrapped in figure.table-wrapper" do
     find_editor.toggle_command("insertTable")
 
-    html = find_editor.value
-    assert_match(/<figure class="lexxy-content__table-wrapper">/, html, "Exported HTML should have figure. table-wrapper")
-
-    assert_match(/<figure class="lexxy-content__table-wrapper">.*?<table>.*?<\/table>.*?<\/figure>/m, html, "Table with content should be nested inside the figure wrapper")
+    assert_editor_html do
+      assert_selector "figure.lexxy-content__table-wrapper" do |figure|
+        figure.has_table?
+      end
+    end
   end
+
+  private
+    def within_table(&)
+      assert_editor_html do
+        find("table").instance_exec(&) if has_table?
+      end
+    end
 end

--- a/test/system/toolbar_test.rb
+++ b/test/system/toolbar_test.rb
@@ -9,33 +9,36 @@ class ToolbarTest < ApplicationSystemTestCase
   test "bold" do
     find_editor.select("everyone")
     click_on "Bold"
-    assert_equal_html "<p>Hello <b><strong>everyone</strong></b></p>", find_editor.value
+
+    assert_editor_html "<p>Hello <b><strong>everyone</strong></b></p>"
   end
 
   test "italic" do
     find_editor.select("everyone")
     click_on "Italic"
-    assert_equal_html "<p>Hello <i><em>everyone</em></i></p>", find_editor.value
+
+    assert_editor_html "<p>Hello <i><em>everyone</em></i></p>"
   end
 
   test "strikethrough" do
     find_editor.select("everyone")
     click_on "Strikethrough"
-    assert_equal_html "<p>Hello <s>everyone</s></p>", find_editor.value
+
+    assert_editor_html "<p>Hello <s>everyone</s></p>"
   end
 
   test "color highlighting" do
     find_editor.select("everyone")
     apply_highlight_option("color", 1)
 
-    assert_equal_html "<p>Hello <mark style=\"color: var(--highlight-1);\">everyone</mark></p>", find_editor.value
+    assert_editor_html "<p>Hello <mark style=\"color: var(--highlight-1);\">everyone</mark></p>"
   end
 
   test "background color highlighting" do
     find_editor.select("everyone")
     apply_highlight_option("background-color", 1)
 
-    assert_equal_html "<p>Hello <mark style=\"background-color: var(--highlight-bg-1);\">everyone</mark></p>", find_editor.value
+    assert_editor_html "<p>Hello <mark style=\"background-color: var(--highlight-bg-1);\">everyone</mark></p>"
   end
 
   test "color and background highlighting" do
@@ -45,7 +48,7 @@ class ToolbarTest < ApplicationSystemTestCase
     find_editor.select("everyone")
     apply_highlight_option("background-color", 1)
 
-    assert_equal_html "<p>Hello <mark style=\"color: var(--highlight-1);background-color: var(--highlight-bg-1);\">everyone</mark></p>", find_editor.value
+    assert_editor_html "<p>Hello <mark style=\"color: var(--highlight-1);background-color: var(--highlight-bg-1);\">everyone</mark></p>"
   end
 
   test "bold and color highlighting" do
@@ -55,81 +58,81 @@ class ToolbarTest < ApplicationSystemTestCase
     find_editor.select("everyone")
     apply_highlight_option("color", 1)
 
-    assert_equal_html "<p>Hello <b><mark style=\"color: var(--highlight-1);\"><strong>everyone</strong></mark></b></p>", find_editor.value
+    assert_editor_html "<p>Hello <b><mark style=\"color: var(--highlight-1);\"><strong>everyone</strong></mark></b></p>"
   end
 
   test "rotate headers" do
     find_editor.select("everyone")
 
     click_on "Heading"
-    assert_equal_html "<h2>Hello everyone</h2>", find_editor.value
+    assert_editor_html "<h2>Hello everyone</h2>"
 
     click_on "Heading"
-    assert_equal_html "<h3>Hello everyone</h3>", find_editor.value
+    assert_editor_html "<h3>Hello everyone</h3>"
 
     click_on "Heading"
-    assert_equal_html "<h4>Hello everyone</h4>", find_editor.value
+    assert_editor_html "<h4>Hello everyone</h4>"
 
     click_on "Heading"
-    assert_equal_html "<p>Hello everyone</p>", find_editor.value
+    assert_editor_html "<p>Hello everyone</p>"
   end
 
   test "bullet list" do
     find_editor.select("everyone")
 
     click_on "Bullet list"
-    assert_equal_html "<ul><li>Hello everyone</li></ul>", find_editor.value
+    assert_editor_html "<ul><li>Hello everyone</li></ul>"
   end
 
   test "numbered list" do
     find_editor.select("everyone")
 
     click_on "Numbered list"
-    assert_equal_html "<ol><li>Hello everyone</li></ol>", find_editor.value
+    assert_editor_html "<ol><li>Hello everyone</li></ol>"
   end
 
   test "toggle code for selected words" do
     find_editor.select("everyone")
 
     click_on "Code"
-    assert_equal_html %( <p>Hello <code>everyone</code></p> ), find_editor.value
+    assert_editor_html %( <p>Hello <code>everyone</code></p> )
 
     find_editor.select("everyone")
     click_on "Code"
-    assert_equal_html "<p>Hello everyone</p>", find_editor.value
+    assert_editor_html "<p>Hello everyone</p>"
   end
 
   test "toggle code for block" do
     find_editor.click
 
     click_on "Code"
-    assert_equal_html %( <pre data-language=\"plain\" data-highlight-language=\"plain\">Hello everyone</pre> ), find_editor.value
+    assert_editor_html %( <pre data-language=\"plain\" data-highlight-language=\"plain\">Hello everyone</pre> )
 
     click_on "Code"
-    assert_equal_html "<p>Hello everyone</p>", find_editor.value
+    assert_editor_html "<p>Hello everyone</p>"
   end
 
   test "insert quote without selection" do
     click_on "Quote"
-    assert_equal_html "<blockquote><p>Hello everyone</p></blockquote>", find_editor.value
+    assert_editor_html "<blockquote><p>Hello everyone</p></blockquote>"
   end
 
   test "quote" do
     find_editor.select("everyone")
 
     click_on "Quote"
-    assert_equal_html "<blockquote><p>Hello everyone</p></blockquote>", find_editor.value
+    assert_editor_html "<blockquote><p>Hello everyone</p></blockquote>"
 
     find_editor.select("everyone")
     click_on "Quote"
-    assert_equal_html "<p>Hello everyone</p>", find_editor.value
+    assert_editor_html "<p>Hello everyone</p>"
   end
 
   test "multi line quote" do
     find_editor.value = "<p>Hello</p><p>Everyone</p>"
     find_editor.select_all
     click_on "Quote"
-    assert_equal_html "<blockquote><p>Hello</p><p>Everyone</p></blockquote>", find_editor.value
+    assert_editor_html "<blockquote><p>Hello</p><p>Everyone</p></blockquote>"
   end
 
   test "links" do
@@ -142,7 +145,7 @@ class ToolbarTest < ApplicationSystemTestCase
       click_on "Link"
     end
 
-    assert_equal_html "<p>Hello <a href=\"https://37signals.com\">everyone</a></p>", find_editor.value
+    assert_editor_html "<p>Hello <a href=\"https://37signals.com\">everyone</a></p>"
   end
 
   test "disable toolbar" do
@@ -195,25 +198,25 @@ class ToolbarTest < ApplicationSystemTestCase
 
     # Type first text
     find_editor.send "Hello"
-    assert_equal_html "<p>Hello</p>", find_editor.value
+    assert_editor_html "<p>Hello</p>"
 
     # Type second text
     find_editor.send " World"
-    assert_equal_html "<p>Hello World</p>", find_editor.value
+    assert_editor_html "<p>Hello World</p>"
 
     # Click undo 2 times
     click_on "Undo"
-    assert_equal_html "<p>Hello</p>", find_editor.value
+    assert_editor_html "<p>Hello</p>"
 
     click_on "Undo"
-    assert_equal_html "<p><br></p>", find_editor.value
+    assert_editor_html "<p><br></p>"
 
     # Click redo 2 times
     click_on "Redo"
-    assert_equal_html "<p>Hello</p>", find_editor.value
+    assert_editor_html "<p>Hello</p>"
 
     click_on "Redo"
-    assert_equal_html "<p>Hello World</p>", find_editor.value
+    assert_editor_html "<p>Hello World</p>"
   end
 
   test "external toolbar" do

--- a/test/system/trix_html_test.rb
+++ b/test/system/trix_html_test.rb
@@ -21,7 +21,7 @@ class TrixHtmlTest < ApplicationSystemTestCase
 
       visit edit_post_path(post)
 
-      assert_equal_html lexxy_html, find_editor.value
+      assert_editor_html lexxy_html
     end
   end
 
@@ -53,7 +53,7 @@ class TrixHtmlTest < ApplicationSystemTestCase
 
       visit edit_post_path(post)
 
-      assert_equal_html "<p>#{lexxy_html}</p>", find_editor.value
+      assert_editor_html "<p>#{lexxy_html}</p>"
     end
   end
 end

--- a/test/test_helpers/editor_helper.rb
+++ b/test/test_helpers/editor_helper.rb
@@ -12,8 +12,12 @@ module EditorHelper
     wait_until { find_editor.plain_text_value == value }
   end
 
-  def assert_editor_html_value(expected)
-    wait_until { normalize_html(find_editor.value) == normalize_html(expected) }
+  def assert_editor_html(expected = nil, &block)
+    if block
+      Capybara.string(find_editor.value).instance_exec(&block)
+    else
+      wait_until { normalize_html(find_editor.value) == normalize_html(expected) }
+    end
   rescue Timeout::Error
     assert_equal normalize_html(expected), normalize_html(find_editor.value)
   end


### PR DESCRIPTION
- Introduce `assert_editor_html` which compares html to editor.value
- Allow passing a block which allows working with Capybara selectors
- Add `within_table` helper which takes a block in the same way to clarify table tests

Test time is stable before/after at ~45s

```ruby
# Comparing editor value
test "lexxy value" do
  assert_editor_html "<p>Hello there</p>"
end

# Passing a block
test "table is wrapped in figure.table-wrapper" do
  find_editor.toggle_command("insertTable")

  assert_editor_html do
    assert_selector "figure.lexxy-content__table-wrapper" do |figure|
      figure.has_table?
    end
  end
end

# Using `within_table`
test "writing in table fields" do
  find_editor.toggle_command("insertTable")

  find_editor.send "Test Cell"

  within_table do
    assert_selector "td", text: "Test Cell"
  end
end
```