### PR TITLE
Allow parallel Playwright runs via VITE_PORT env var

### DIFF
--- a/test/browser/playwright.config.js
+++ b/test/browser/playwright.config.js
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test"
 
 const isCI = !!process.env.CI
+const vitePort = process.env.VITE_PORT || "5173"
 
 export default defineConfig({
   testDir: "./tests",
@@ -13,7 +14,7 @@ export default defineConfig({
     : [["list"], ["html", { open: "on-failure", outputFolder: "./playwright-report" }]],
 
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${vitePort}`,
     trace: "on-first-retry",
     video: "on-first-retry",
     screenshot: "only-on-failure",
@@ -27,7 +28,7 @@ export default defineConfig({
 
   webServer: {
     command: `npx vite --config ${import.meta.dirname}/vite.config.js`,
-    url: "http://localhost:5173",
+    url: `http://localhost:${vitePort}`,
     reuseExistingServer: !isCI,
     timeout: 15_000,
   },

--- a/test/browser/vite.config.js
+++ b/test/browser/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: parseInt(process.env.VITE_PORT || "5173", 10),
     strictPort: true,
   },
 })


### PR DESCRIPTION
## Summary
- Both `playwright.config.js` and `vite.config.js` had port 5173 hardcoded
- When running multiple worktrees in parallel, all Playwright runs would collide on the same Vite server (or worse, test against the wrong worktree's code due to `reuseExistingServer`)
- Now reads `VITE_PORT` env var (defaults to 5173), so parallel worktrees can each use a unique port: `VITE_PORT=5174 yarn test:browser`