### PR TITLE
Add foreman with bin/dev for local development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 gem "rack-cors"
+
+gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
+    foreman (0.90.0)
+      thor (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -316,6 +318,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   cuprite
+  foreman
   image_processing
   importmap-rails
   lexxy!

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+js: yarn watch

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Kill any previous Rails server
+if [ -f tmp/pids/server.pid ]; then
+  pid=$(cat tmp/pids/server.pid)
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "Killing previous Rails server (PID: $pid)..."
+    kill "$pid"
+    wait "$pid" 2>/dev/null
+  fi
+  rm -f tmp/pids/server.pid
+fi
+
+exec foreman start -f Procfile.dev -p 3000 "$@"

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,16 +16,10 @@ bin/setup
 
 ## Local development
 
-To build the JS source when it changes, run:
+To start both the Rails server and the JS watcher:
 
 ```bash
-yarn build -w
-```
-
-To the sandbox app:
-
-```bash
-bin/rails server
+bin/dev
 ```
 
 The sandbox app is available at http://lexxy.localhost:3000. There is also a CRUD example at http://lexxy.localhost:3000/posts.


### PR DESCRIPTION
## Summary

- Add `foreman` gem and `Procfile.dev` to run the Rails server and JS watcher together
- Add `bin/dev` script that kills any stale Rails server and starts both processes
- Update `docs/development.md` to document `bin/dev`