### PR TITLE
Add regression tests for pasting into blockquotes

### DIFF
--- a/test/browser/tests/paste/paste.test.js
+++ b/test/browser/tests/paste/paste.test.js
@@ -109,6 +109,81 @@ test.describe("Paste — Files & Attachments", () => {
   })
 })
 
+test.describe("Paste — Blockquote", () => {
+  test("pasting plain text with newlines into an empty blockquote keeps all lines inside the quote", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    // Reproduce the exact user flow from the bug report:
+    // 1. Click Quote button to enter blockquote mode
+    // 2. Paste plain text with newlines (console output)
+    await editor.click()
+    await page.getByRole("button", { name: "Quote" }).click()
+    await editor.flush()
+
+    await editor.paste("this \nis\nwhat\n\nI am pasting")
+    await editor.flush()
+
+    // ALL pasted text must remain inside the blockquote — nothing should
+    // escape to a paragraph outside the quote.
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toHaveCount(1)
+      const outerParagraphs = content.locator(":scope > p")
+      await expect(outerParagraphs).toHaveCount(0)
+    })
+  })
+
+  test("pasting HTML with multiple paragraphs into a blockquote keeps all inside", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    await editor.click()
+    await page.getByRole("button", { name: "Quote" }).click()
+    await editor.flush()
+
+    // Paste HTML with paragraph-level structure (common when copying from web pages)
+    await editor.paste("line one\nline two\nline three", {
+      html: "<p>line one</p><p>line two</p><p>line three</p>",
+    })
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toHaveCount(1)
+      const outerParagraphs = content.locator(":scope > p")
+      await expect(outerParagraphs).toHaveCount(0)
+    })
+  })
+
+  test("pasting plain text into blockquote with existing content keeps all inside", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    // Set up a blockquote with existing text
+    await editor.setValue("<blockquote><p>Already quoted</p></blockquote>")
+    await editor.focus()
+    await editor.send("End")
+    await editor.flush()
+
+    await editor.paste("this \nis\nwhat\n\nI am pasting")
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toHaveCount(1)
+      const outerParagraphs = content.locator(":scope > p")
+      await expect(outerParagraphs).toHaveCount(0)
+    })
+  })
+})
+
 const modifier = process.platform === "darwin" ? "Meta" : "Control"
 
 test.describe("Paste — Cut and paste", () => {


### PR DESCRIPTION
## Summary

- The blockquote paste bug (#4979) — where pasting text with line breaks caused content to escape the blockquote — was fixed in PR #839, then accidentally reverted during the contents refactoring in the toolbar rework (PR #891, commit `9b2af073`).
- The toolbar rework coincidentally fixed the bug as a side effect by changing how `toggleBlockquote` structures the blockquote: it now always wraps content in `<p>` elements inside the `<blockquote>`, so Lexical's `selection.insertNodes()` inserts pasted nodes into the paragraph (which stays inside the blockquote) rather than splitting them out.
- The original PR #839 tests were also removed during the refactoring, so there were no regression tests preventing the bug from coming back.
- This PR adds three Playwright regression tests covering the key paste-into-blockquote scenarios: plain text with newlines, rich HTML with paragraph breaks, and plain text into a blockquote with existing content.

[Fizzy card #4979](https://app.fizzy.do/5986089/cards/4979)