### PR TITLE
Improve worktree development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@ Lexxy is a rich text editor built on Lexical, distributed as both a Ruby gem and
 
 See [docs/development.md](docs/development.md) for local development setup, how to run tests, and release instructions.
 
+## Worktrees
+
+When working from a git worktree:
+
+- Run all commands from that worktree, not from the main checkout.
+- For system-level work, start `bin/dev` in the worktree before investigating or running `test/system/` after `src/` changes. Rails system tests use `app/assets/javascript/lexxy.js`, so the watcher must keep built assets in sync.
+- Use a unique port per worktree, for example `PORT=3100 bin/dev` or `PORT=3200 bin/dev`, to avoid Rails server collisions.
+- If you skip `bin/dev`, rebuild assets in the worktree before trusting system test results after any `src/` change.
+- Playwright tests in `test/browser/` do not need `bin/dev`.
+
 ## Fixing Bugs
 
 Follow this mandatory workflow. Every step must complete before moving to the next.

--- a/bin/dev
+++ b/bin/dev
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+search_dir="$root_dir"
+
+while [ "$search_dir" != "/" ]; do
+  if [ -d "$search_dir/node_modules/.bin" ]; then
+    export PATH="$search_dir/node_modules/.bin:$PATH"
+    break
+  fi
+  search_dir="$(dirname "$search_dir")"
+done
+
 # Kill any previous Rails server
 if [ -f tmp/pids/server.pid ]; then
   pid=$(cat tmp/pids/server.pid)
@@ -11,4 +22,6 @@ if [ -f tmp/pids/server.pid ]; then
   rm -f tmp/pids/server.pid
 fi
 
-exec foreman start -f Procfile.dev -p 3000 "$@"
+port="${PORT:-3000}"
+
+exec foreman start -f Procfile.dev -p "$port" "$@"

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,15 @@ bin/dev
 
 The sandbox app is available at http://lexxy.localhost:3000. There is also a CRUD example at http://lexxy.localhost:3000/posts.
 
+To run multiple worktrees in parallel, give each worktree its own port:
+
+```bash
+PORT=3100 bin/dev
+PORT=3200 bin/dev
+```
+
+Use the matching URL for that worktree, for example `http://lexxy.localhost:3100/posts`.
+
 ## Tests
 
 CI runs the full suite on every pull request and push to `main` via GitHub Actions (see `.github/workflows/ci.yml`). It runs four jobs in parallel: lint, JS unit tests, Rails system tests, and Playwright browser tests (across Chromium, Firefox, and WebKit).


### PR DESCRIPTION
## Summary
- document how to work from git worktrees in AGENTS.md
- make bin/dev respect PORT so multiple worktrees can run in parallel
- document per-worktree ports in development docs

## Verification
- bash -n bin/dev