### PR TITLE
Add browser performance benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,84 @@
+name: Benchmarks
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  browser-benchmarks:
+    name: Browser benchmarks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      BENCHMARK_ITERATIONS: 10
+      BENCHMARK_WARMUP_ITERATIONS: 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "yarn"
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser benchmarks
+        run: yarn benchmark:browser
+
+      - name: Upload browser benchmark results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-benchmarks
+          path: tmp/browser-benchmarks.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Find latest successful main benchmark run
+        id: baseline
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/benchmarks.yml/runs?branch=main&status=success&event=push&per_page=1" \
+            | jq -r '.workflow_runs[0].id // empty'
+          )
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Note missing baseline
+        if: steps.baseline.outputs.run_id == ''
+        run: |
+          echo "## Browser Benchmark Comparison" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No successful \`main\` benchmark run exists yet, so this run only published a fresh baseline artifact." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download baseline benchmark artifact
+        if: steps.baseline.outputs.run_id != ''
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          name: browser-benchmarks
+          path: baseline
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.baseline.outputs.run_id }}
+
+      - name: Compare benchmark medians against main
+        if: steps.baseline.outputs.run_id != ''
+        run: yarn benchmark:browser:compare baseline/browser-benchmarks.json tmp/browser-benchmarks.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@ Single-file tests (`code_highlighting`, `events`) live at the root level.
 
 When adding a new test, pick the folder whose description fits best. If none fits, consider whether a new folder is warranted or if the test extends an existing category.
 
+## Performance Benchmarks
+
+Use the browser benchmark harness for Lexxy performance work. It is intentionally scoped to the JS/editor side of the project, not Rails persistence or Action Text server behavior.
+
+- Run browser benchmarks from the worktree with `yarn benchmark:browser`.
+- Results are written to `tmp/browser-benchmarks.json`.
+- For targeted iteration, use `yarn benchmark:browser --list-scenarios` and `yarn benchmark:browser --scenario <name> --warmup <n> --iterations <n>`.
+- Compare two runs with `yarn benchmark:browser:compare <baseline.json> <current.json>`.
+- CI uses `.github/workflows/benchmarks.yml` and compares PR results against the latest successful benchmark run on `main`.
+- Treat CI benchmark failures as coarse regression alarms. The thresholds are intentionally loose enough to survive normal GitHub-hosted runner variance.
 ## Fixing Bugs
 
 Follow this mandatory workflow. Every step must complete before moving to the next.

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,3 +106,50 @@ yarn release
 Create [a new release in GitHub](https://github.com/basecamp/lexxy/releases). 
 
 While in beta we are flagging the releases as pre-release.
+
+## Performance benchmarks
+
+Lexxy also ships a browser benchmark harness for the JS side of the editor. These benchmarks run against the Vite fixture app in `test/browser/fixtures/`, just like the Playwright browser tests, so they measure editor bootstrap and content-loading cost without involving Rails, Action Text persistence, or Active Storage uploads.
+
+To run the full browser benchmark suite locally:
+
+```bash
+yarn benchmark:browser
+```
+
+Results are written to `tmp/browser-benchmarks.json`.
+
+For quicker iteration, you can narrow the run to a single scenario or reduce the sample counts:
+
+```bash
+# List scenarios
+yarn benchmark:browser --list-scenarios
+
+# Run one scenario with smaller sample sizes
+yarn benchmark:browser --scenario load-very-large-table --warmup 1 --iterations 5
+```
+
+The current benchmark scenarios are:
+
+- `bootstrap-empty-editor`
+- `bootstrap-many-editors`
+- `load-large-content`
+- `load-very-large-table`
+- `load-many-attachments`
+
+To compare two result files locally:
+
+```bash
+yarn benchmark:browser:compare tmp/baseline.json tmp/current.json
+```
+
+The compare script checks per-scenario median regressions against coarse thresholds so it can be used in CI without flapping on normal GitHub runner variance.
+
+## Benchmark CI
+
+GitHub Actions runs the browser benchmark workflow from `.github/workflows/benchmarks.yml` on pull requests, pushes to `main`, and manual dispatches.
+
+- Each run uploads `tmp/browser-benchmarks.json` as the `browser-benchmarks` artifact.
+- Pull requests compare their results against the latest successful benchmark run from `main`.
+- The workflow only fails when a scenario median regresses by more than both the configured absolute and relative threshold.
+- The comparison is written to the workflow summary, so you can inspect the deltas without downloading artifacts manually.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,5 +69,48 @@ export default [
       "semi": ["error", "never"],
       "sort-imports": ["error", { "ignoreDeclarationSort": true }]
     }
+  },
+  {
+    files: ["scripts/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        AbortController: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
+        clearTimeout: "readonly",
+        console: "readonly",
+        fetch: "readonly",
+        performance: "readonly",
+        process: "readonly",
+        setTimeout: "readonly",
+        window: "readonly"
+      }
+    },
+    rules: {
+      "array-bracket-spacing": ["error", "always"],
+      "block-spacing": ["error", "always"],
+      "camelcase": ["error"],
+      "comma-spacing": ["error"],
+      "curly": ["error", "multi-line"],
+      "dot-notation": ["error"],
+      "eol-last": ["error"],
+      "func-style": ["error", "declaration"],
+      "getter-return": ["error"],
+      "keyword-spacing": ["error"],
+      "no-empty": "off",
+      "no-multi-spaces": ["error", { "exceptions": { "VariableDeclarator": true } }],
+      "no-multiple-empty-lines": ["error", { "max": 2 }],
+      "no-restricted-globals": ["error", "event"],
+      "no-trailing-spaces": ["error"],
+      "no-unused-vars": ["error", { "vars": "all", "args": "none", "caughtErrors": "none" }],
+      "no-var": ["error"],
+      "object-curly-spacing": ["error", "always"],
+      "prefer-const": ["error"],
+      "quotes": ["error", "double"],
+      "semi": ["error", "never"],
+      "sort-imports": ["error", { "ignoreDeclarationSort": true }]
+    }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "scripts": {
     "build": "rollup -c",
     "build:npm": "rollup -c rollup.config.npm.mjs",
+    "benchmark:browser": "node scripts/benchmarks/run-browser-benchmarks.js",
+    "benchmark:browser:compare": "node scripts/benchmarks/compare-browser-benchmarks.js",
     "watch": "rollup -wc --watch.onEnd=\"rails restart\"",
     "lint": "eslint",
     "test": "vitest",

--- a/scripts/benchmarks/compare-browser-benchmarks.js
+++ b/scripts/benchmarks/compare-browser-benchmarks.js
@@ -1,0 +1,224 @@
+import { appendFile, readFile } from "node:fs/promises"
+import path from "node:path"
+import process from "node:process"
+
+const DEFAULT_THRESHOLD = {
+  absoluteMedianRegressionMs: 20,
+  relativeMedianRegression: 0.2,
+}
+
+const SCENARIO_THRESHOLDS = {
+  "bootstrap-empty-editor": {
+    absoluteMedianRegressionMs: 10,
+    relativeMedianRegression: 0.25,
+  },
+  "bootstrap-many-editors": {
+    absoluteMedianRegressionMs: 20,
+    relativeMedianRegression: 0.2,
+  },
+  "load-large-content": {
+    absoluteMedianRegressionMs: 25,
+    relativeMedianRegression: 0.2,
+  },
+  "load-many-attachments": {
+    absoluteMedianRegressionMs: 25,
+    relativeMedianRegression: 0.2,
+  },
+  "load-very-large-table": {
+    absoluteMedianRegressionMs: 30,
+    relativeMedianRegression: 0.2,
+  },
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})
+
+async function main() {
+  const { baselinePath, currentPath } = parseArgs(process.argv.slice(2))
+  const baselineResults = await loadBenchmarkResults(baselinePath)
+  const currentResults = await loadBenchmarkResults(currentPath)
+  const comparison = compareResults({ baselineResults, currentResults })
+  const summary = buildSummary(comparison, { baselinePath, currentPath })
+
+  console.log(summary.consoleOutput)
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary.markdown}\n`)
+  }
+
+  if (comparison.failures.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+function parseArgs(args) {
+  if (args.length !== 2) {
+    throw new Error("Usage: node scripts/benchmarks/compare-browser-benchmarks.js <baseline.json> <current.json>")
+  }
+
+  return {
+    baselinePath: path.resolve(args[0]),
+    currentPath: path.resolve(args[1]),
+  }
+}
+
+async function loadBenchmarkResults(filePath) {
+  const contents = await readFile(filePath, "utf8")
+  const parsedContents = JSON.parse(contents)
+
+  if (!Array.isArray(parsedContents.scenarios)) {
+    throw new Error(`Invalid browser benchmark result file: ${filePath}`)
+  }
+
+  return parsedContents
+}
+
+function compareResults({ baselineResults, currentResults }) {
+  const baselineScenarios = new Map(baselineResults.scenarios.map((scenario) => [ scenario.name, scenario ]))
+  const currentScenarios = new Map(currentResults.scenarios.map((scenario) => [ scenario.name, scenario ]))
+  const names = new Set([ ...baselineScenarios.keys(), ...currentScenarios.keys() ])
+  const entries = []
+  const failures = []
+
+  for (const name of [ ...names ].sort()) {
+    const baselineScenario = baselineScenarios.get(name)
+    const currentScenario = currentScenarios.get(name)
+
+    if (!baselineScenario) {
+      entries.push({
+        currentMedian: currentScenario.stats.median,
+        name,
+        status: "new",
+      })
+      continue
+    }
+
+    if (!currentScenario) {
+      const failure = {
+        name,
+        reason: "scenario missing from current benchmark results",
+        status: "missing",
+      }
+
+      entries.push(failure)
+      failures.push(failure)
+      continue
+    }
+
+    const threshold = SCENARIO_THRESHOLDS[name] || DEFAULT_THRESHOLD
+    const deltaMs = roundNumber(currentScenario.stats.median - baselineScenario.stats.median)
+    const deltaRatio = baselineScenario.stats.median === 0
+      ? null
+      : roundNumber(deltaMs / baselineScenario.stats.median)
+    const isRegression = deltaMs > threshold.absoluteMedianRegressionMs &&
+      deltaRatio !== null &&
+      deltaRatio > threshold.relativeMedianRegression
+
+    const entry = {
+      baselineMedian: baselineScenario.stats.median,
+      currentMedian: currentScenario.stats.median,
+      deltaMs,
+      deltaRatio,
+      name,
+      status: statusForDelta(deltaMs, isRegression),
+      threshold,
+    }
+
+    entries.push(entry)
+
+    if (isRegression) {
+      failures.push(entry)
+    }
+  }
+
+  return { entries, failures }
+}
+
+function buildSummary(comparison, { baselinePath, currentPath }) {
+  const consoleLines = [
+    "Browser benchmark comparison:",
+    `baseline: ${baselinePath}`,
+    `current: ${currentPath}`,
+    "",
+  ]
+
+  const markdownLines = [
+    "## Browser Benchmark Comparison",
+    "",
+    `Baseline: \`${baselinePath}\`  `,
+    `Current: \`${currentPath}\``,
+    "",
+    "| Scenario | Baseline median | Current median | Delta | Threshold | Status |",
+    "| --- | ---: | ---: | ---: | --- | --- |",
+  ]
+
+  for (const entry of comparison.entries) {
+    const thresholdLabel = formatThreshold(entry.threshold)
+    const deltaLabel = formatDelta(entry)
+    const baselineLabel = formatMedian(entry.baselineMedian)
+    const currentLabel = formatMedian(entry.currentMedian)
+
+    consoleLines.push([
+      `- ${entry.name}`,
+      `baseline=${baselineLabel}`,
+      `current=${currentLabel}`,
+      `delta=${deltaLabel}`,
+      `threshold=${thresholdLabel}`,
+      `status=${entry.status}`,
+    ].join(" "))
+
+    markdownLines.push(`| ${entry.name} | ${baselineLabel} | ${currentLabel} | ${deltaLabel} | ${thresholdLabel} | ${entry.status} |`)
+  }
+
+  markdownLines.push("")
+
+  if (comparison.failures.length === 0) {
+    consoleLines.push("")
+    consoleLines.push("No benchmark regressions exceeded the configured thresholds.")
+    markdownLines.push("No benchmark regressions exceeded the configured thresholds.")
+  } else {
+    consoleLines.push("")
+    consoleLines.push(`${comparison.failures.length} benchmark regression(s) exceeded the configured thresholds.`)
+    markdownLines.push(`${comparison.failures.length} benchmark regression(s) exceeded the configured thresholds.`)
+  }
+
+  return {
+    consoleOutput: consoleLines.join("\n"),
+    markdown: markdownLines.join("\n"),
+  }
+}
+
+function statusForDelta(deltaMs, isRegression) {
+  if (isRegression) return "regressed"
+  if (deltaMs < 0) return "improved"
+  if (deltaMs > 0) return "stable"
+  return "unchanged"
+}
+
+function formatMedian(value) {
+  if (typeof value !== "number") return "n/a"
+  return `${value.toFixed(3)} ms`
+}
+
+function formatDelta(entry) {
+  if (typeof entry.deltaMs !== "number") return "n/a"
+
+  if (entry.deltaRatio === null) {
+    return `${entry.deltaMs.toFixed(3)} ms`
+  }
+
+  const sign = entry.deltaMs > 0 ? "+" : ""
+  return `${sign}${entry.deltaMs.toFixed(3)} ms (${sign}${(entry.deltaRatio * 100).toFixed(1)}%)`
+}
+
+function formatThreshold(threshold) {
+  if (!threshold) return "n/a"
+
+  return `>${threshold.absoluteMedianRegressionMs} ms and >${(threshold.relativeMedianRegression * 100).toFixed(0)}%`
+}
+
+function roundNumber(value) {
+  return Number.parseFloat(value.toFixed(3))
+}

--- a/scripts/benchmarks/run-browser-benchmarks.js
+++ b/scripts/benchmarks/run-browser-benchmarks.js
@@ -1,0 +1,410 @@
+import { chromium } from "@playwright/test"
+import { execFileSync } from "node:child_process"
+import { mkdir, writeFile } from "node:fs/promises"
+import net from "node:net"
+import path from "node:path"
+import process from "node:process"
+import { createServer } from "vite"
+
+const DEFAULT_OUTPUT_PATH = path.resolve("tmp/browser-benchmarks.json")
+const DEFAULT_ITERATIONS = numberFromEnv("BENCHMARK_ITERATIONS", 10)
+const DEFAULT_WARMUP_ITERATIONS = numberFromEnv("BENCHMARK_WARMUP_ITERATIONS", 2)
+const BENCHMARK_PAGE_PATH = "/benchmarks.html"
+const VIEWPORT = { width: 1440, height: 1200 }
+const SCENARIOS = [
+  {
+    description: "Create a single empty editor with the default toolbar",
+    kind: "bootstrap",
+    name: "bootstrap-empty-editor",
+    options: { editorCount: 1 },
+    title: "Bootstrap one empty editor",
+  },
+  {
+    description: "Create many editors in one pass to expose aggregate startup cost",
+    kind: "bootstrap",
+    name: "bootstrap-many-editors",
+    options: { editorCount: 20 },
+    title: "Bootstrap twenty editors",
+  },
+  {
+    description: "Load a large mixed-content HTML document",
+    kind: "load",
+    name: "load-large-content",
+    payload: {
+      kind: "large-content",
+      listItemsPerSection: 6,
+      paragraphsPerSection: 4,
+      sections: 24,
+      wordsPerParagraph: 40,
+    },
+    title: "Load large content",
+  },
+  {
+    description: "Load a very large table",
+    kind: "load",
+    name: "load-very-large-table",
+    payload: {
+      columns: 18,
+      kind: "table",
+      rows: 120,
+    },
+    title: "Load very large table",
+  },
+  {
+    description: "Load many static image attachments without any Rails upload path",
+    kind: "load",
+    name: "load-many-attachments",
+    payload: {
+      count: 60,
+      kind: "attachments",
+    },
+    title: "Load many attachments",
+  },
+]
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+
+  if (options.listScenarios) {
+    printScenarioList()
+    return
+  }
+
+  const port = options.port || await findAvailablePort()
+  const baseUrl = `http://127.0.0.1:${port}`
+  const viteServer = await startViteServer(port)
+
+  try {
+    const browser = await chromium.launch({
+      args: [
+        "--disable-background-timer-throttling",
+        "--disable-renderer-backgrounding",
+        "--disable-backgrounding-occluded-windows",
+      ],
+      headless: !options.headed,
+    })
+
+    try {
+      const context = await browser.newContext({
+        colorScheme: "light",
+        deviceScaleFactor: 1,
+        viewport: VIEWPORT,
+      })
+
+      try {
+        const environment = await collectEnvironment({ baseUrl, browser, context, options, port })
+        const scenarioResults = []
+
+        for (const scenario of options.scenarios) {
+          scenarioResults.push(await runScenario({ baseUrl, context, options, scenario }))
+        }
+
+        const output = {
+          environment,
+          formatVersion: 1,
+          generatedAt: new Date().toISOString(),
+          scenarios: scenarioResults,
+        }
+
+        await mkdir(path.dirname(options.outputPath), { recursive: true })
+        await writeFile(options.outputPath, `${JSON.stringify(output, null, 2)}\n`)
+
+        printScenarioSummary(output, options.outputPath)
+      } finally {
+        await context.close()
+      }
+    } finally {
+      await browser.close()
+    }
+  } finally {
+    await stopViteServer(viteServer)
+  }
+}
+
+async function runScenario({ baseUrl, context, options, scenario }) {
+  console.log(`Running ${scenario.name} (${options.warmupIterations} warmup, ${options.iterations} measured)`)
+
+  for (let iteration = 0; iteration < options.warmupIterations; iteration += 1) {
+    await runScenarioSample({ baseUrl, context, scenario })
+  }
+
+  const samples = []
+  let details = null
+
+  for (let iteration = 0; iteration < options.iterations; iteration += 1) {
+    const sample = await runScenarioSample({ baseUrl, context, scenario })
+    samples.push(roundNumber(sample.durationMs))
+    details ||= sample.details
+  }
+
+  return {
+    description: scenario.description,
+    details,
+    name: scenario.name,
+    samples,
+    stats: summarizeSamples(samples),
+    title: scenario.title,
+    unit: "ms",
+  }
+}
+
+async function runScenarioSample({ baseUrl, context, scenario }) {
+  const page = await openBenchmarkPage(context, baseUrl)
+
+  try {
+    return await page.evaluate(async (scenarioDefinition) => {
+      return await window.lexxyBenchmarks.measureScenario(scenarioDefinition)
+    }, scenario)
+  } finally {
+    await page.close()
+  }
+}
+
+async function collectEnvironment({ baseUrl, browser, context, options, port }) {
+  const page = await openBenchmarkPage(context, baseUrl)
+
+  try {
+    const browserMetadata = await page.evaluate(() => window.lexxyBenchmarks.browserMetadata())
+
+    return {
+      benchmarkPage: BENCHMARK_PAGE_PATH,
+      browser: {
+        name: "chromium",
+        version: browser.version(),
+      },
+      ci: {
+        githubActions: !!process.env.GITHUB_ACTIONS,
+        githubRef: process.env.GITHUB_REF || null,
+        githubRunId: process.env.GITHUB_RUN_ID || null,
+      },
+      git: {
+        branch: safeGitCommand([ "branch", "--show-current" ]),
+        commitSha: safeGitCommand([ "rev-parse", "HEAD" ]),
+      },
+      machine: browserMetadata,
+      node: process.version,
+      port,
+      warmupIterations: options.warmupIterations,
+      iterations: options.iterations,
+    }
+  } finally {
+    await page.close()
+  }
+}
+
+async function openBenchmarkPage(context, baseUrl) {
+  const page = await context.newPage()
+  await page.goto(`${baseUrl}${BENCHMARK_PAGE_PATH}`)
+  await page.evaluate(async () => {
+    await window.lexxyBenchmarks.prepare()
+  })
+  return page
+}
+
+function summarizeSamples(samples) {
+  const sortedSamples = [ ...samples ].sort((left, right) => left - right)
+  const count = sortedSamples.length
+  const sum = sortedSamples.reduce((total, sample) => total + sample, 0)
+
+  return {
+    count,
+    max: roundNumber(sortedSamples.at(-1)),
+    mean: roundNumber(sum / count),
+    median: roundNumber(percentile(sortedSamples, 0.5)),
+    min: roundNumber(sortedSamples[0]),
+    p90: roundNumber(percentile(sortedSamples, 0.9)),
+    p95: roundNumber(percentile(sortedSamples, 0.95)),
+  }
+}
+
+function percentile(sortedSamples, percentileValue) {
+  const position = (sortedSamples.length - 1) * percentileValue
+  const lowerIndex = Math.floor(position)
+  const upperIndex = Math.ceil(position)
+
+  if (lowerIndex === upperIndex) {
+    return sortedSamples[lowerIndex]
+  }
+
+  const weight = position - lowerIndex
+  return sortedSamples[lowerIndex] + ((sortedSamples[upperIndex] - sortedSamples[lowerIndex]) * weight)
+}
+
+function roundNumber(value) {
+  return Number.parseFloat(value.toFixed(3))
+}
+
+function parseArgs(args) {
+  const options = {
+    headed: false,
+    iterations: DEFAULT_ITERATIONS,
+    listScenarios: false,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    port: null,
+    scenarioNames: null,
+    warmupIterations: DEFAULT_WARMUP_ITERATIONS,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+
+    if (arg === "--headed") {
+      options.headed = true
+      continue
+    }
+
+    if (arg === "--list-scenarios") {
+      options.listScenarios = true
+      continue
+    }
+
+    if (arg === "--iterations") {
+      options.iterations = parsePositiveInteger(args[++index], "--iterations")
+      continue
+    }
+
+    if (arg === "--output") {
+      options.outputPath = path.resolve(args[++index])
+      continue
+    }
+
+    if (arg === "--port") {
+      options.port = parsePositiveInteger(args[++index], "--port")
+      continue
+    }
+
+    if (arg === "--scenario") {
+      options.scenarioNames = args[++index].split(",").map((name) => name.trim()).filter(Boolean)
+      continue
+    }
+
+    if (arg === "--warmup") {
+      options.warmupIterations = parseNonNegativeInteger(args[++index], "--warmup")
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  options.scenarios = options.scenarioNames ? selectScenarios(options.scenarioNames) : SCENARIOS
+  return options
+}
+
+function selectScenarios(scenarioNames) {
+  const names = new Set(scenarioNames)
+  const selectedScenarios = SCENARIOS.filter((scenario) => names.has(scenario.name))
+  const missingScenarios = scenarioNames.filter((scenarioName) => !selectedScenarios.find((scenario) => scenario.name === scenarioName))
+
+  if (missingScenarios.length > 0) {
+    throw new Error(`Unknown benchmark scenarios: ${missingScenarios.join(", ")}`)
+  }
+
+  return selectedScenarios
+}
+
+function printScenarioList() {
+  console.log("Available benchmark scenarios:")
+
+  for (const scenario of SCENARIOS) {
+    console.log(`- ${scenario.name}: ${scenario.description}`)
+  }
+}
+
+function printScenarioSummary(output, outputPath) {
+  console.log("")
+  console.log("Browser benchmark summary:")
+
+  for (const scenario of output.scenarios) {
+    console.log([
+      `- ${scenario.name}`,
+      `median=${scenario.stats.median.toFixed(3)}ms`,
+      `p95=${scenario.stats.p95.toFixed(3)}ms`,
+      `min=${scenario.stats.min.toFixed(3)}ms`,
+      `max=${scenario.stats.max.toFixed(3)}ms`,
+    ].join(" "))
+  }
+
+  console.log("")
+  console.log(`Wrote benchmark results to ${outputPath}`)
+}
+
+function parsePositiveInteger(value, flagName) {
+  const parsedValue = Number.parseInt(value, 10)
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(`${flagName} expects a positive integer`)
+  }
+
+  return parsedValue
+}
+
+function parseNonNegativeInteger(value, flagName) {
+  const parsedValue = Number.parseInt(value, 10)
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`${flagName} expects a non-negative integer`)
+  }
+
+  return parsedValue
+}
+
+function numberFromEnv(name, fallback) {
+  const value = process.env[name]
+
+  if (!value) {
+    return fallback
+  }
+
+  const parsedValue = Number.parseInt(value, 10)
+  return Number.isInteger(parsedValue) && parsedValue > 0 ? parsedValue : fallback
+}
+
+function safeGitCommand(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8" }).trim()
+  } catch {
+    return null
+  }
+}
+
+async function startViteServer(port) {
+  const viteServer = await createServer({
+    configFile: path.resolve("test/browser/vite.config.js"),
+    logLevel: "error",
+    server: {
+      host: "127.0.0.1",
+      port,
+      strictPort: true,
+    },
+  })
+
+  await viteServer.listen()
+  return viteServer
+}
+
+async function stopViteServer(viteServer) {
+  await viteServer.close()
+}
+
+function findAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Could not determine an available TCP port")))
+        return
+      }
+
+      server.close(() => resolve(address.port))
+    })
+  })
+}

