### PR TITLE
Fix crash when applying list formatting to a selected attachment

### DIFF
--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -131,7 +131,7 @@ export class CommandDispatcher {
 
   dispatchInsertUnorderedList() {
     const selection = $getSelection()
-    if (!selection) return
+    if (!$isRangeSelection(selection)) return
 
     const anchorNode = selection.anchor.getNode()
 
@@ -144,7 +144,7 @@ export class CommandDispatcher {
 
   dispatchInsertOrderedList() {
     const selection = $getSelection()
-    if (!selection) return
+    if (!$isRangeSelection(selection)) return
 
     const anchorNode = selection.anchor.getNode()
 

--- a/test/browser/tests/formatting/list_format_with_attachment_selected.test.js
+++ b/test/browser/tests/formatting/list_format_with_attachment_selected.test.js
@@ -1,0 +1,61 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("List formatting with attachment selected", () => {
+  const ATTACHMENT_HTML =
+    '<action-text-attachment content-type="image/png" url="/test.png" filename="photo.png" width="100" height="100"></action-text-attachment>'
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments-enabled.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("bullet list does not crash when an attachment is selected", async ({ page, editor }) => {
+    await editor.setValue(`<p>Hello</p>${ATTACHMENT_HTML}`)
+
+    // Click the figure to select the attachment (creating a NodeSelection)
+    await editor.content.locator("figure.attachment").click()
+    await editor.flush()
+    await expect(editor.content.locator("figure.node--selected")).toHaveCount(1)
+
+    // Listen for errors -- the bug causes "Cannot read properties of undefined (reading 'getNode')"
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    // Click the bullet list button -- should not crash
+    await page.getByRole("button", { name: "Bullet list" }).click()
+    await page.waitForTimeout(500)
+
+    // No JS errors should have been thrown
+    expect(errors).toHaveLength(0)
+
+    // The paragraph and attachment should still be present (command was a no-op)
+    await expect(editor.content).toContainText("Hello")
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(1)
+  })
+
+  test("numbered list does not crash when an attachment is selected", async ({ page, editor }) => {
+    await editor.setValue(`<p>Hello</p>${ATTACHMENT_HTML}`)
+
+    // Click the figure to select the attachment (creating a NodeSelection)
+    await editor.content.locator("figure.attachment").click()
+    await editor.flush()
+    await expect(editor.content.locator("figure.node--selected")).toHaveCount(1)
+
+    // Listen for errors
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    // Click the numbered list button -- should not crash
+    await page.getByRole("button", { name: "Numbered list" }).click()
+    await page.waitForTimeout(500)
+
+    // No JS errors should have been thrown
+    expect(errors).toHaveLength(0)
+
+    // The paragraph and attachment should still be present (command was a no-op)
+    await expect(editor.content).toContainText("Hello")
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(1)
+  })
+})


### PR DESCRIPTION
## Summary
- List formatting commands (bullet/ordered) crashed when an attachment was selected because `NodeSelection` has no `anchor` property
- Added `$isRangeSelection` guard to bail out early when selection isn't a text range
- Audited other formatting commands in command_dispatcher.js for the same pattern — the rest already had proper guards

Fixes [Lexxy throws an error when trying to format an attachment as a bullet list](https://app.3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9742702871)