### PR TITLE
Async test stability

### DIFF
--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -37,10 +37,12 @@ class AttachmentsTest < ApplicationSystemTestCase
     assert_image_figure_attachment content_type: "image/png", caption: "example.png"
 
     find("figure.attachment img").click
+    wait_for_node_selection
+
     find_editor.send_key "Delete"
+    wait_for_node_selection false
 
     assert_no_attachment content_type: "image/png"
-
     assert_editor_html "<p><br></p>"
   end
 

--- a/test/system/horizontal_divider_test.rb
+++ b/test/system/horizontal_divider_test.rb
@@ -23,9 +23,11 @@ class HorizontalDividerTest < ApplicationSystemTestCase
     click_on "Insert a divider"
     find_editor.send "Text after"
 
-    # Click on the divider to select it
     find("figure.horizontal-divider").click
+    wait_for_node_selection
+
     find_editor.send_key "Delete"
+    wait_for_node_selection false
 
     assert_no_selector "figure.horizontal-divider"
     assert_editor_html "<p>Text before</p><p>Text after</p>"
@@ -36,8 +38,9 @@ class HorizontalDividerTest < ApplicationSystemTestCase
     click_on "Insert a divider"
     find_editor.send "After divider"
 
-    assert_selector "figure.horizontal-divider"
-    assert_selector "figure.horizontal-divider hr"
+    assert_selector "figure.horizontal-divider" do
+      assert_selector "hr"
+    end
 
     assert_editor_html "<p>Before divider</p><hr><p>After divider</p>"
   end

--- a/test/system/prompts_test.rb
+++ b/test/system/prompts_test.rb
@@ -37,11 +37,11 @@ class ActionTextLoadTest < ApplicationSystemTestCase
 
     find_editor.send "1"
 
-    assert find_editor.open_prompt?
+    wait_until { find_editor.open_prompt? }
 
     find_editor.send "peter "
 
-    assert_not find_editor.open_prompt?
+    wait_until { !find_editor.open_prompt? }
   end
 
   test "configure space support in searches" do

--- a/test/test_helpers/editor_handler.rb
+++ b/test/test_helpers/editor_handler.rb
@@ -29,6 +29,10 @@ class EditorHandler
     evaluate_script "this.isBlank"
   end
 
+  def has_node_selection?
+    evaluate_script "this.selection.hasNodeSelection"
+  end
+
   def open_prompt?
     evaluate_script "this.hasOpenPrompt"
   end

--- a/test/test_helpers/editor_helper.rb
+++ b/test/test_helpers/editor_helper.rb
@@ -74,6 +74,10 @@ module EditorHelper
     assert_css "lexxy-toolbar[connected]" if has_css?("lexxy-toolbar")
   end
 
+  def wait_for_node_selection(expected = true)
+    wait_until { expected == find_editor.has_node_selection? }
+  end
+
   def click_table_handler_button(aria_label)
     find(".lexxy-table-handle-buttons button[aria-label='#{aria_label}']").click
   end


### PR DESCRIPTION
In the same vein as #552 to remove sleeps, this stabilizes flaky tests of `async` operations by waiting for selection conditions and popovers to appear.