--- a/test/browser/fixtures/benchmarks.html
+++ b/test/browser/fixtures/benchmarks.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Benchmarks</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <main id="benchmark-root"></main>
+
+  <script type="module" src="/benchmarks.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/benchmarks.js
+++ b/test/browser/fixtures/benchmarks.js
@@ -1,0 +1,293 @@
+import "lexxy"
+
+const root = document.getElementById("benchmark-root")
+const READY_TIMEOUT_MS = 5_000
+const SETTLE_FRAMES = 2
+const ATTACHMENT_IMAGE_URL = "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='120' viewBox='0 0 160 120'%3E%3Crect width='160' height='120' fill='%23d8d5cf'/%3E%3Ccircle cx='48' cy='42' r='14' fill='%23998367'/%3E%3Crect x='24' y='72' width='112' height='18' rx='9' fill='%2376644f'/%3E%3C/svg%3E"
+const WORD_BANK = [ "lexxy", "editor", "selection", "format", "table", "attachment", "toolbar", "cursor", "markdown", "history", "highlight", "command" ]
+
+window.lexxyBenchmarks = {
+  async prepare() {
+    await customElements.whenDefined("lexxy-editor")
+    await nextAnimationFrames(SETTLE_FRAMES)
+  },
+
+  browserMetadata() {
+    return {
+      deviceMemory: navigator.deviceMemory ?? null,
+      hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+      language: navigator.language,
+      platform: navigator.platform,
+      userAgent: navigator.userAgent,
+    }
+  },
+
+  async measureScenario(scenario) {
+    if (scenario.kind === "bootstrap") {
+      return measureBootstrap(scenario.options)
+    }
+
+    if (scenario.kind === "load") {
+      return measureLoad(scenario.payload, scenario.editorAttributes)
+    }
+
+    throw new Error(`Unknown benchmark kind: ${scenario.kind}`)
+  },
+}
+
+async function measureBootstrap(options = {}) {
+  await clearRoot()
+
+  const editorCount = options.editorCount ?? 1
+  const editorAttributes = options.editorAttributes ?? {}
+  const editors = []
+  const initializationPromises = []
+
+  for (let index = 0; index < editorCount; index += 1) {
+    const editorElement = buildEditor(editorAttributes)
+    editors.push(editorElement)
+    initializationPromises.push(waitForEvent(editorElement, "lexxy:initialize"))
+  }
+
+  const startTime = performance.now()
+  root.replaceChildren(...editors)
+
+  await Promise.all(initializationPromises)
+  await Promise.all(editors.map(waitForEditorReady))
+  const durationMs = performance.now() - startTime
+
+  return {
+    details: {
+      editorCount,
+      renderedNodeCount: editors.reduce((count, editor) => count + editor.querySelectorAll("*").length, 0),
+      toolbarCount: editors.filter((editor) => editor.toolbarElement).length,
+    },
+    durationMs,
+  }
+}
+
+async function measureLoad(payload, editorAttributes = {}) {
+  await clearRoot()
+
+  const editorElement = await createReadyEditor(editorAttributes)
+  const { details, html } = buildPayload(payload)
+  const startTime = performance.now()
+
+  editorElement.value = html
+  await settleEditor(editorElement)
+  const durationMs = performance.now() - startTime
+
+  return {
+    details: {
+      ...details,
+      htmlLength: html.length,
+      renderedNodeCount: editorElement.querySelectorAll("*").length,
+      serializedHtmlLength: editorElement.value.length,
+      textLength: editorElement.toString().length,
+    },
+    durationMs,
+  }
+}
+
+function buildPayload(payload) {
+  if (payload.kind === "large-content") {
+    return buildLargeContentPayload(payload)
+  }
+
+  if (payload.kind === "table") {
+    return buildTablePayload(payload)
+  }
+
+  if (payload.kind === "attachments") {
+    return buildAttachmentPayload(payload)
+  }
+
+  throw new Error(`Unknown payload kind: ${payload.kind}`)
+}
+
+function buildLargeContentPayload({ listItemsPerSection, paragraphsPerSection, sections, wordsPerParagraph }) {
+  const html = Array.from({ length: sections }, (_item, sectionIndex) => {
+    const headingLevel = (sectionIndex % 3) + 2
+    const heading = `<h${headingLevel}>Section ${sectionIndex + 1}</h${headingLevel}>`
+    const paragraphs = Array.from({ length: paragraphsPerSection }, (_paragraph, paragraphIndex) => {
+      const offset = sectionIndex * paragraphsPerSection + paragraphIndex
+      return `<p>${buildFormattedSentence(offset, wordsPerParagraph)}</p>`
+    }).join("")
+    const list = `<ul>${Array.from({ length: listItemsPerSection }, (_listItem, itemIndex) => `<li>${buildPlainSentence(sectionIndex + itemIndex, 12)}</li>`).join("")}</ul>`
+    const quote = `<blockquote><p>${buildPlainSentence(sectionIndex + 1, 24)}</p></blockquote>`
+    const code = `<pre><code class="language-js">const section${sectionIndex + 1} = "${buildCodeString(sectionIndex)}"</code></pre>`
+
+    return `${heading}${paragraphs}${list}${quote}${code}`
+  }).join("")
+
+  return {
+    details: {
+      listItemsPerSection,
+      paragraphsPerSection,
+      sections,
+      wordsPerParagraph,
+    },
+    html,
+  }
+}
+
+function buildTablePayload({ columns, rows }) {
+  const header = `<thead><tr>${Array.from({ length: columns }, (_item, columnIndex) => `<th>Column ${columnIndex + 1}</th>`).join("")}</tr></thead>`
+  const body = `<tbody>${Array.from({ length: rows }, (_item, rowIndex) => `<tr>${Array.from({ length: columns }, (_cell, columnIndex) => `<td>R${rowIndex + 1}C${columnIndex + 1} ${buildPlainSentence(rowIndex + columnIndex, 8)}</td>`).join("")}</tr>`).join("")}</tbody>`
+
+  return {
+    details: {
+      columns,
+      rows,
+      totalCells: rows * columns,
+    },
+    html: `<table>${header}${body}</table>`,
+  }
+}
+
+function buildAttachmentPayload({ count }) {
+  const html = Array.from({ length: count }, (_item, index) => {
+    return [
+      "<p>Attachment group</p>",
+      `<action-text-attachment`,
+      ` previewable="true"`,
+      ` url="${ATTACHMENT_IMAGE_URL}"`,
+      ` alt="Attachment ${index + 1}"`,
+      ` caption="Attachment ${index + 1}"`,
+      ` content-type="image/png"`,
+      ` filename="attachment-${index + 1}.png"`,
+      ` width="160"`,
+      ` height="120">`,
+      "</action-text-attachment>",
+    ].join("")
+  }).join("")
+
+  return {
+    details: {
+      count,
+    },
+    html,
+  }
+}
+
+function buildEditor(editorAttributes = {}) {
+  const editorElement = document.createElement("lexxy-editor")
+  editorElement.classList.add("lexxy-content")
+  editorElement.setAttribute("placeholder", "Write something...")
+
+  Object.entries(editorAttributes).forEach(([ name, value ]) => {
+    if (value === false || value === null || value === undefined) return
+
+    if (value === true) {
+      editorElement.setAttribute(name, "true")
+      return
+    }
+
+    editorElement.setAttribute(name, String(value))
+  })
+
+  return editorElement
+}
+
+async function createReadyEditor(editorAttributes = {}) {
+  const editorElement = buildEditor(editorAttributes)
+  const initialized = waitForEvent(editorElement, "lexxy:initialize")
+
+  root.replaceChildren(editorElement)
+
+  await initialized
+  await waitForEditorReady(editorElement)
+
+  return editorElement
+}
+
+async function waitForEditorReady(editorElement) {
+  await waitForCondition(() => editorElement.hasAttribute("connected"))
+
+  if (editorElement.toolbarElement) {
+    await waitForCondition(() => editorElement.toolbarElement?.hasAttribute("connected"))
+  }
+
+  await settleEditor(editorElement)
+}
+
+function settleEditor(editorElement) {
+  return new Promise((resolve) => {
+    editorElement.editor.update(() => {}, {
+      onUpdate: async () => {
+        await nextAnimationFrames(SETTLE_FRAMES)
+        resolve()
+      },
+    })
+  })
+}
+
+async function clearRoot() {
+  root.replaceChildren()
+  await nextAnimationFrames(SETTLE_FRAMES)
+}
+
+function waitForEvent(target, eventName) {
+  return new Promise((resolve) => {
+    target.addEventListener(eventName, resolve, { once: true })
+  })
+}
+
+function waitForCondition(predicate) {
+  const startTime = performance.now()
+
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) {
+        resolve()
+        return
+      }
+
+      if ((performance.now() - startTime) > READY_TIMEOUT_MS) {
+        reject(new Error("Benchmark fixture timed out while waiting for editor readiness"))
+        return
+      }
+
+      requestAnimationFrame(tick)
+    }
+
+    tick()
+  })
+}
+
+function nextAnimationFrames(frameCount) {
+  let promise = Promise.resolve()
+
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    promise = promise.then(() => new Promise((resolve) => requestAnimationFrame(resolve)))
+  }
+
+  return promise
+}
+
+function buildFormattedSentence(offset, wordCount) {
+  const plainSentence = buildPlainSentence(offset, wordCount)
+
+  return [
+    `Paragraph ${offset + 1} uses`,
+    `<strong>bold text</strong>,`,
+    `<em>emphasis</em>,`,
+    `<a href="https://example.com/sections/${offset + 1}">linked text</a>,`,
+    `<mark style="color: var(--highlight-1)">highlighting</mark>,`,
+    `${plainSentence}.`,
+  ].join(" ")
+}
+
+function buildPlainSentence(offset, wordCount) {
+  const words = []
+
+  for (let index = 0; index < wordCount; index += 1) {
+    words.push(WORD_BANK[(offset + index) % WORD_BANK.length])
+  }
+
+  return words.join(" ")
+}
+
+function buildCodeString(sectionIndex) {
+  return `section-${sectionIndex + 1}-${buildPlainSentence(sectionIndex, 4).replaceAll(" ", "-")}`
+}


### PR DESCRIPTION
## Summary
- add a browser-side benchmark harness and JSON compare script for Lexxy editor startup/load scenarios
- add a dedicated GitHub Actions benchmark workflow that compares PR runs against the latest successful main baseline
- document local benchmark usage and CI comparison flow in docs/development.md and AGENTS.md

## Testing
- yarn lint
- yarn benchmark:browser --iterations 2 --warmup 1
- yarn benchmark:browser:compare tmp/browser-benchmarks.json tmp/browser-benchmarks.json
- yarn test:browser:chromium