### PR TITLE
Prevent Safari Live Text selection on attachment images

### DIFF
--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -338,6 +338,7 @@
       display: block;
       margin-inline: auto;
       max-inline-size: 100%;
+      -webkit-user-select: none;
       user-select: none;
     }
 

--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -103,7 +103,7 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
   }
 
   #createDOMForImage() {
-    return createElement("img")
+    return createElement("img", { draggable: "false" })
   }
 
   #createDOMForFile() {


### PR DESCRIPTION
## Summary

- Adds `draggable="false"` to the upload node's preview `<img>` element (the permanent attachment node already has this)
- Adds `-webkit-user-select: none` prefix to `.attachment--preview img, video` for Safari consistency

Safari's Live Text feature recognizes text within images and makes it selectable. After dragging an attachment image in the editor, subsequent interactions can trigger this recognition, highlighting text inside the image unexpectedly.

Fizzy card: https://app.fizzy.do/5986089/cards/5121

## Test plan

- [ ] Drop an image containing text into a Lexxy editor in Safari
- [ ] Drag the image, then drag over it again
- [ ] Verify text in the image is not selected/highlighted
- [ ] Verify normal image drag-and-drop upload still works
- [ ] Verify image captions remain editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)