### PR TITLE
Fix multi-line code block toggle creating separate blocks per line

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -79,25 +79,19 @@ export default class Contents {
     $setBlocksType(selection, () => $createHeadingNode(tag))
   }
 
-  #applyCodeBlockFormat() {
-    const selection = $getSelection()
-    if (!$isRangeSelection(selection)) return
-
-    $setBlocksType(selection, () => $createCodeNode("plain"))
-  }
-
   toggleCodeBlock() {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
     if (this.#insertNodeIfRoot($createCodeNode("plain"))) return
 
-    const topLevelElement = selection.anchor.getNode().getTopLevelElementOrThrow()
+    const topLevelElements = this.#topLevelElementsInSelection(selection)
+    const allCode = topLevelElements.length > 0 && topLevelElements.every($isCodeNode)
 
-    if (topLevelElement && !$isCodeNode(topLevelElement)) {
-      this.#applyCodeBlockFormat()
+    if (allCode) {
+      topLevelElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
-      this.applyParagraphFormat()
+      this.#applyCodeBlockFormat(topLevelElements)
     }
   }
 
@@ -297,6 +291,60 @@ export default class Contents {
     }
 
     return false
+  }
+
+  #applyCodeBlockFormat(topLevelElements) {
+    if (topLevelElements.length === 0) return
+
+    const codeNode = $createCodeNode("plain")
+    topLevelElements[0].insertBefore(codeNode)
+
+    topLevelElements.forEach((element, index) => {
+      if (index > 0) codeNode.append($createLineBreakNode())
+
+      const children = element.getChildren()
+      if (children.length === 0) {
+        codeNode.append($createTextNode(""))
+      } else {
+        children.forEach(child => {
+          if ($isTextNode(child)) {
+            codeNode.append($createTextNode(child.getTextContent()))
+          } else if ($isLineBreakNode(child)) {
+            codeNode.append($createLineBreakNode())
+          } else {
+            codeNode.append($createTextNode(child.getTextContent()))
+          }
+        })
+      }
+
+      element.remove()
+    })
+
+    codeNode.selectEnd()
+  }
+
+  #unwrapCodeBlock(codeNode) {
+    const children = codeNode.getChildren()
+    const groups = [ [] ]
+
+    for (const child of children) {
+      if ($isLineBreakNode(child)) {
+        groups.push([])
+      } else {
+        groups[groups.length - 1].push(child.getTextContent())
+      }
+    }
+
+    for (const group of groups) {
+      const paragraph = $createParagraphNode()
+      const text = group.join("")
+      if (text) {
+        paragraph.append($createTextNode(text))
+      }
+      codeNode.insertBefore(paragraph)
+    }
+
+    codeNode.remove()
   }
 
   #splitParagraphsAtLineBreaks(selection) {

--- a/test/browser/tests/formatting/inline_formatting.test.js
+++ b/test/browser/tests/formatting/inline_formatting.test.js
@@ -175,4 +175,44 @@ test.describe("Inline formatting", () => {
     await page.getByRole("button", { name: "Code" }).click()
     await assertEditorHtml(editor, "<p>Hello everyone</p>")
   })
+
+  test("selecting multiple lines and toggling code block creates a single code block", async ({ page, editor }) => {
+    await editor.send("Line one")
+    await editor.send("Enter")
+    await editor.send("Line two")
+    await editor.send("Enter")
+    await editor.send("Line three")
+
+    await editor.selectAll()
+    await page.getByRole("button", { name: "Code" }).click()
+
+    await assertEditorHtml(
+      editor,
+      '<pre data-language="plain" data-highlight-language="plain">Line one<br>Line two<br>Line three</pre>',
+    )
+  })
+
+  test("toggling off a multi-line code block restores separate paragraphs", async ({ page, editor }) => {
+    await editor.send("Line one")
+    await editor.send("Enter")
+    await editor.send("Line two")
+    await editor.send("Enter")
+    await editor.send("Line three")
+
+    await editor.selectAll()
+    await page.getByRole("button", { name: "Code" }).click()
+
+    await assertEditorHtml(
+      editor,
+      '<pre data-language="plain" data-highlight-language="plain">Line one<br>Line two<br>Line three</pre>',
+    )
+
+    await editor.selectAll()
+    await page.getByRole("button", { name: "Code" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>Line one</p><p>Line two</p><p>Line three</p>",
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- Selecting multiple lines and pressing the Code block button was creating one code block per line instead of a single code block containing all the selected lines.
- Rewrote `toggleCodeBlock()` to collect all top-level elements in the selection and merge them into a single `CodeNode` separated by line breaks, mirroring how `toggleBlockquote()` already handles multi-line selection.
- Toggle-off correctly splits the code block content at line breaks back into separate paragraphs.

[Fizzy card #5029](https://app.fizzy.do/5986089/cards/5029)