### PR TITLE
Loosen version range for ActiveStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prismjs": "^1.30.0"
   },
   "peerDependencies": {
-    "@rails/activestorage": "^7.0.0"
+    "@rails/activestorage": ">= 7.0.0"
   },
   "peerDependenciesMeta": {
     "@rails/activestorage": {


### PR DESCRIPTION
Loosen version range for ActiveStorage so it can be used with v8 and above rather than being restricted to v7.

For example, this is typically how ActionText specifies the range: https://github.com/rails/rails/blob/4cf3b7bb80e7e0f0ecdd09baa6bd395b6f2004ed/actiontext/package.json#L25

If desired, I could add an upper bound.