### PR TITLE
Fix XSS via unsanitized action-text-attachment content attribute

### DIFF
--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -4,3 +4,11 @@ import { buildConfig } from "../config/dom_purify"
 export function sanitize(html) {
   return DOMPurify.sanitize(html, buildConfig())
 }
+
+// Sanitize HTML for custom attachment content (mentions, cards, etc.).
+// Uses DOMPurify defaults to strip XSS vectors (scripts, event handlers)
+// while preserving the richer tag set that server-rendered attachment
+// content legitimately uses (e.g. <span>, <div>, <img>).
+export function sanitizeAttachmentContent(html) {
+  return DOMPurify.sanitize(html)
+}

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -2,6 +2,7 @@ import Lexxy from "../config/lexxy"
 import { $createTextNode, DecoratorNode } from "lexical"
 
 import { createElement, extractPlainTextFromHtml } from "../helpers/html_helper"
+import { sanitizeAttachmentContent } from "../helpers/sanitization_helper"
 import { parseAttachmentContent } from "../helpers/storage_helper"
 
 export class CustomActionTextAttachmentNode extends DecoratorNode {
@@ -74,7 +75,7 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
   createDOM() {
     const figure = createElement(this.tagName, { "content-type": this.contentType, "data-lexxy-decorator": true })
 
-    figure.insertAdjacentHTML("beforeend", this.innerHtml)
+    figure.insertAdjacentHTML("beforeend", sanitizeAttachmentContent(this.innerHtml))
 
     const deleteButton = createElement("lexxy-node-delete-button")
     figure.appendChild(deleteButton)

--- a/test/browser/tests/paste/xss_sanitization.test.js
+++ b/test/browser/tests/paste/xss_sanitization.test.js
@@ -1,0 +1,112 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+test.describe("Paste — XSS sanitization via action-text-attachment content", () => {
+  test("sanitizes onerror XSS payload in content attribute", async ({ page, editor }) => {
+    await page.goto("/mentions.html")
+    await editor.waitForConnected()
+
+    // Listen for any dialog (alert) triggered by XSS
+    let dialogTriggered = false
+    page.on("dialog", async (dialog) => {
+      dialogTriggered = true
+      await dialog.dismiss()
+    })
+
+    const xssPayload = [
+      '<action-text-attachment',
+      ' content-type="text/html"',
+      ' content="&quot;&lt;img src=x onerror=alert(document.domain)&gt;&quot;"',
+      '>',
+      '</action-text-attachment>'
+    ].join("")
+
+    await editor.paste("", { html: xssPayload })
+    await editor.flush()
+    await page.waitForTimeout(1000)
+
+    // The XSS alert should not have fired
+    expect(dialogTriggered).toBe(false)
+
+    // The malicious img with onerror should not be present in the DOM
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("img[onerror]")).toHaveCount(0)
+    })
+  })
+
+  test("sanitizes meta refresh HTML injection in content attribute", async ({ page, editor }) => {
+    await page.goto("/mentions.html")
+    await editor.waitForConnected()
+
+    const metaPayload = [
+      '<action-text-attachment',
+      ' content-type="text/html"',
+      " content=\"&quot;&lt;meta http-equiv='refresh' content='1; http://evil.com'&gt;&quot;\"",
+      '>',
+      '</action-text-attachment>'
+    ].join("")
+
+    await editor.paste("", { html: metaPayload })
+    await editor.flush()
+    await page.waitForTimeout(500)
+
+    // The meta tag should be stripped by sanitization
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("meta")).toHaveCount(0)
+    })
+  })
+
+  test("sanitizes script tag in content attribute", async ({ page, editor }) => {
+    await page.goto("/mentions.html")
+    await editor.waitForConnected()
+
+    let dialogTriggered = false
+    page.on("dialog", async (dialog) => {
+      dialogTriggered = true
+      await dialog.dismiss()
+    })
+
+    const scriptPayload = [
+      '<action-text-attachment',
+      ' content-type="text/html"',
+      ' content="&lt;script&gt;alert(1)&lt;/script&gt;"',
+      '>',
+      '</action-text-attachment>'
+    ].join("")
+
+    await editor.paste("", { html: scriptPayload })
+    await editor.flush()
+    await page.waitForTimeout(1000)
+
+    expect(dialogTriggered).toBe(false)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("script")).toHaveCount(0)
+    })
+  })
+
+  test("preserves legitimate mention content through sanitization", async ({ page, editor }) => {
+    await page.goto("/mentions.html")
+    await editor.waitForConnected()
+
+    // A legitimate mention should still work after the fix
+    const mentionHtml = [
+      '<action-text-attachment',
+      ' sgid="test-sgid-lexxy"',
+      ' content-type="application/vnd.actiontext.mention"',
+      ' content="&lt;span class=&quot;person person--inline&quot;&gt;&lt;span class=&quot;person--name&quot;&gt;Michael Berger&lt;/span&gt;&lt;/span&gt;"',
+      '>',
+      '<span class="person person--inline"><span class="person--name">Michael Berger</span></span>',
+      '</action-text-attachment>'
+    ].join("")
+
+    await editor.paste("Michael Berger", { html: mentionHtml })
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("action-text-attachment")).toHaveCount(1)
+      await expect(content.locator("action-text-attachment .person--name")).toHaveText("Michael Berger")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Security fix**: `CustomActionTextAttachmentNode.createDOM()` inserted `innerHtml` extracted from the `content` attribute directly into the DOM via `insertAdjacentHTML` without sanitization. Because DOMPurify treats `content` as a harmless string attribute during paste, malicious HTML (e.g. `<img onerror=alert(...)>`, `<script>`, `<meta http-equiv=refresh>`) survived the initial paste sanitization and was injected into the live DOM when the node rendered.
- Sanitize `innerHtml` with `DOMPurify.sanitize()` before inserting it into the DOM. Uses DOMPurify's defaults (not the editor's restrictive tag allowlist) so legitimate attachment content (mentions with `<span>`, cards, etc.) is preserved while XSS vectors are stripped.
- Adds Playwright regression tests covering XSS via `onerror`, `<script>` injection, `<meta http-equiv=refresh>` injection, and verifying legitimate mention content still renders correctly.

[Fizzy card #5072](https://app.fizzy.do/5986089/cards/5072) | [Fizzy card #5073](https://app.fizzy.do/5986089/cards/5073)