### PR TITLE
Fix cursor position when typing over a selected inline decorator

### DIFF
--- a/.claude/skills/bugs-reproducer.md
+++ b/.claude/skills/bugs-reproducer.md
@@ -378,7 +378,7 @@ When reproduced via Capybara, keep the test in `test/system/`. When reproduced v
 
 These are areas where bugs tend to cluster, based on the architecture:
 
-**Decorator node navigation** — Arrow keys around attachments, dividers, and galleries. The `Selection` class manually intercepts LEFT/RIGHT/UP/DOWN at node boundaries. Chrome has specific workarounds for fake cursor elements.
+**Decorator node navigation and NodeSelection** — Arrow keys around attachments, dividers, and galleries. The `Selection` class manually intercepts LEFT/RIGHT/UP/DOWN at node boundaries. Chrome has specific workarounds for fake cursor elements. Lexical's `NodeSelection` also has no-op `insertText()`/`insertRawText()` methods, so any text input while an inline decorator is selected must be handled by custom code — the browser's native text insertion will go to the wrong position because the native selection has no ranges.
 
 **Provisional paragraph lifecycle** — The invisible paragraphs inserted around decorator nodes by `ProvisionalParagraphExtension`. They should appear when needed, disappear when not, and convert to real paragraphs when typed into. Bugs: they don't appear, they duplicate, they don't convert, or they persist when they shouldn't.
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -1,5 +1,5 @@
 import {
-  $createParagraphNode, $getNearestNodeFromDOMNode, $getRoot, $getSelection, $isDecoratorNode, $isElementNode,
+  $createParagraphNode, $createTextNode, $getNearestNodeFromDOMNode, $getRoot, $getSelection, $isDecoratorNode, $isElementNode,
   $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $setSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW, DELETE_CHARACTER_COMMAND, DecoratorNode,
   KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND, SELECTION_CHANGE_COMMAND, isDOMNode
 } from "lexical"
@@ -25,6 +25,7 @@ export default class Selection {
     this.#listenForNodeSelections()
     this.#processSelectionChangeCommands()
     this.#containEditorFocus()
+    this.#handleTextInsertionOnNodeSelection()
   }
 
   set current(selection) {
@@ -333,6 +334,33 @@ export default class Selection {
         }
       }
     }, true)
+  }
+
+  #handleTextInsertionOnNodeSelection() {
+    this.editorContentElement.addEventListener("keydown", (event) => {
+      if (!this.hasNodeSelection) return
+      if (event.key.length !== 1 || event.metaKey || event.ctrlKey || event.altKey) return
+
+      event.preventDefault()
+
+      this.editor.update(() => {
+        const selection = $getSelection()
+        if (!$isNodeSelection(selection)) return
+
+        const nodes = selection.getNodes()
+        if (nodes.length === 0) return
+
+        const firstNode = nodes[0]
+        const textNode = $createTextNode(event.key)
+
+        firstNode.insertBefore(textNode)
+        for (const node of nodes) {
+          node.remove()
+        }
+
+        textNode.selectEnd()
+      })
+    })
   }
 
   #syncSelectedClasses() {

--- a/test/browser/tests/inline_decorator_deletion.test.js
+++ b/test/browser/tests/inline_decorator_deletion.test.js
@@ -1,0 +1,116 @@
+import { test } from "../test_helper.js"
+import { expect } from "@playwright/test"
+
+const mentionHtml = (name) =>
+  `<action-text-attachment content-type="application/vnd.actiontext.mention" content="<span>${name}</span>"></action-text-attachment>`
+
+test.describe("Inline decorator deletion", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("typing with a selected mention replaces it at the correct position", async ({ page, editor }) => {
+    await editor.setValue(
+      `<p>Before ${mentionHtml("Alice")} after</p>`,
+    )
+    await editor.flush()
+
+    const mention = editor.content.locator("action-text-attachment")
+    await expect(mention).toHaveCount(1)
+
+    // Click to select the mention
+    await mention.click()
+    await editor.flush()
+    await expect(mention).toHaveClass(/node--selected/)
+
+    // Type to replace the mention
+    await editor.send("X")
+    await editor.flush()
+
+    // Mention should be gone and X should be at the correct position
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(0)
+
+    const text = await editor.plainTextValue()
+    expect(text).toMatch(/Before\s*X\s*after/)
+  })
+
+  test("typing with a selected mention between two mentions replaces only the selected one", async ({ page, editor }) => {
+    await editor.setValue(
+      `<p>AAA ${mentionHtml("Alice")} BBB ${mentionHtml("Bob")} CCC</p>`,
+    )
+    await editor.flush()
+
+    const mentions = editor.content.locator("action-text-attachment")
+    await expect(mentions).toHaveCount(2)
+
+    // Select Alice
+    await mentions.first().click()
+    await editor.flush()
+    await expect(mentions.first()).toHaveClass(/node--selected/)
+
+    // Type to replace
+    await editor.send("X")
+    await editor.flush()
+
+    // Only Bob should remain
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(1)
+
+    const text = await editor.plainTextValue()
+    expect(text).toMatch(/AAA\s*X\s*BBB/)
+    expect(text).toContain("Bob")
+    expect(text).toContain("CCC")
+  })
+
+  test("pressing Delete on a selected inline decorator removes it and positions cursor correctly", async ({ page, editor }) => {
+    await editor.setValue(
+      `<p>Before ${mentionHtml("Alice")} after</p>`,
+    )
+    await editor.flush()
+
+    const mention = editor.content.locator("action-text-attachment")
+    await expect(mention).toHaveCount(1)
+
+    await mention.click()
+    await editor.flush()
+    await expect(mention).toHaveClass(/node--selected/)
+
+    await page.keyboard.press("Delete")
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(0)
+
+    // Type to verify position
+    await editor.send("X")
+    await editor.flush()
+
+    const text = await editor.plainTextValue()
+    expect(text).toMatch(/Before\s*X\s*after/)
+  })
+
+  test("pressing Backspace on a selected inline decorator removes it and positions cursor correctly", async ({ page, editor }) => {
+    await editor.setValue(
+      `<p>Before ${mentionHtml("Alice")} after</p>`,
+    )
+    await editor.flush()
+
+    const mention = editor.content.locator("action-text-attachment")
+    await expect(mention).toHaveCount(1)
+
+    await mention.click()
+    await editor.flush()
+    await expect(mention).toHaveClass(/node--selected/)
+
+    await page.keyboard.press("Backspace")
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(0)
+
+    // Type to verify position
+    await editor.send("X")
+    await editor.flush()
+
+    const text = await editor.plainTextValue()
+    expect(text).toMatch(/Before\s*X\s*after/)
+  })
+})


### PR DESCRIPTION
## Summary

- Fix cursor jumping to wrong position when typing with an @mention (or other inline decorator) selected
- Lexical's `NodeSelection` has no-op `insertText()`/`insertRawText()` methods, so native browser text insertion defaults to the start of the contentEditable when a decorator has NodeSelection (the native selection has no ranges)
- Intercept `keydown` events when NodeSelection is active: for printable characters, programmatically insert a text node, remove the selected decorator, and place the cursor correctly

[Fizzy card #3494](https://app.fizzy.do/5986089/cards/3494)