### PR TITLE
Fix Lexical error when loading HTML with whitespace between div elements

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,4 +1,4 @@
-import { $addUpdateTag, $createParagraphNode, $getRoot, $isDecoratorNode, $isElementNode, $isParagraphNode, $isTextNode, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isParagraphNode, $isTextNode, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
@@ -210,8 +210,18 @@ export class LexicalEditorElement extends HTMLElement {
     const nodes = $generateNodesFromDOM(this.editor, parseHtml(`${html}`))
 
     return nodes
+      .filter(this.#isNotWhitespaceOnlyNode)
       .map(this.#wrapTextNode)
       .map(this.#unwrapDecoratorNode)
+  }
+
+  // Whitespace-only text nodes (e.g. "\n" between block elements like <div>) and stray line break
+  // nodes are formatting artifacts from the HTML source. They can't be appended to the root node
+  // and have no semantic meaning, so we strip them during import.
+  #isNotWhitespaceOnlyNode(node) {
+    if ($isLineBreakNode(node)) return false
+    if ($isTextNode(node) && node.getTextContent().trim() === "") return false
+    return true
   }
 
   // Raw string values produce TextNodes which cannot be appended directly to the RootNode.

--- a/test/browser/tests/editor/load_html.test.js
+++ b/test/browser/tests/editor/load_html.test.js
@@ -23,4 +23,16 @@ test.describe("Load HTML", () => {
     await editor.setValue("<div>hello</div> <div>there</div>")
     await assertEditorHtml(editor, "<p>hello</p><p>there</p>")
   })
+
+  test("load HTML with newlines between div elements does not crash", async ({ editor }) => {
+    // Whitespace text nodes (\n) between block elements like <div> are common in email HTML.
+    // Previously this threw Lexical error #282 because the \n became a TextNode at the root level.
+    await editor.setValue("<div>First paragraph.</div>\n<div><br></div>\n<div>Second paragraph.</div>")
+
+    await assertEditorContent(editor, async (content) => {
+      const paragraphs = content.locator("p")
+      await expect(paragraphs.first()).toHaveText("First paragraph.")
+      await expect(paragraphs.last()).toHaveText("Second paragraph.")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Strip whitespace-only text nodes at the root level during HTML import to prevent Lexical error #282
- Handles `<div>` elements with formatting whitespace (common in email HTML) the same way `<p>` elements are handled

Fixes #812