### PR TITLE
Enable attachments and emoji on the Try it page

### DIFF
--- a/docs/attachments-sw.js
+++ b/docs/attachments-sw.js
@@ -1,0 +1,73 @@
+// Service Worker that mocks Active Storage's Direct Upload endpoints.
+// Allows the "Try it" demo to support file uploads without a server.
+
+const files = new Map()
+let blobCounter = 0
+
+self.addEventListener("install", () => self.skipWaiting())
+self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()))
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url)
+  const method = event.request.method
+
+  if (url.pathname.endsWith("/rails/active_storage/direct_uploads") && method === "POST") {
+    event.respondWith(createBlob(event.request))
+  } else if (url.pathname.includes("/rails/active_storage/disk/") && method === "PUT") {
+    event.respondWith(storeFile(event.request, url))
+  } else if (url.pathname.includes("/rails/active_storage/blobs/") && method === "GET") {
+    event.respondWith(serveFile(url))
+  }
+})
+
+async function createBlob(request) {
+  const { blob } = await request.json()
+  const signedId = `demo-signed-id-${++blobCounter}`
+
+  files.set(signedId, { metadata: blob })
+
+  return new Response(JSON.stringify({
+    id: blobCounter,
+    key: `demo-key-${blobCounter}`,
+    filename: blob.filename,
+    content_type: blob.content_type,
+    byte_size: blob.byte_size,
+    checksum: blob.checksum,
+    signed_id: signedId,
+    attachable_sgid: `demo-sgid-${blobCounter}`,
+    direct_upload: {
+      url: `/rails/active_storage/disk/${signedId}`,
+      headers: { "Content-Type": blob.content_type },
+    },
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+async function storeFile(request, url) {
+  const signedId = url.pathname.split("/").pop()
+  const data = await request.arrayBuffer()
+  const contentType = request.headers.get("content-type")
+
+  const existing = files.get(signedId) || {}
+  files.set(signedId, { ...existing, data, contentType })
+
+  return new Response(null, { status: 204 })
+}
+
+async function serveFile(url) {
+  const segments = url.pathname.split("/")
+  const blobsIndex = segments.indexOf("blobs")
+  const signedId = segments[blobsIndex + 1]
+
+  const file = files.get(signedId)
+  if (file?.data) {
+    return new Response(file.data, {
+      status: 200,
+      headers: { "Content-Type": file.contentType || "application/octet-stream" },
+    })
+  }
+
+  return new Response("Not found", { status: 404 })
+}

--- a/docs/try-it.md
+++ b/docs/try-it.md
@@ -10,9 +10,36 @@ nav_order: 2
 <link rel="stylesheet" href="https://unpkg.com/@37signals/lexxy@latest/dist/stylesheets/lexxy.css">
 <script type="module">
   import * as Lexxy from "https://esm.sh/@37signals/lexxy@latest";
+
+  navigator.serviceWorker.register("{{ site.baseurl }}/attachments-sw.js");
 </script>
 
-<lexxy-editor class="lexxy-content" placeholder="Write something…" attachments="false">
+<lexxy-editor
+  class="lexxy-content"
+  placeholder="Write something…"
+  data-direct-upload-url="/rails/active_storage/direct_uploads"
+  data-blob-url-template="/rails/active_storage/blobs/:signed_id/:filename">
+  <lexxy-prompt trigger=":" insert-editable-text>
+    <lexxy-prompt-item search="joy laughing face"><template type="menu">😂 Joy</template><template type="editor">😂</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="heart red heart"><template type="menu">❤️ Heart</template><template type="editor">❤️</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="thumbs up like"><template type="menu">👍 Thumbs Up</template><template type="editor">👍</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="fire hot lit"><template type="menu">🔥 Fire</template><template type="editor">🔥</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="party popper celebration"><template type="menu">🎉 Party</template><template type="editor">🎉</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="star favorite"><template type="menu">⭐ Star</template><template type="editor">⭐</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="clap applause"><template type="menu">👏 Clap</template><template type="editor">👏</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="rocket launch"><template type="menu">🚀 Rocket</template><template type="editor">🚀</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="100 hundred perfect"><template type="menu">💯 100</template><template type="editor">💯</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="checkmark check mark"><template type="menu">✅ Check</template><template type="editor">✅</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="heart eyes love"><template type="menu">😍 Heart Eyes</template><template type="editor">😍</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="thinking thought"><template type="menu">🤔 Thinking</template><template type="editor">🤔</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="wink wink"><template type="menu">😉 Wink</template><template type="editor">😉</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="celebrate party"><template type="menu">🎊 Celebrate</template><template type="editor">🎊</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="muscle flex strong"><template type="menu">💪 Muscle</template><template type="editor">💪</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="lightbulb idea"><template type="menu">💡 Lightbulb</template><template type="editor">💡</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="thumbs down dislike"><template type="menu">👎 Thumbs Down</template><template type="editor">👎</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="pray hands thank"><template type="menu">🙏 Pray</template><template type="editor">🙏</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="clown face funny"><template type="menu">🤡 Clown</template><template type="editor">🤡</template></lexxy-prompt-item>
+    <lexxy-prompt-item search="crown king queen"><template type="menu">👑 Crown</template><template type="editor">👑</template></lexxy-prompt-item>
+  </lexxy-prompt>
 </lexxy-editor>
 {:/nomarkdown}
-*Attachment uploads are not supported in this demo*


### PR DESCRIPTION
## Summary

- Add a Service Worker (`docs/attachments-sw.js`) that mocks Active Storage's Direct Upload endpoints, allowing file uploads to work entirely client-side on the GitHub Pages demo — files go through the full upload lifecycle (progress bar, attachment rendering) without a server.
- Add an emoji picker prompt (triggered by `:`) with 20 common emojis.
- Remove the `attachments="false"` restriction and the "not supported" notice.