### PR TITLE
Fix underline formatting not persisting in editor output

### DIFF
--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -3,7 +3,7 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 import Lexxy from "./lexxy"
 
 const ALLOWED_HTML_TAGS = [ "a", "b", "blockquote", "br", "code", "div", "em",
-  "figcaption", "figure", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "li", "mark", "ol", "p", "pre", "q", "s", "strong", "ul", "table", "tbody", "tr", "th", "td" ]
+  "figcaption", "figure", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "li", "mark", "ol", "p", "pre", "q", "s", "strong", "u", "ul", "table", "tbody", "tr", "th", "td" ]
 
 const ALLOWED_HTML_ATTRIBUTES = [ "alt", "caption", "class", "content", "content-type", "contenteditable",
   "data-direct-upload-id", "data-sgid", "filename", "filesize", "height", "href", "presentation",

--- a/test/browser/tests/formatting/inline_formatting.test.js
+++ b/test/browser/tests/formatting/inline_formatting.test.js
@@ -31,6 +31,20 @@ test.describe("Inline formatting", () => {
     await assertEditorHtml(editor, "<p>Hello <s>everyone</s></p>")
   })
 
+  test("underline via keyboard shortcut", async ({ page, editor }) => {
+    await editor.setValue(HELLO_EVERYONE)
+    await editor.select("everyone")
+
+    const modifier = process.platform === "darwin" ? "Meta" : "Control"
+    await editor.content.press(`${modifier}+u`)
+    await assertEditorHtml(editor, "<p>Hello <u>everyone</u></p>")
+  })
+
+  test("underline round-trips through setValue/value", async ({ editor }) => {
+    await editor.setValue("<p>Hello <u>everyone</u></p>")
+    await assertEditorHtml(editor, "<p>Hello <u>everyone</u></p>")
+  })
+
   test("toggle code for selected words", async ({ page, editor }) => {
     await editor.setValue(HELLO_EVERYONE)
     await editor.select("everyone")


### PR DESCRIPTION
## Summary

- The `<u>` tag was missing from the DOMPurify `ALLOWED_HTML_TAGS` allowlist in `src/config/dom_purify.js`, so the HTML sanitizer stripped underline formatting from the editor's value output
- The export layer (`text_node_export_helper.js`) correctly wraps underlined text in `<u>` tags, but `sanitize()` removed them before the value was returned
- Added `"u"` to the allowed tags list, alongside the already-present `"s"` (strikethrough) and `"b"` / `"i"` tags
- Added regression tests for underline via keyboard shortcut and round-trip through setValue/value

Fixes #710