### PR TITLE
Add 'start' to allowed HTML attributes

### DIFF
--- a/lib/lexxy/engine.rb
+++ b/lib/lexxy/engine.rb
@@ -39,7 +39,7 @@ module Lexxy
         ActionText::ContentHelper.allowed_tags = default_allowed_tags + %w[ video audio source embed table tbody tr th td ]
 
         default_allowed_attributes = Class.new.include(ActionText::ContentHelper).new.sanitizer_allowed_attributes
-        ActionText::ContentHelper.allowed_attributes = default_allowed_attributes + %w[ controls poster data-language style ]
+        ActionText::ContentHelper.allowed_attributes = default_allowed_attributes + %w[ controls poster data-language start style ]
 
         Loofah::HTML5::SafeList::ALLOWED_CSS_FUNCTIONS << "var" # Allow CSS variables
       end

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -7,7 +7,7 @@ const ALLOWED_HTML_TAGS = [ "a", "b", "blockquote", "br", "code", "div", "em",
 
 const ALLOWED_HTML_ATTRIBUTES = [ "alt", "caption", "class", "content", "content-type", "contenteditable",
   "data-direct-upload-id", "data-sgid", "filename", "filesize", "height", "href", "presentation",
-  "previewable", "sgid", "src", "style", "title", "url", "width" ]
+  "previewable", "sgid", "src", "start", "style", "title", "url", "width" ]
 
 const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
 

--- a/test/system/load_html_test.rb
+++ b/test/system/load_html_test.rb
@@ -18,6 +18,16 @@ class LoadHtmlTest < ApplicationSystemTestCase
     assert_editor_html "<p>hello</p><p>there</p>"
   end
 
+  test "load ordered list with start attribute" do
+    find_editor.value = '<ol start="3"><li>Third</li><li>Fourth</li></ol>'
+
+    assert_editor_html do
+      assert_selector "ol[start='3']"
+      assert_selector "li", text: "Third"
+      assert_selector "li", text: "Fourth"
+    end
+  end
+
   test "load attachment with custom tag" do
     visit new_post_path(attachment_tag_name: "bc-attachment")
 


### PR DESCRIPTION
In order for `ol` list elements to respect the numbers they were authored with we need to make sure that the [start](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol#start) attribute makes it through dom_purify and the ActionText allowlist.