### PR TITLE
Fix quote formatting consuming unselected lines with mixed break types

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -300,7 +300,8 @@ export default class Contents {
   }
 
   #splitParagraphsAtLineBreaks(selection) {
-    const selectedNodeKeys = new Set(selection.getNodes().map(n => n.getKey()))
+    const anchorKey = selection.anchor.getNode().getKey()
+    const focusKey = selection.focus.getNode().getKey()
     const topLevelElements = this.#topLevelElementsInSelection(selection)
 
     for (const element of topLevelElements) {
@@ -308,6 +309,14 @@ export default class Contents {
 
       const children = element.getChildren()
       if (!children.some($isLineBreakNode)) continue
+
+      // Check whether this paragraph needs splitting: skip only if neither
+      // selection endpoint is inside it (meaning it's a middle paragraph
+      // fully between anchor and focus with no partial lines to split off).
+      const hasEndpoint = children.some(child =>
+        child.getKey() === anchorKey || child.getKey() === focusKey
+      )
+      if (!hasEndpoint) continue
 
       const groups = [ [] ]
       for (const child of children) {
@@ -318,8 +327,6 @@ export default class Contents {
           groups[groups.length - 1].push(child)
         }
       }
-
-      if (groups.every(group => group.some(child => selectedNodeKeys.has(child.getKey())))) continue
 
       for (const group of groups) {
         if (group.length === 0) continue

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -144,6 +144,76 @@ test.describe("Block formatting", () => {
     )
   })
 
+  test("quote soft-break lines splits them into separate paragraphs in the blockquote", async ({
+    page,
+    editor,
+  }) => {
+    // Selecting two soft-break lines and quoting should split them into
+    // separate paragraphs inside the blockquote, not merge them into one.
+    await editor.setValue(
+      "<p>Before</p><p>First line<br>Second line</p><p>After</p>",
+    )
+
+    await editor.content.evaluate((el) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let startNode, endNode
+      let node
+      while ((node = walker.nextNode())) {
+        if (node.nodeValue.includes("First line")) startNode = node
+        if (node.nodeValue.includes("Second line")) endNode = node
+      }
+      const range = document.createRange()
+      range.setStart(startNode, 0)
+      range.setEnd(endNode, endNode.nodeValue.length)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>Before</p><blockquote><p>First line</p><p>Second line</p></blockquote><p>After</p>",
+    )
+  })
+
+  test("quote only selected lines across paragraphs with mixed break types", async ({
+    page,
+    editor,
+  }) => {
+    // Line one (Shift+Enter) Line two (Enter) Line three (Shift+Enter) Line four
+    // Selecting "Line two" through "Line three" and applying quote should only
+    // quote those two lines, not all four.
+    await editor.setValue(
+      "<p>Line one<br>Line two</p><p>Line three<br>Line four</p>",
+    )
+
+    // Select from "Line two" in the first <p> through "Line three" in the second <p>
+    await editor.content.evaluate((el) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let startNode, endNode
+      let node
+      while ((node = walker.nextNode())) {
+        if (node.nodeValue.includes("Line two")) startNode = node
+        if (node.nodeValue.includes("Line three")) endNode = node
+      }
+      const range = document.createRange()
+      range.setStart(startNode, 0)
+      range.setEnd(endNode, endNode.nodeValue.length)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>Line one</p><blockquote><p>Line two</p><p>Line three</p></blockquote><p>Line four</p>",
+    )
+  })
+
   test("links", async ({ page, editor }) => {
     await editor.setValue(HELLO_EVERYONE)
     await editor.select("everyone")


### PR DESCRIPTION
## Summary

- When text has a mix of soft breaks (Shift+Enter) and hard paragraph breaks (Enter), selecting only the middle lines and applying quote formatting wrapped ALL lines instead of just the selection.
- `#splitParagraphsAtLineBreaks` used `selection.getNodes()` to determine which soft-break lines were selected. For cross-paragraph selections, Lexical returns all children of partially-selected paragraphs, so every line appeared "selected" and the method skipped splitting entirely.
- Fix by checking selection anchor/focus positions instead of the broad node list to determine which lines actually need splitting out of boundary paragraphs.

[Fizzy card #4687](https://app.fizzy.do/5986089/cards/4687)