### PR TITLE
Update JavaScript assets path in initializer

### DIFF
--- a/lib/lexxy/engine.rb
+++ b/lib/lexxy/engine.rb
@@ -29,7 +29,7 @@ module Lexxy
     initializer "lexxy.assets" do |app|
       if Rails.application.config.respond_to?(:assets)
         app.config.assets.paths << root.join("app/assets/stylesheets")
-        app.config.assets.paths << root.join("app/javascript")
+        app.config.assets.paths << root.join("app/assets/javascript")
       end
     end
 


### PR DESCRIPTION
The `lexxy.assets` initializer in `lib/lexxy/engine.rb` added `app/javascript` to the asset paths, but the correct path is `app/assets/javascript`.

Fixes #730.