### PR TITLE
Add support for ActionText::EncryptedRichText

### DIFF
--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -24,7 +24,14 @@ module Lexxy
       # Temporary: we need to *adaptarize* action text
       def render_custom_attachments_in(value)
         if value.respond_to?(:body)
-          if html = value.body_before_type_cast.presence
+          encrypted_rich_text = defined?(ActionText::EncryptedRichText) && value.is_a?(ActionText::EncryptedRichText)
+          html = if encrypted_rich_text
+                   value.body&.to_html.presence
+          else
+                   value.body_before_type_cast.presence
+          end
+
+          if html
             self.prefix_partial_path_with_controller_namespace = false if respond_to?(:prefix_partial_path_with_controller_namespace=)
             ActionText::Fragment.wrap(html).replace(ActionText::Attachment.tag_name) do |node|
               if node["url"].blank?

--- a/test/dummy/app/models/note.rb
+++ b/test/dummy/app/models/note.rb
@@ -1,0 +1,3 @@
+class Note < ApplicationRecord
+  has_rich_text :body, encrypted: true
+end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -27,5 +27,11 @@ module Dummy
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.hosts = []
+
+    if Rails.env.test?
+      config.active_record.encryption.primary_key = "test-deterministic-key-32-bytes!"
+      config.active_record.encryption.deterministic_key = "test-deterministic-key-32-bytes!"
+      config.active_record.encryption.key_derivation_salt = "test-salt"
+    end
   end
 end

--- a/test/dummy/db/migrate/20250517040252_create_action_text_tables.action_text.rb
+++ b/test/dummy/db/migrate/20250517040252_create_action_text_tables.action_text.rb
@@ -13,6 +13,16 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
 
       t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
     end
+
+
+    create_table :action_text_encrypted_rich_texts, id: primary_key_type do |t|
+      t.text :body, size: :long
+      t.string :name, null: false
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.string :locale
+      t.timestamps
+      t.index [ "record_type", "record_id", "name", "locale" ], name: "index_action_text_encrypted_rich_texts_uniqueness", unique: true
+    end
   end
 
   private

--- a/test/dummy/db/migrate/20260320195843_create_notes.rb
+++ b/test/dummy/db/migrate/20260320195843_create_notes.rb
@@ -1,0 +1,9 @@
+class CreateNotes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notes do |t|
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_09_03_124207) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_20_195843) do
+  create_table "action_text_encrypted_rich_texts" do |t|
+    t.text "body"
+    t.datetime "created_at", precision: nil, null: false
+    t.string "locale"
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index [ "record_type", "record_id", "name", "locale" ], name: "index_action_text_encrypted_rich_texts_uniqueness", unique: true
+  end
+
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -47,6 +58,12 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_03_124207) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index [ "blob_id", "variation_digest" ], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "notes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
   end
 
   create_table "people", force: :cascade do |t|

--- a/test/dummy/test/fixtures/notes.yml
+++ b/test/dummy/test/fixtures/notes.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+
+two:
+  title: MyString

--- a/test/fixtures/notes.yml
+++ b/test/fixtures/notes.yml
@@ -1,0 +1,5 @@
+basic:
+  title: "A note without rich text record"
+
+secret_note:
+  title: "Hello World"

--- a/test/helpers/lexxy/tag_helper_test.rb
+++ b/test/helpers/lexxy/tag_helper_test.rb
@@ -40,4 +40,22 @@ class Lexxy::TagHelperTest < ActionView::TestCase
       assert_not_includes value, "<div>"
     end
   end
+
+  test "#lexxy_rich_textarea_tag renders persisted encrypted rich text content" do
+    note = Note.create!(title: "Hello World")
+    note.body = "<p>This is encrypted contents</p>"
+    note.save!
+    note.reload
+
+    render inline: <<~ERB, locals: { note: note }
+      <%= lexxy_rich_textarea_tag :body, note.body %>
+    ERB
+
+    assert_dom "lexxy-editor", count: 1 do |lexxy_editor, *|
+      value = lexxy_editor["value"]
+      decrypted_html = note.body.to_s
+
+      assert_includes decrypted_html, value
+    end
+  end
 end


### PR DESCRIPTION
**Summary**

Enable usage of ActionText::EncryptedRichText with lexxy. This came up migrating an application I use with encrypted action text content. Its content was displaying only the encrypted values rather than the raw values.

Changed:
* Added support for ActionText::EncryptedRichText
* Add note model with `has_rich_text :body, encrypted: true`
* Added test to confirm the encryption/decryption of the values