### PR TITLE
Fix non-previewable attachments rendered as broken images

### DIFF
--- a/src/helpers/string_helper.js
+++ b/src/helpers/string_helper.js
@@ -28,3 +28,10 @@ export function filterMatches(text, potentialMatch) {
 export function upcaseFirst(string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
+
+// Parses a value that may arrive as a boolean or as a string (e.g. from DOM
+// getAttribute) into a proper boolean. Ensures "false" doesn't evaluate as truthy.
+export function parseBoolean(value) {
+  if (typeof value === "string") return value === "true"
+  return Boolean(value)
+}

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -1,8 +1,8 @@
 import Lexxy from "../config/lexxy"
 import { $getEditor, $getNearestRootOrShadowRoot, DecoratorNode, HISTORY_MERGE_TAG } from "lexical"
 import { createAttachmentFigure, createElement, isPreviewableImage } from "../helpers/html_helper"
-import { bytesToHumanSize } from "../helpers/storage_helper"
-import { extractFileName } from "../helpers/storage_helper"
+import { bytesToHumanSize, extractFileName } from "../helpers/storage_helper"
+import { parseBoolean } from "../helpers/string_helper"
 
 
 export class ActionTextAttachmentNode extends DecoratorNode {
@@ -85,7 +85,7 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     this.tagName = tagName || ActionTextAttachmentNode.TAG_NAME
     this.sgid = sgid
     this.src = src
-    this.previewable = previewable
+    this.previewable = parseBoolean(previewable)
     this.altText = altText || ""
     this.caption = caption || ""
     this.contentType = contentType || ""
@@ -189,9 +189,30 @@ export class ActionTextAttachmentNode extends DecoratorNode {
 
   #createDOMForImage(options = {}) {
     const img = createElement("img", { src: this.src, draggable: false, alt: this.altText, ...this.#imageDimensions, ...options })
+
+    if (this.previewable && !this.isPreviewableImage) {
+      img.onerror = () => this.#swapPreviewToFileDOM(img)
+    }
+
     const container = createElement("div", { className: "attachment__container" })
     container.appendChild(img)
     return container
+  }
+
+  #swapPreviewToFileDOM(img) {
+    const figure = img.closest("figure.attachment")
+    if (!figure) return
+
+    figure.className = figure.className.replace("attachment--preview", "attachment--file")
+
+    const container = figure.querySelector(".attachment__container")
+    if (container) container.remove()
+
+    const caption = figure.querySelector("figcaption")
+    if (caption) caption.remove()
+
+    figure.appendChild(this.#createDOMForFile())
+    figure.appendChild(this.#createDOMForNotImage())
   }
 
   get #imageDimensions() {

--- a/test/browser/tests/attachments/non_previewable_attachment.test.js
+++ b/test/browser/tests/attachments/non_previewable_attachment.test.js
@@ -1,0 +1,80 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const pdfAttachment = (attrs = {}) => {
+  const defaults = {
+    sgid: "test-sgid-123",
+    "content-type": "application/pdf",
+    filename: "protected.pdf",
+    filesize: "12345",
+    previewable: "false",
+    url: "http://example.com/protected.pdf",
+  }
+  const merged = { ...defaults, ...attrs }
+  const attrString = Object.entries(merged).map(([k, v]) => `${k}="${v}"`).join(" ")
+  return `<action-text-attachment ${attrString}></action-text-attachment>`
+}
+
+test.describe("Non-previewable attachment", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments-enabled.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("previewable='false' renders as file attachment", async ({ page, editor }) => {
+    await editor.setValue(pdfAttachment({ previewable: "false" }))
+    await editor.flush()
+
+    const figure = page.locator("figure.attachment")
+    await expect(figure).toBeVisible()
+    await expect(figure).toHaveClass(/attachment--file/)
+    await expect(figure.locator("img")).toHaveCount(0)
+    await expect(figure.locator(".attachment__icon")).toBeVisible()
+    await expect(figure.locator(".attachment__name")).toHaveText("protected.pdf")
+  })
+
+  test("broken preview image falls back to file rendering", async ({ page, editor }) => {
+    const brokenUrl = "http://localhost:9999/broken-preview.png"
+
+    await editor.setValue(pdfAttachment({ previewable: "true", url: brokenUrl }))
+    await editor.flush()
+
+    const figure = page.locator("figure.attachment")
+    await expect(figure).toBeVisible()
+
+    // After onerror fires, the figure should swap to file rendering
+    await expect(figure).toHaveClass(/attachment--file/, { timeout: 5000 })
+    await expect(figure.locator("img")).toHaveCount(0)
+    await expect(figure.locator(".attachment__icon")).toBeVisible()
+    await expect(figure.locator(".attachment__name")).toHaveText("protected.pdf")
+  })
+
+  test("exportDOM preserves previewable='true' after visual fallback", async ({ page, editor }) => {
+    const brokenUrl = "http://localhost:9999/broken-preview.png"
+
+    await editor.setValue(pdfAttachment({ previewable: "true", url: brokenUrl }))
+    await editor.flush()
+
+    // Wait for fallback to complete
+    const figure = page.locator("figure.attachment")
+    await expect(figure).toHaveClass(/attachment--file/, { timeout: 5000 })
+
+    // The serialized output should still have previewable="true"
+    const value = await editor.value()
+    expect(value).toContain('previewable="true"')
+    expect(value).toContain('sgid="test-sgid-123"')
+    expect(value).toContain('filename="protected.pdf"')
+  })
+
+  test("serializes correctly in editor value", async ({ editor }) => {
+    await editor.setValue(pdfAttachment({ previewable: "false" }))
+    await editor.flush()
+
+    const value = await editor.value()
+    expect(value).toContain("action-text-attachment")
+    expect(value).toContain('sgid="test-sgid-123"')
+    expect(value).toContain('filename="protected.pdf"')
+    // previewable="false" should not be serialized (it's falsy)
+    expect(value).not.toContain("previewable")
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `parsePreviewable()` to normalize the string `"false"` from DOM `getAttribute` to boolean `false`, so `previewable="false"` attachments render as files instead of broken preview images.
- Adds an `onerror` fallback on `<img>` for non-image previewable attachments (e.g. password-protected PDFs). When the representation URL fails (500 from Active Storage), the DOM swaps from broken-image preview to file rendering (icon + filename). The node's `previewable` property stays `true` so `exportDOM` preserves it for the server.

[Fizzy card #3853](https://app.fizzy.do/5986089/cards/3853)