### PR TITLE
Fix form attribute being discarded in rich_text_area_tag

### DIFF
--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -2,7 +2,6 @@ module Lexxy
   module TagHelper
     def lexxy_rich_textarea_tag(name, value = nil, options = {}, &block)
       options = options.symbolize_keys
-      form = options.delete(:form)
 
       value = render_custom_attachments_in(value)
       value = "<div>#{value}</div>" if value


### PR DESCRIPTION
lexxy_rich_textarea_tag was removing 'form' from html options.
This prevented using lexxy from outside a form like we can do with regular inputs:

`<input form="myform">
`

This change was made in actionText [when they extracted ActionText::TrixEditor](https://github.com/rails/rails/commit/cb0fd2254acb8b7c1c9354ef34538ba51bf28d1f)

This attribute should pass through so we can associate lexxy editor with external form.