### PR TITLE
Build JavaScript assets automatically for git: gem installs

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,0 +1,31 @@
+task :default do
+  root = File.expand_path("..", __dir__)
+  target = File.join(root, "app", "assets", "javascript", "lexxy.js")
+
+  next if File.exist?(target)
+
+  puts <<~MSG
+
+    Lexxy: JavaScript assets not found — building from source.
+
+    This is expected when using Lexxy via `git:` in your Gemfile.
+    It requires Node.js and Yarn to be installed.
+
+  MSG
+
+  Dir.chdir(root) do
+    unless system("command -v yarn > /dev/null 2>&1")
+      abort <<~MSG
+
+        Lexxy: `yarn` is not installed. Lexxy needs Node.js and Yarn
+        to build its JavaScript assets when installed from git.
+
+        Install Yarn: https://yarnpkg.com/getting-started/install
+
+      MSG
+    end
+
+    sh "yarn install --frozen-lockfile"
+    sh "yarn build"
+  end
+end

--- a/lexxy.gemspec
+++ b/lexxy.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
+  spec.extensions = [ "ext/Rakefile" ]
+
   spec.add_dependency "rails", ">= 8.0.2"
   spec.add_development_dependency "turbo-rails"
   spec.add_development_dependency "stimulus-rails"


### PR DESCRIPTION
## Summary

- Follows up on #861 which removed built JS assets from git.
- Adds a gem extension (`ext/Rakefile`) so that `gem "lexxy", git: "..."` works: Bundler runs the extension during `bundle install`, which triggers `yarn install` + `yarn build` to produce the missing assets.
- The extension is a no-op for published gems (assets already ship in the `.gem` file).
- If Yarn isn't installed, it aborts with a helpful message pointing to the install docs.