### PR TITLE
Fix input lag in prompt/mention system

### DIFF
--- a/src/editor/prompt/local_filter_source.js
+++ b/src/editor/prompt/local_filter_source.js
@@ -1,7 +1,7 @@
 import BaseSource from "./base_source"
 import { filterMatches } from "../../helpers/string_helper"
 
-const MAX_RENDERED_SUGGESTIONS = 50
+const MAX_RENDERED_SUGGESTIONS = 100
 
 export default class LocalFilterSource extends BaseSource {
   async buildListItems(filter = "") {

--- a/src/editor/prompt/local_filter_source.js
+++ b/src/editor/prompt/local_filter_source.js
@@ -1,6 +1,8 @@
 import BaseSource from "./base_source"
 import { filterMatches } from "../../helpers/string_helper"
 
+const MAX_RENDERED_SUGGESTIONS = 50
+
 export default class LocalFilterSource extends BaseSource {
   async buildListItems(filter = "") {
     const promptItems = await this.fetchPromptItems()
@@ -19,7 +21,10 @@ export default class LocalFilterSource extends BaseSource {
   #buildListItemsFromPromptItems(promptItems, filter) {
     const listItems = []
     this.promptItemByListItem = new WeakMap()
-    promptItems.forEach((promptItem) => {
+
+    for (const promptItem of promptItems) {
+      if (listItems.length >= MAX_RENDERED_SUGGESTIONS) break
+
       const searchableText = promptItem.getAttribute("search")
 
       if (!filter || filterMatches(searchableText, filter)) {
@@ -27,7 +32,7 @@ export default class LocalFilterSource extends BaseSource {
         this.promptItemByListItem.set(listItem, promptItem)
         listItems.push(listItem)
       }
-    })
+    }
 
     return listItems
   }

--- a/src/editor/prompt/remote_filter_source.js
+++ b/src/editor/prompt/remote_filter_source.js
@@ -2,6 +2,7 @@ import BaseSource from "./base_source"
 import { debounceAsync } from "../../helpers/timing_helpers"
 
 const DEBOUNCE_INTERVAL = 200
+const MAX_RENDERED_SUGGESTIONS = 50
 
 export default class RemoteFilterSource extends BaseSource {
   constructor(url) {
@@ -35,6 +36,8 @@ export default class RemoteFilterSource extends BaseSource {
     this.promptItemByListItem = new WeakMap()
 
     for (const promptItem of promptItems) {
+      if (listItems.length >= MAX_RENDERED_SUGGESTIONS) break
+
       const listItem = this.buildListItemElementFor(promptItem)
       this.promptItemByListItem.set(listItem, promptItem)
       listItems.push(listItem)

--- a/src/editor/prompt/remote_filter_source.js
+++ b/src/editor/prompt/remote_filter_source.js
@@ -2,7 +2,7 @@ import BaseSource from "./base_source"
 import { debounceAsync } from "../../helpers/timing_helpers"
 
 const DEBOUNCE_INTERVAL = 200
-const MAX_RENDERED_SUGGESTIONS = 50
+const MAX_RENDERED_SUGGESTIONS = 100
 
 export default class RemoteFilterSource extends BaseSource {
   constructor(url) {

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -7,14 +7,16 @@ import InlinePromptSource from "../editor/prompt/inline_source"
 import DeferredPromptSource from "../editor/prompt/deferred_source"
 import RemoteFilterSource from "../editor/prompt/remote_filter_source"
 import { $generateNodesFromDOM } from "@lexical/html"
-import { nextFrame } from "../helpers/timing_helpers"
+import { debounce, nextFrame } from "../helpers/timing_helpers"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 
 const NOTHING_FOUND_DEFAULT_MESSAGE = "Nothing found"
+const FILTER_DEBOUNCE_INTERVAL = 50
 
 export class LexicalPromptElement extends HTMLElement {
   #globalListeners = new ListenerBin()
   #popoverListeners = new ListenerBin()
+  #debouncedFilterOptions = debounce(() => this.#filterOptions(), FILTER_DEBOUNCE_INTERVAL)
 
   constructor() {
     super()
@@ -172,7 +174,7 @@ export class LexicalPromptElement extends HTMLElement {
 
     this.#popoverListeners.track(
       registerEventListener(this.#editorElement, "keydown", this.#handleKeydownOnPopover),
-      registerEventListener(this.#editorElement, "lexxy:change", this.#filterOptions)
+      registerEventListener(this.#editorElement, "lexxy:change", this.#debouncedFilterOptions)
     )
 
     this.#registerKeyListeners()

--- a/src/helpers/timing_helpers.js
+++ b/src/helpers/timing_helpers.js
@@ -1,3 +1,12 @@
+export function debounce(fn, wait) {
+  let timeout
+
+  return (...args) => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => fn(...args), wait)
+  }
+}
+
 export function debounceAsync(fn, wait) {
   let timeout
 

--- a/test/browser/fixtures/mentions-large.html
+++ b/test/browser/fixtures/mentions-large.html
@@ -1,0 +1,2423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Mentions (Large List)</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something...">
+        <lexxy-prompt trigger="@" name="mention" id="large-prompt">
+          <lexxy-prompt-item search="Person 0" sgid="test-sgid-person-0">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 0</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 0</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 1" sgid="test-sgid-person-1">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 1</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 1</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 2" sgid="test-sgid-person-2">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 2</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 2</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 3" sgid="test-sgid-person-3">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 3</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 3</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 4" sgid="test-sgid-person-4">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 4</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 4</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 5" sgid="test-sgid-person-5">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 5</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 5</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 6" sgid="test-sgid-person-6">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 6</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 6</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 7" sgid="test-sgid-person-7">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 7</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 7</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 8" sgid="test-sgid-person-8">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 8</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 8</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 9" sgid="test-sgid-person-9">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 9</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 9</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 10" sgid="test-sgid-person-10">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 10</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 10</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 11" sgid="test-sgid-person-11">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 11</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 11</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 12" sgid="test-sgid-person-12">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 12</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 12</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 13" sgid="test-sgid-person-13">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 13</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 13</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 14" sgid="test-sgid-person-14">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 14</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 14</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 15" sgid="test-sgid-person-15">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 15</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 15</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 16" sgid="test-sgid-person-16">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 16</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 16</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 17" sgid="test-sgid-person-17">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 17</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 17</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 18" sgid="test-sgid-person-18">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 18</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 18</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 19" sgid="test-sgid-person-19">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 19</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 19</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 20" sgid="test-sgid-person-20">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 20</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 20</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 21" sgid="test-sgid-person-21">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 21</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 21</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 22" sgid="test-sgid-person-22">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 22</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 22</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 23" sgid="test-sgid-person-23">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 23</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 23</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 24" sgid="test-sgid-person-24">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 24</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 24</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 25" sgid="test-sgid-person-25">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 25</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 25</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 26" sgid="test-sgid-person-26">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 26</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 26</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 27" sgid="test-sgid-person-27">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 27</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 27</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 28" sgid="test-sgid-person-28">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 28</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 28</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 29" sgid="test-sgid-person-29">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 29</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 29</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 30" sgid="test-sgid-person-30">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 30</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 30</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 31" sgid="test-sgid-person-31">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 31</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 31</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 32" sgid="test-sgid-person-32">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 32</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 32</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 33" sgid="test-sgid-person-33">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 33</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 33</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 34" sgid="test-sgid-person-34">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 34</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 34</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 35" sgid="test-sgid-person-35">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 35</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 35</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 36" sgid="test-sgid-person-36">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 36</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 36</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 37" sgid="test-sgid-person-37">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 37</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 37</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 38" sgid="test-sgid-person-38">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 38</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 38</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 39" sgid="test-sgid-person-39">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 39</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 39</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 40" sgid="test-sgid-person-40">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 40</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 40</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 41" sgid="test-sgid-person-41">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 41</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 41</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 42" sgid="test-sgid-person-42">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 42</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 42</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 43" sgid="test-sgid-person-43">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 43</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 43</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 44" sgid="test-sgid-person-44">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 44</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 44</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 45" sgid="test-sgid-person-45">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 45</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 45</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 46" sgid="test-sgid-person-46">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 46</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 46</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 47" sgid="test-sgid-person-47">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 47</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 47</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 48" sgid="test-sgid-person-48">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 48</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 48</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 49" sgid="test-sgid-person-49">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 49</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 49</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 50" sgid="test-sgid-person-50">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 50</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 50</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 51" sgid="test-sgid-person-51">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 51</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 51</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 52" sgid="test-sgid-person-52">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 52</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 52</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 53" sgid="test-sgid-person-53">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 53</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 53</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 54" sgid="test-sgid-person-54">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 54</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 54</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 55" sgid="test-sgid-person-55">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 55</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 55</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 56" sgid="test-sgid-person-56">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 56</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 56</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 57" sgid="test-sgid-person-57">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 57</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 57</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 58" sgid="test-sgid-person-58">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 58</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 58</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 59" sgid="test-sgid-person-59">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 59</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 59</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 60" sgid="test-sgid-person-60">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 60</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 60</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 61" sgid="test-sgid-person-61">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 61</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 61</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 62" sgid="test-sgid-person-62">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 62</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 62</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 63" sgid="test-sgid-person-63">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 63</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 63</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 64" sgid="test-sgid-person-64">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 64</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 64</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 65" sgid="test-sgid-person-65">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 65</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 65</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 66" sgid="test-sgid-person-66">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 66</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 66</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 67" sgid="test-sgid-person-67">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 67</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 67</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 68" sgid="test-sgid-person-68">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 68</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 68</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 69" sgid="test-sgid-person-69">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 69</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 69</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 70" sgid="test-sgid-person-70">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 70</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 70</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 71" sgid="test-sgid-person-71">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 71</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 71</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 72" sgid="test-sgid-person-72">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 72</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 72</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 73" sgid="test-sgid-person-73">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 73</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 73</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 74" sgid="test-sgid-person-74">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 74</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 74</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 75" sgid="test-sgid-person-75">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 75</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 75</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 76" sgid="test-sgid-person-76">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 76</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 76</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 77" sgid="test-sgid-person-77">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 77</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 77</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 78" sgid="test-sgid-person-78">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 78</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 78</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 79" sgid="test-sgid-person-79">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 79</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 79</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 80" sgid="test-sgid-person-80">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 80</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 80</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 81" sgid="test-sgid-person-81">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 81</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 81</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 82" sgid="test-sgid-person-82">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 82</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 82</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 83" sgid="test-sgid-person-83">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 83</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 83</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 84" sgid="test-sgid-person-84">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 84</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 84</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 85" sgid="test-sgid-person-85">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 85</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 85</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 86" sgid="test-sgid-person-86">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 86</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 86</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 87" sgid="test-sgid-person-87">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 87</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 87</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 88" sgid="test-sgid-person-88">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 88</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 88</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 89" sgid="test-sgid-person-89">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 89</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 89</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 90" sgid="test-sgid-person-90">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 90</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 90</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 91" sgid="test-sgid-person-91">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 91</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 91</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 92" sgid="test-sgid-person-92">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 92</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 92</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 93" sgid="test-sgid-person-93">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 93</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 93</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 94" sgid="test-sgid-person-94">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 94</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 94</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 95" sgid="test-sgid-person-95">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 95</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 95</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 96" sgid="test-sgid-person-96">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 96</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 96</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 97" sgid="test-sgid-person-97">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 97</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 97</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 98" sgid="test-sgid-person-98">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 98</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 98</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 99" sgid="test-sgid-person-99">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 99</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 99</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 100" sgid="test-sgid-person-100">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 100</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 100</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 101" sgid="test-sgid-person-101">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 101</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 101</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 102" sgid="test-sgid-person-102">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 102</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 102</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 103" sgid="test-sgid-person-103">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 103</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 103</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 104" sgid="test-sgid-person-104">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 104</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 104</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 105" sgid="test-sgid-person-105">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 105</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 105</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 106" sgid="test-sgid-person-106">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 106</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 106</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 107" sgid="test-sgid-person-107">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 107</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 107</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 108" sgid="test-sgid-person-108">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 108</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 108</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 109" sgid="test-sgid-person-109">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 109</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 109</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 110" sgid="test-sgid-person-110">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 110</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 110</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 111" sgid="test-sgid-person-111">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 111</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 111</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 112" sgid="test-sgid-person-112">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 112</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 112</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 113" sgid="test-sgid-person-113">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 113</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 113</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 114" sgid="test-sgid-person-114">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 114</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 114</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 115" sgid="test-sgid-person-115">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 115</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 115</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 116" sgid="test-sgid-person-116">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 116</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 116</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 117" sgid="test-sgid-person-117">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 117</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 117</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 118" sgid="test-sgid-person-118">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 118</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 118</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 119" sgid="test-sgid-person-119">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 119</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 119</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 120" sgid="test-sgid-person-120">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 120</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 120</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 121" sgid="test-sgid-person-121">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 121</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 121</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 122" sgid="test-sgid-person-122">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 122</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 122</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 123" sgid="test-sgid-person-123">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 123</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 123</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 124" sgid="test-sgid-person-124">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 124</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 124</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 125" sgid="test-sgid-person-125">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 125</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 125</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 126" sgid="test-sgid-person-126">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 126</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 126</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 127" sgid="test-sgid-person-127">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 127</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 127</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 128" sgid="test-sgid-person-128">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 128</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 128</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 129" sgid="test-sgid-person-129">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 129</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 129</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 130" sgid="test-sgid-person-130">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 130</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 130</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 131" sgid="test-sgid-person-131">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 131</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 131</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 132" sgid="test-sgid-person-132">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 132</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 132</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 133" sgid="test-sgid-person-133">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 133</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 133</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 134" sgid="test-sgid-person-134">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 134</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 134</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 135" sgid="test-sgid-person-135">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 135</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 135</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 136" sgid="test-sgid-person-136">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 136</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 136</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 137" sgid="test-sgid-person-137">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 137</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 137</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 138" sgid="test-sgid-person-138">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 138</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 138</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 139" sgid="test-sgid-person-139">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 139</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 139</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 140" sgid="test-sgid-person-140">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 140</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 140</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 141" sgid="test-sgid-person-141">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 141</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 141</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 142" sgid="test-sgid-person-142">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 142</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 142</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 143" sgid="test-sgid-person-143">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 143</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 143</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 144" sgid="test-sgid-person-144">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 144</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 144</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 145" sgid="test-sgid-person-145">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 145</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 145</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 146" sgid="test-sgid-person-146">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 146</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 146</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 147" sgid="test-sgid-person-147">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 147</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 147</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 148" sgid="test-sgid-person-148">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 148</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 148</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 149" sgid="test-sgid-person-149">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 149</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 149</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 150" sgid="test-sgid-person-150">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 150</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 150</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 151" sgid="test-sgid-person-151">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 151</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 151</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 152" sgid="test-sgid-person-152">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 152</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 152</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 153" sgid="test-sgid-person-153">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 153</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 153</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 154" sgid="test-sgid-person-154">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 154</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 154</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 155" sgid="test-sgid-person-155">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 155</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 155</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 156" sgid="test-sgid-person-156">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 156</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 156</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 157" sgid="test-sgid-person-157">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 157</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 157</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 158" sgid="test-sgid-person-158">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 158</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 158</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 159" sgid="test-sgid-person-159">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 159</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 159</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 160" sgid="test-sgid-person-160">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 160</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 160</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 161" sgid="test-sgid-person-161">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 161</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 161</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 162" sgid="test-sgid-person-162">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 162</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 162</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 163" sgid="test-sgid-person-163">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 163</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 163</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 164" sgid="test-sgid-person-164">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 164</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 164</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 165" sgid="test-sgid-person-165">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 165</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 165</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 166" sgid="test-sgid-person-166">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 166</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 166</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 167" sgid="test-sgid-person-167">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 167</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 167</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 168" sgid="test-sgid-person-168">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 168</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 168</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 169" sgid="test-sgid-person-169">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 169</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 169</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 170" sgid="test-sgid-person-170">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 170</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 170</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 171" sgid="test-sgid-person-171">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 171</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 171</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 172" sgid="test-sgid-person-172">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 172</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 172</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 173" sgid="test-sgid-person-173">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 173</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 173</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 174" sgid="test-sgid-person-174">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 174</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 174</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 175" sgid="test-sgid-person-175">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 175</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 175</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 176" sgid="test-sgid-person-176">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 176</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 176</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 177" sgid="test-sgid-person-177">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 177</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 177</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 178" sgid="test-sgid-person-178">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 178</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 178</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 179" sgid="test-sgid-person-179">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 179</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 179</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 180" sgid="test-sgid-person-180">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 180</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 180</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 181" sgid="test-sgid-person-181">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 181</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 181</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 182" sgid="test-sgid-person-182">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 182</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 182</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 183" sgid="test-sgid-person-183">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 183</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 183</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 184" sgid="test-sgid-person-184">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 184</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 184</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 185" sgid="test-sgid-person-185">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 185</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 185</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 186" sgid="test-sgid-person-186">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 186</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 186</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 187" sgid="test-sgid-person-187">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 187</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 187</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 188" sgid="test-sgid-person-188">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 188</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 188</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 189" sgid="test-sgid-person-189">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 189</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 189</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 190" sgid="test-sgid-person-190">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 190</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 190</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 191" sgid="test-sgid-person-191">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 191</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 191</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 192" sgid="test-sgid-person-192">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 192</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 192</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 193" sgid="test-sgid-person-193">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 193</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 193</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 194" sgid="test-sgid-person-194">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 194</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 194</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 195" sgid="test-sgid-person-195">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 195</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 195</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 196" sgid="test-sgid-person-196">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 196</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 196</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 197" sgid="test-sgid-person-197">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 197</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 197</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 198" sgid="test-sgid-person-198">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 198</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 198</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Person 199" sgid="test-sgid-person-199">
+            <template type="menu">
+              <span class="person person--prompt-item">
+                <span class="person--name">Person 199</span>
+              </span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">
+                <span class="person--name">Person 199</span>
+              </span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/prompts/prompt_performance.test.js
+++ b/test/browser/tests/prompts/prompt_performance.test.js
@@ -1,0 +1,45 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt performance with large lists", () => {
+  test.describe.configure({ mode: "serial" })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-large.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("caps the number of rendered suggestions", async ({ page, editor }) => {
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    // With 200 matching items, the popover should cap rendered items at 50
+    const itemCount = await popover.locator(".lexxy-prompt-menu__item").count()
+    expect(itemCount).toBeLessThanOrEqual(50)
+    expect(itemCount).toBeGreaterThan(0)
+  })
+
+  test("filtering narrows results within the cap", async ({ page, editor }) => {
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    // Type a numeric filter to narrow results without triggering space-select.
+    // "19" matches "Person 19", "Person 190"-"Person 199" = 11 items
+    await editor.content.pressSequentially("19")
+    await editor.flush()
+
+    // Wait for debounce to settle and results to update
+    await page.waitForTimeout(200)
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items.first()).toBeVisible({ timeout: 2_000 })
+
+    const itemCount = await items.count()
+    expect(itemCount).toBeGreaterThan(0)
+    expect(itemCount).toBeLessThan(50)
+  })
+})

--- a/test/browser/tests/prompts/prompt_performance.test.js
+++ b/test/browser/tests/prompts/prompt_performance.test.js
@@ -15,9 +15,9 @@ test.describe("Prompt performance with large lists", () => {
     const popover = page.locator(".lexxy-prompt-menu--visible")
     await expect(popover).toBeVisible({ timeout: 5_000 })
 
-    // With 200 matching items, the popover should cap rendered items at 50
+    // With 200 matching items, the popover should cap rendered items at 100
     const itemCount = await popover.locator(".lexxy-prompt-menu__item").count()
-    expect(itemCount).toBeLessThanOrEqual(50)
+    expect(itemCount).toBeLessThanOrEqual(100)
     expect(itemCount).toBeGreaterThan(0)
   })
 
@@ -40,6 +40,6 @@ test.describe("Prompt performance with large lists", () => {
 
     const itemCount = await items.count()
     expect(itemCount).toBeGreaterThan(0)
-    expect(itemCount).toBeLessThan(50)
+    expect(itemCount).toBeLessThan(100)
   })
 })


### PR DESCRIPTION
## Summary

The prompt/mention autocomplete system was causing noticeable input lag, especially on the first characters typed in campfire chat. Two root causes, mirroring the pattern from BC3 PR #10263:

- **No input debounce** — every keystroke fired the full filter-and-render pipeline via the `lexxy:change` event listener. Fix: debounce at 50ms so rapid keystrokes coalesce into fewer filter cycles.
- **All matches rendered to DOM** — broad queries (e.g., just typing `@`) rendered hundreds of suggestion elements for large accounts. Fix: cap rendered suggestions at 50 in both `LocalFilterSource` and `RemoteFilterSource`.

The initial popover display (when the trigger character is typed) remains immediate — only subsequent filtering during typing is debounced.

Fixes [Input lag on campfire input](https://app.3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9764302503)