### PR TITLE
Fix @mentions menu rendering out of bounds near right edge

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -1010,6 +1010,7 @@
   &[data-clipped-at-right] {
     inset-inline-start: unset;
     inset-inline-end: 1ch;
+    max-inline-size: calc(100% - 1ch);
   }
 
   &[data-clipped-at-bottom] {

--- a/test/browser/tests/prompts/mentions.test.js
+++ b/test/browser/tests/prompts/mentions.test.js
@@ -81,4 +81,24 @@ test.describe("Mentions", () => {
     expect(positions.textTop).toBeLessThan(positions.mentionBottom)
     expect(positions.textBottom).toBeGreaterThan(positions.mentionTop)
   })
+
+  test("popover stays within viewport when triggered near right edge", async ({ page, editor }) => {
+    await page.setViewportSize({ width: 400, height: 600 })
+    await editor.locator.evaluate((el) => {
+      el.style.width = "150px"
+      el.style.marginLeft = "auto"
+    })
+
+    await editor.send("Some text @")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const rect = await popover.evaluate((el) => {
+      const r = el.getBoundingClientRect()
+      return { left: r.left, right: r.right }
+    })
+    expect(rect.right).toBeLessThanOrEqual(400)
+    expect(rect.left).toBeGreaterThanOrEqual(0)
+  })
 })


### PR DESCRIPTION
## Summary
- Fixed @mentions popover overflowing viewport when triggered near the right edge of the screen
- When right-aligned (`data-clipped-at-right`), constrain `max-inline-size` to `calc(100% - 1ch)` so the popover stays within the editor

Fixes [Fizzy card #3899](https://app.fizzy.do/5986089/cards/3899): @mentions menu can render out of bounds