### PR TITLE
Fix flaky form system test timeout

### DIFF
--- a/test/system/form_test.rb
+++ b/test/system/form_test.rb
@@ -11,6 +11,7 @@ class FormTest < ApplicationSystemTestCase
 
     click_on "Create Post"
     click_on "Edit this post"
+    wait_for_editor
 
     assert_editor_html "<p>Hello</p><p>there</p>"
   end
@@ -23,6 +24,8 @@ class FormTest < ApplicationSystemTestCase
     find_editor.send "there"
 
     click_on "Update Post"
+    click_on "Edit this post"
+    wait_for_editor
 
     assert_editor_html "<p>Hello</p><p>there</p>"
   end
@@ -37,7 +40,7 @@ class FormTest < ApplicationSystemTestCase
 
     click_on "Create Post"
     click_on "Edit this post"
-
+    wait_for_editor
 
     assert_editor_html "<p>That</p>"
   end


### PR DESCRIPTION
## Summary

- The "edit existing records" test asserted editor HTML right after `click_on "Update Post"`, which redirects to the show page via Turbo Drive. The show page has no `lexxy-editor` element, so `assert_editor_html` raced against Turbo's async navigation -- passing when the assertion ran before the redirect completed, timing out on slower CI runners.
- Fixed by navigating back to the edit page (`click_on "Edit this post"`) before asserting, matching the pattern used by the other form tests.
- Added `wait_for_editor` after all post-navigation editor assertions in `FormTest` to ensure the custom element is fully connected before `flush_lexical_updates` accesses its editor instance.