### PR TITLE
Wake testing up ☕☕☕

### DIFF
--- a/test/test_helpers/editor_handler.rb
+++ b/test/test_helpers/editor_handler.rb
@@ -59,7 +59,6 @@ class EditorHandler
       });
       this.dispatchEvent(event);
     JS
-    sleep 0.1
   end
 
   def send_tab(shift: false)
@@ -76,7 +75,6 @@ class EditorHandler
       });
       this.dispatchEvent(event);
     JS
-    sleep 0.1
   end
 
   def select(text)
@@ -99,6 +97,16 @@ class EditorHandler
           break
         }
       }
+    JS
+  end
+
+  def flush_lexical_updates
+    page.evaluate_async_script <<~JS
+      const [ done ] = arguments
+      const editor = document.querySelector('lexxy-editor').editor
+      editor.update(() => null, {
+        onUpdate: () => requestAnimationFrame(done)
+      });
     JS
   end
 

--- a/test/test_helpers/editor_helper.rb
+++ b/test/test_helpers/editor_helper.rb
@@ -26,7 +26,7 @@ module EditorHelper
 
   def wait_until(timeout: Capybara.default_max_wait_time)
     Timeout.timeout(timeout) do
-      sleep 0.05 until yield
+      find_editor.flush_lexical_updates until yield
     end
   end
 


### PR DESCRIPTION
Await all lexical updates to have occurred with a Lexical `onUpdate` callback triggering the `done` callback of a selenium async script executor

Remove all `sleep` commands ☕☕☕

cc @packagethief 