### PR TITLE
Fix try-it page: switch CDN from esm.sh to jsdelivr

### DIFF
--- a/docs/try-it.md
+++ b/docs/try-it.md
@@ -7,9 +7,9 @@ nav_order: 2
 # Try the Editor
 
 {::nomarkdown}
-<link rel="stylesheet" href="https://unpkg.com/@37signals/lexxy@0.8.0-beta/dist/stylesheets/lexxy.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@37signals/lexxy@latest/dist/stylesheets/lexxy.css">
 <script type="module">
-  import * as Lexxy from "https://esm.sh/@37signals/lexxy@0.8.0-beta";
+  import * as Lexxy from "https://cdn.jsdelivr.net/npm/@37signals/lexxy@latest/+esm";
 
   navigator.serviceWorker.register("{{ site.baseurl }}/attachments-sw.js");
 </script>


### PR DESCRIPTION
## Summary
- esm.sh serves corrupted content for `@latest`, mixing in unrelated packages (entities, supabase)
- Switch to jsdelivr which handles `@latest` and ESM rewriting correctly
- Also switches CSS from unpkg to jsdelivr for consistency