### PR TITLE
Toolbar configuration

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -441,13 +441,6 @@
     display: none;
   }
 
-  &[data-upload="file"] button[name="image"] {
-    display: none;
-  }
-
-  &[data-upload="image"] button[name="file"] {
-    display: none;
-  }
 
   .lexxy-editor__toolbar-button {
     aspect-ratio: 1;
@@ -600,10 +593,8 @@
       }
     }
 
-    .separator {
-      background: var(--lexxy-color-ink-lighter);
-      block-size: 1px;
-      inline-size: 100%;
+    .lexxy-editor__toolbar-group-end {
+      border-block-end: 1px solid var(--lexxy-color-ink-lighter);
     }
   }
 

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -441,7 +441,6 @@
     display: none;
   }
 
-
   .lexxy-editor__toolbar-button {
     aspect-ratio: 1;
     block-size: var(--lexxy-toolbar-button-size);
@@ -565,7 +564,7 @@
   .lexxy-editor__toolbar-dropdown-list {
     border-start-start-radius: 0;
     flex-direction: column;
-    gap: 0.1ch;
+    gap: var(--lexxy-toolbar-gap);
     padding: 0.1ch;
 
     button {
@@ -574,6 +573,7 @@
       flex-direction: row;
       gap: 1ch;
       padding: 1ch;
+      position: relative;
 
       &[aria-pressed="true"] {
         background-color: var(--lexxy-color-selected);
@@ -594,7 +594,47 @@
     }
 
     .lexxy-editor__toolbar-group-end {
-      border-block-end: 1px solid var(--lexxy-color-ink-lighter);
+      margin-block-end: var(--lexxy-toolbar-gap);
+
+      &:after {
+        background: var(--lexxy-color-ink-lighter);
+        block-size: 1px;
+        content: "";
+        display: block;
+        inset-inline: 0.5ch;
+        inset-block-end: calc(var(--lexxy-toolbar-gap) * -2);
+        pointer-events: none;
+        position: absolute;
+      }
+
+      & + * {
+        margin: 0;
+        margin-block-start: calc(var(--lexxy-toolbar-gap) + 1px);
+      }
+    }
+
+    [overflowing] & {
+      flex-direction: row;
+
+      button span { display: none; }
+
+      .lexxy-editor__toolbar-group-end {
+        margin: 0;
+        margin-inline-end: var(--lexxy-toolbar-gap);
+
+        &:after {
+          block-size: auto;
+          inline-size: 1px;
+          inset-block: 0.5ch;
+          inset-inline-start: auto;
+          inset-inline-end: calc(var(--lexxy-toolbar-gap) * -2);
+        }
+
+        & + * {
+          margin: 0;
+          margin-inline-start: calc(var(--lexxy-toolbar-gap) + 1px);
+        }
+      }
     }
   }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,8 @@ Lexxy.configure({
 
 Editors support the following options, configurable using presets and element attributes:
 
-- `toolbar`: Pass `false` to disable the toolbar entirely, pass the ID of a `<lexxy-toolbar>` element to use as an external toolbar, or pass an object to configure individual toolbar buttons. By default, the toolbar is bootstrapped and displayed above the editor.
-  - `toolbar.upload`: Control which upload button(s) appear in the toolbar. Accepts `"file"`, `"image"`, or `"both"` (default). The image button restricts the file picker to images and videos (`accept="image/*,video/*"`), which triggers the native photo/video picker on iOS and Android. The file button opens an unrestricted file picker.
+- `toolbar`: Pass `false` to disable the toolbar entirely, pass the ID of a `<lexxy-toolbar>` element to use as an external toolbar, or pass an object to configure the toolbar layout. By default, the toolbar is bootstrapped and displayed above the editor. See [Toolbar Customization](toolbar.md) for full details.
+  - `toolbar.items`: An array that controls which items appear in the toolbar and in what order. See [Toolbar Customization](toolbar.md).
 - `attachments`: Pass `false` to disable attachments completely. By default, attachments are supported, including paste and drag & drop support.
 - `markdown`: Pass `false` to disable Markdown support.
 - `multiLine`: Pass `false` to force single line editing.

--- a/docs/toolbar.md
+++ b/docs/toolbar.md
@@ -1,0 +1,173 @@
+---
+title: Toolbar
+layout: default
+parent: Configuration
+nav_order: 2
+---
+
+# Toolbar Customization
+
+The toolbar layout is fully configurable through the `toolbar.items` array. Each entry defines a button, dropdown group, separator, or spacer.
+
+## Item types
+
+| Entry | Description |
+|-------|-------------|
+| `"bold"` | A button name from the built-in registry (see below) |
+| `{ name, icon, label, items }` | A dropdown group containing child items |
+| `"|"` | A visual group separator — adds a border after the preceding item |
+| `"~"` | A flexible spacer — pushes subsequent items to the right edge |
+
+## Default items
+
+This is the default toolbar configuration:
+
+```js
+toolbar: {
+  items: [
+    "image",
+    "file",
+    "|",
+    "bold",
+    "italic",
+    { name: "format", icon: "heading", label: "Text formatting", items: [
+        "paragraph",
+        "heading-large",
+        "heading-medium",
+        "heading-small",
+        "|",
+        "strikethrough",
+        "underline",
+      ]
+    },
+    { name: "lists", icon: "ul", label: "Lists", items: [
+        "unordered-list",
+        "ordered-list",
+      ]
+    },
+    "highlight",
+    "link",
+    "quote",
+    "code",
+    "|",
+    "table",
+    "divider",
+    "~",
+    "undo",
+    "redo",
+  ]
+}
+```
+
+## Available items
+
+| Name | Icon | Description |
+|------|------|-------------|
+| `image` | image | Upload images |
+| `file` | attachment | Upload files |
+| `bold` | bold | Bold formatting |
+| `italic` | italic | Italic formatting |
+| `paragraph` | paragraph | Normal text (typically inside a format dropdown) |
+| `heading-large` | h2 | Large heading |
+| `heading-medium` | h3 | Medium heading |
+| `heading-small` | h4 | Small heading |
+| `strikethrough` | strikethrough | Strikethrough text |
+| `underline` | underline | Underline text |
+| `unordered-list` | ul | Bullet list |
+| `ordered-list` | ol | Numbered list |
+| `highlight` | highlight | Color highlight picker |
+| `link` | link | Insert/edit link |
+| `quote` | quote | Block quote |
+| `code` | code | Code block |
+| `table` | table | Insert table |
+| `divider` | hr | Horizontal divider |
+| `undo` | undo | Undo |
+| `redo` | redo | Redo |
+
+## Examples
+
+### Minimal toolbar
+
+```js
+Lexxy.configure({
+  compact: {
+    toolbar: {
+      items: ["bold", "italic", "link", "|", "undo", "redo"]
+    }
+  }
+})
+```
+
+```html
+<lexxy-editor preset="compact"></lexxy-editor>
+```
+
+### Without attachments
+
+Omit `image` and `file` to remove upload buttons:
+
+```js
+toolbar: {
+  items: [
+    "bold",
+    "italic",
+    { name: "format", icon: "heading", label: "Text formatting", items: [
+        "paragraph", "heading-large", "heading-medium", "heading-small",
+        "|", "strikethrough", "underline",
+      ]
+    },
+    "link",
+    "quote",
+    "code",
+    "~",
+    "undo",
+    "redo",
+  ]
+}
+```
+
+### Custom dropdown groups
+
+Create your own dropdown groupings:
+
+```js
+toolbar: {
+  items: [
+    "bold",
+    "italic",
+    { name: "insert", icon: "table", label: "Insert", items: [
+        "table",
+        "divider",
+        "code",
+        "quote",
+      ]
+    },
+    "link",
+    "~",
+    "undo",
+    "redo",
+  ]
+}
+```
+
+### Per-editor override
+
+Override the toolbar for a specific editor using the HTML attribute:
+
+```html
+<lexxy-editor toolbar='{"items":["bold","italic","link"]}'></lexxy-editor>
+```
+
+### Disabling the toolbar
+
+Pass `false` to hide the toolbar entirely:
+
+```html
+<lexxy-editor toolbar="false"></lexxy-editor>
+```
+
+## Separators and spacers
+
+Use `"|"` between items to create visual groups. The separator renders as a thin vertical line (top-level) or a horizontal line (inside dropdowns).
+
+Use `"~"` to insert a flexible spacer that pushes all following items to the right edge of the toolbar. This is typically used before undo/redo.

--- a/src/config/lexxy.js
+++ b/src/config/lexxy.js
@@ -15,7 +15,38 @@ const presets = new Configuration({
     multiLine: true,
     richText: true,
     toolbar: {
-      upload: "both"
+      items: [
+        "image",
+        "file",
+        "|",
+        "bold",
+        "italic",
+        { name: "format", icon: "heading", label: "Text formatting", items: [
+            "paragraph",
+            "heading-large",
+            "heading-medium",
+            "heading-small",
+            "|",
+            "strikethrough",
+            "underline",
+          ]
+        },
+        { name: "lists", icon: "ul", label: "Lists", items: [
+            "unordered-list",
+            "ordered-list",
+          ]
+        },
+        "highlight",
+        "link",
+        "quote",
+        "code",
+        "|",
+        "table",
+        "divider",
+        "~",
+        "undo",
+        "redo",
+      ]
     },
     highlight: {
       buttons: {

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -1,5 +1,7 @@
 import { $getSelection, $isRangeSelection } from "lexical"
 import { $getSelectionStyleValueForProperty } from "@lexical/selection"
+import { createElement } from "../../helpers/html_helper"
+import ToolbarIcons from "../toolbar_icons"
 import { ToolbarDropdown } from "../toolbar_dropdown"
 
 const APPLY_HIGHLIGHT_SELECTOR = "button.lexxy-highlight-button"
@@ -11,6 +13,31 @@ const REMOVE_HIGHLIGHT_SELECTOR = "[data-command='removeHighlight']"
 const NO_STYLE = Symbol("no_style")
 
 export class HighlightDropdown extends ToolbarDropdown {
+  static buildToolbarElement(name, entry) {
+    const details = createElement("details", {
+      className: "lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron",
+      name: "lexxy-dropdown"
+    })
+
+    details.appendChild(createElement("summary", {
+      className: "lexxy-editor__toolbar-button",
+      name,
+      title: entry.title
+    }, ToolbarIcons[entry.icon]))
+
+    const dropdown = createElement("lexxy-highlight-dropdown", {
+      className: "lexxy-editor__toolbar-dropdown-content"
+    })
+    dropdown.appendChild(createElement("div", { className: "lexxy-highlight-colors" }))
+    dropdown.appendChild(createElement("button", {
+      className: "lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset",
+      "data-command": "removeHighlight"
+    }, "Remove all coloring"))
+
+    details.appendChild(dropdown)
+    return details
+  }
+
   connectedCallback() {
     super.connectedCallback()
     this.#registerToggleHandler()

--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -1,8 +1,53 @@
 import { $getSelection, $isRangeSelection } from "lexical"
 import { $isLinkNode } from "@lexical/link"
+import { createElement } from "../../helpers/html_helper"
+import ToolbarIcons from "../toolbar_icons"
 import { ToolbarDropdown } from "../toolbar_dropdown"
 
 export class LinkDropdown extends ToolbarDropdown {
+  static buildToolbarElement(name, entry) {
+    const details = createElement("details", {
+      className: "lexxy-editor__toolbar-dropdown",
+      name: "lexxy-dropdown"
+    })
+
+    const summaryProps = {
+      className: "lexxy-editor__toolbar-button",
+      name,
+      title: entry.title
+    }
+    if (entry.hotkey) summaryProps["data-hotkey"] = entry.hotkey
+    details.appendChild(createElement("summary", summaryProps, ToolbarIcons[entry.icon]))
+
+    const dropdown = createElement("lexxy-link-dropdown", {
+      className: "lexxy-editor__toolbar-dropdown-content"
+    })
+
+    const form = createElement("form", { method: "dialog" })
+    form.appendChild(createElement("input", {
+      type: "url",
+      placeholder: "Enter a URL\u2026",
+      className: "input"
+    }))
+
+    const actions = createElement("div", { className: "lexxy-editor__toolbar-dropdown-actions" })
+    actions.appendChild(createElement("button", {
+      type: "submit",
+      className: "lexxy-editor__toolbar-button",
+      value: "link"
+    }, "Link"))
+    actions.appendChild(createElement("button", {
+      type: "button",
+      className: "lexxy-editor__toolbar-button",
+      value: "unlink"
+    }, "Unlink"))
+
+    form.appendChild(actions)
+    dropdown.appendChild(form)
+    details.appendChild(dropdown)
+    return details
+  }
+
   connectedCallback() {
     super.connectedCallback()
     this.input = this.querySelector("input")

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -494,10 +494,10 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #createDefaultToolbar() {
+    const items = this.config.get("toolbar.items")
     const toolbar = createElement("lexxy-toolbar")
-    toolbar.innerHTML = LexicalToolbar.defaultTemplate
+    toolbar.innerHTML = LexicalToolbar.buildTemplate(items)
     toolbar.setAttribute("data-attachments", this.supportsAttachments) // Drives toolbar CSS styles
-    toolbar.configure(this.config.get("toolbar"))
     this.prepend(toolbar)
     return toolbar
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -496,7 +496,7 @@ export class LexicalEditorElement extends HTMLElement {
   #createDefaultToolbar() {
     const items = this.config.get("toolbar.items")
     const toolbar = createElement("lexxy-toolbar")
-    toolbar.innerHTML = LexicalToolbar.buildTemplate(items)
+    toolbar.appendChild(LexicalToolbar.buildTemplate(items))
     toolbar.setAttribute("data-attachments", this.supportsAttachments) // Drives toolbar CSS styles
     this.prepend(toolbar)
     return toolbar


### PR DESCRIPTION
## Configurable toolbar items

Introduces `toolbar.items` — a declarative array that controls which buttons, dropdowns, separators, and spacers appear in the toolbar and in what order.

### Changes

- **`src/config/lexxy.js`** — Replace `toolbar.upload` with `toolbar.items` array in the default preset. The default items reproduce the existing toolbar layout exactly.
- **`src/elements/toolbar.js`** — Add `static registry` (maps item names to icon/command/title metadata) and `buildTemplate(items)` which builds a `DocumentFragment` using `createElement`. Replaces the hardcoded `defaultTemplate` HTML string.
- **`src/elements/editor.js`** — `#createDefaultToolbar()` reads `toolbar.items` from config, calls `buildTemplate()`, and appends the fragment. Removes the `toolbar.configure()` call.
- **`src/elements/dropdown/highlight.js`** — Add `static buildToolbarElement()` that owns the highlight dropdown's DOM construction.
- **`src/elements/dropdown/link.js`** — Add `static buildToolbarElement()` that owns the link dropdown's DOM construction.
- **`app/assets/stylesheets/lexxy-editor.css`** — Remove `data-upload` CSS rules. Unify dropdown separators under `lexxy-editor__toolbar-group-end`.
- **`docs/toolbar.md`** (new) — Dedicated toolbar customization page.
- **`docs/configuration.md`** — Replace `toolbar.upload` docs with `toolbar.items` reference.

### How it works

Each entry in the `items` array is one of:
- A **string** — button name from the registry (e.g. `"bold"`, `"image"`, `"highlight"`)
- An **object** — dropdown group with `{ name, icon, label, items: [...] }`
- **`"|"`** — group separator (adds `lexxy-editor__toolbar-group-end` to the preceding element)
- **`"~"`** — flexible spacer (pushes subsequent items to the right)

Integrators can override via preset or per-editor HTML attribute:

```js
Lexxy.configure({
  compact: {
    toolbar: {
      items: ["bold", "italic", "link", "|", "undo", "redo"]
    }
  }
})
```