### PR TITLE
Remove unwanted space between @mentions and trailing text

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -768,8 +768,9 @@ export default class Contents {
     const textBeforeString = fullText.slice(0, lastIndex)
     const textAfterCursor = fullText.slice(offset)
 
+    const trailingSpacer = this.#hasInlineDecoratorNode(replacementNodes) ? "\u2060" : " "
     const textNodeBefore = this.#cloneTextNodeFormatting(anchorNode, selection, textBeforeString)
-    const textNodeAfter = this.#cloneTextNodeFormatting(anchorNode, selection, textAfterCursor || " ")
+    const textNodeAfter = this.#cloneTextNodeFormatting(anchorNode, selection, textAfterCursor || trailingSpacer)
 
     anchorNode.replace(textNodeBefore)
 
@@ -779,6 +780,10 @@ export default class Contents {
     this.#appendLineBreakIfNeeded(textNodeAfter.getParentOrThrow())
     const cursorOffset = textAfterCursor ? 0 : 1
     textNodeAfter.select(cursorOffset, cursorOffset)
+  }
+
+  #hasInlineDecoratorNode(nodes) {
+    return nodes.some(node => node instanceof CustomActionTextAttachmentNode && node.isInline())
   }
 
   #cloneTextNodeFormatting(anchorNode, selection, text) {

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -40,7 +40,7 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
               contentType: attachment.getAttribute("content-type")
             }))
 
-            nodes.push($createTextNode(" "))
+            nodes.push($createTextNode("\u2060"))
 
             return { node: nodes }
           },

--- a/test/browser/fixtures/mentions.html
+++ b/test/browser/fixtures/mentions.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Mentions</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something...">
+        <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="Zacharias" sgid="test-sgid-zacharias">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Zacharias</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Zacharias</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Alice</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Alice</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/attachments/mentions.test.js
+++ b/test/browser/tests/attachments/mentions.test.js
@@ -1,0 +1,93 @@
+import { test } from "../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Mentions", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("typing apostrophe-s after a mention has no space between mention and possessive", async ({ page, editor }) => {
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    const mention = editor.content.locator("action-text-attachment")
+    await expect(mention).toBeVisible({ timeout: 5_000 })
+
+    await editor.content.pressSequentially("'s")
+    await editor.flush()
+
+    // The text node after the mention should not start with a regular space.
+    // Lexical wraps text in <span data-lexical-text="true">, so look for that.
+    const textAfterMention = await editor.content.evaluate((el) => {
+      const attachment = el.querySelector("action-text-attachment")
+      if (!attachment) return null
+      const nextSpan = attachment.nextElementSibling
+      if (!nextSpan || !nextSpan.hasAttribute("data-lexical-text")) return null
+      return nextSpan.textContent
+    })
+
+    expect(textAfterMention).not.toBeNull()
+    expect(textAfterMention).not.toMatch(/^ /)
+    expect(textAfterMention).toContain("'s")
+  })
+
+  test("mention and possessive apostrophe-s do not break across lines", async ({ page, editor }) => {
+    await editor.locator.evaluate((el) => {
+      el.style.width = "200px"
+    })
+
+    await editor.send("Hello ")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    const mention = editor.content.locator("action-text-attachment")
+    await expect(mention).toBeVisible({ timeout: 5_000 })
+
+    await editor.content.pressSequentially("'s")
+    await editor.flush()
+
+    // Verify the mention and 's are on the same line by checking their vertical positions
+    const positions = await editor.content.evaluate((el) => {
+      const attachment = el.querySelector("action-text-attachment")
+      if (!attachment) return null
+
+      const attachmentRect = attachment.getBoundingClientRect()
+
+      // Find the text node containing 's after the attachment
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let textNode
+      while ((textNode = walker.nextNode())) {
+        if (textNode.textContent.includes("'s")) {
+          const range = document.createRange()
+          const idx = textNode.textContent.indexOf("'s")
+          range.setStart(textNode, idx)
+          range.setEnd(textNode, idx + 2)
+          const textRect = range.getBoundingClientRect()
+          return {
+            mentionBottom: attachmentRect.bottom,
+            mentionTop: attachmentRect.top,
+            textTop: textRect.top,
+            textBottom: textRect.bottom,
+          }
+        }
+      }
+      return null
+    })
+
+    expect(positions).not.toBeNull()
+    // The mention and 's should be on the same line (their vertical positions should overlap)
+    expect(positions.textTop).toBeLessThan(positions.mentionBottom)
+    expect(positions.textBottom).toBeGreaterThan(positions.mentionTop)
+  })
+})


### PR DESCRIPTION
## Summary

- Replace the trailing space after inline mention attachments with a word joiner character (U+2060), which is zero-width and prevents line breaks
- Possessive forms like "@Zach's" now render tightly against the mention with no visible gap
- Apply the same fix to the `importDOM` conversion path so mentions loaded from HTML also avoid the unwanted space

[Fizzy card #3852](https://app.fizzy.do/5986089/cards/3852)