### PR TITLE
Add `allowedElements` option to customize HTML sanitization

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,21 @@ Editors support the following options, configurable using presets and element at
 - `markdown`: Pass `false` to disable Markdown support.
 - `multiLine`: Pass `false` to force single line editing.
 - `richText`: Pass `false` to disable rich text editing.
+- `allowedElements`: Add or remove HTML elements from sanitization. Keys are tag names; values are `true` (allow), `false` (forbid), or an array of extra attribute names to allow on that tag.
+
+  ```js
+  Lexxy.configure({
+    default: {
+      allowedElements: {
+        time: [ "datetime" ], // allow <time datetime="...">
+        abbr: true,           // allow <abbr>
+        q: false              // remove <q>
+      }
+    }
+  })
+  ```
+
+  Globally allowed attributes (like `class` and `style`) remain available on all elements.
 
 The toolbar is considered part of the editor for `lexxy:focus` and `lexxy:blur` events.
 

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify"
 import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
+import { partition } from "../helpers/hash_helper"
 import Lexxy from "./lexxy"
 
 const ALLOWED_HTML_TAGS = [ "a", "b", "blockquote", "br", "code", "div", "em",
@@ -38,10 +39,15 @@ DOMPurify.addHook("uponSanitizeElement", (node, data) => {
   }
 })
 
-export function buildConfig() {
+export function buildConfig(allowedElements) {
+  const [ add, forbid ] = partition(allowedElements, (_, value) => value)
+
   return {
     ALLOWED_TAGS: ALLOWED_HTML_TAGS.concat(Lexxy.global.get("attachmentTagName")),
     ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
+    ADD_TAGS: Object.keys(add),
+    FORBID_TAGS: Object.keys(forbid),
+    ADD_ATTR: (attr, tag) => add[tag]?.includes?.(attr),
     ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
     SAFE_FOR_XML: false // So that it does not strip attributes that contains serialized HTML (like content)
   }

--- a/src/config/lexxy.js
+++ b/src/config/lexxy.js
@@ -10,6 +10,7 @@ const global = new Configuration({
 
 const presets = new Configuration({
   default: {
+    allowedElements: {},
     attachments: true,
     markdown: true,
     multiLine: true,

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -182,7 +182,7 @@ export class LexicalEditorElement extends HTMLElement {
   get value() {
     if (!this.cachedValue) {
       this.editor?.getEditorState().read(() => {
-        this.cachedValue = sanitize($generateHtmlFromNodes(this.editor, null))
+        this.cachedValue = sanitize($generateHtmlFromNodes(this.editor, null), this.config.get("allowedElements"))
       })
     }
 

--- a/src/helpers/hash_helper.js
+++ b/src/helpers/hash_helper.js
@@ -9,6 +9,19 @@ export function deepMerge(target, source) {
   return result
 }
 
+export function partition(hash, predicate) {
+  const pass = {}
+  const fail = {}
+  for (const [ key, value ] of Object.entries(hash)) {
+    if (predicate(key, value)) {
+      pass[key] = value
+    } else {
+      fail[key] = value
+    }
+  }
+  return [ pass, fail ]
+}
+
 function arePlainHashes(...values) {
   return values.every(value => value && value.constructor == Object)
 }

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -1,6 +1,6 @@
 import DOMPurify from "dompurify"
 import { buildConfig } from "../config/dom_purify"
 
-export function sanitize(html) {
-  return DOMPurify.sanitize(html, buildConfig())
+export function sanitize(html, allowedElements) {
+  return DOMPurify.sanitize(html, buildConfig(allowedElements))
 }

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest"
+import { sanitize } from "src/helpers/sanitization_helper"
+
+const allowedElements = { time: ["datetime"], abbr: true, blockquote: false }
+
+test("preserves tag with scoped attributes", () => {
+  expect(sanitize('<p>Meet at <time datetime="2026-03-19">Thursday</time></p>', allowedElements))
+    .toContain('<time datetime="2026-03-19">Thursday</time>')
+})
+
+test("strips attributes not in the scoped or global list", () => {
+  expect(sanitize('<p><time datetime="2026-03-19" tabindex="0">Thursday</time></p>', allowedElements))
+    .toContain('<time datetime="2026-03-19">Thursday</time>')
+})
+
+test("preserves tag added with true", () => {
+  expect(sanitize("<p>An <abbr>HTML</abbr> element</p>", allowedElements))
+    .toContain("<abbr>HTML</abbr>")
+})
+
+test("forbids default tags set to false", () => {
+  expect(sanitize("<blockquote>A quote</blockquote>", allowedElements))
+    .not.toContain("blockquote")
+})
+
+test("strips unconfigured tags", () => {
+  const result = sanitize("<p>Hello <blink>world</blink></p>", allowedElements)
+  expect(result).not.toContain("blink")
+  expect(result).toContain("Hello world")
+})


### PR DESCRIPTION
Allow editors to add/forbid tags and per-tag attributes during sanitization via a new `allowedElements` preset config. Values can be `true` (allow tag), `false` (forbid tag), or an array of extra attribute names to permit on that tag.

```js
Lexxy.configure({
  default: {
    allowedElements: {
      time: [ "datetime" ], // allow <time datetime="...">
      abbr: true,           // allow <abbr>
      q: false              // remove <q>
    }
  }
})
```

These apply *on top* of the globally allowed tags and attributes we currently have in place.

Includes a `partition` hash helper, unit tests, and documentation.