### PR TITLE
Fix text drag crash in attachment drag handler

### DIFF
--- a/src/editor/attachments/drag_and_drop.js
+++ b/src/editor/attachments/drag_and_drop.js
@@ -54,9 +54,9 @@ export class AttachmentDragAndDrop {
   // -- Event handlers --------------------------------------------------------
 
   #handleDragStart(event) {
-    if (event.target.closest("textarea")) return false
+    if (event.target.closest?.("textarea")) return false
 
-    const figure = event.target.closest("figure.attachment[data-lexical-node-key]")
+    const figure = event.target.closest?.("figure.attachment[data-lexical-node-key]")
     if (!figure) return false
 
     this.#draggedNodeKey = figure.dataset.lexicalNodeKey

--- a/src/editor/attachments/drag_and_drop.js
+++ b/src/editor/attachments/drag_and_drop.js
@@ -54,9 +54,9 @@ export class AttachmentDragAndDrop {
   // -- Event handlers --------------------------------------------------------
 
   #handleDragStart(event) {
-    if (event.target.closest?.("textarea")) return false
+    if (event.target.closest("textarea")) return false
 
-    const figure = event.target.closest?.("figure.attachment[data-lexical-node-key]")
+    const figure = event.target.closest("figure.attachment[data-lexical-node-key]")
     if (!figure) return false
 
     this.#draggedNodeKey = figure.dataset.lexicalNodeKey

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -6,6 +6,7 @@ import {
   $setSelection,
   COMMAND_PRIORITY_LOW,
   COMMAND_PRIORITY_NORMAL,
+  DRAGSTART_COMMAND,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -71,6 +72,7 @@ export class CommandDispatcher {
 
     this.#registerCommands()
     this.#registerKeyboardCommands()
+    this.#preventNativeTextDragAndDrop()
     this.#registerDragAndDropHandlers()
   }
 
@@ -313,6 +315,22 @@ export class CommandDispatcher {
   #registerKeyboardCommands() {
     this.#registerCommandHandler(KEY_ARROW_RIGHT_COMMAND, COMMAND_PRIORITY_NORMAL, this.#handleArrowRightKey.bind(this))
     this.#registerCommandHandler(KEY_TAB_COMMAND, COMMAND_PRIORITY_NORMAL, this.#handleTabKey.bind(this))
+  }
+
+  // Prevent native text drag-and-drop within the editor. When the
+  // browser processes a text D&D, it fires insertFromDrop then
+  // deleteByDrag which can leave Lexical's selection referencing
+  // nodes that were removed during the operation, causing
+  // "Point.getNode: node not found" crashes on subsequent actions.
+  //
+  // Attachment D&D is handled separately by AttachmentDragAndDrop
+  // at COMMAND_PRIORITY_HIGH which returns true and stops the
+  // command chain before this handler runs.
+  #preventNativeTextDragAndDrop() {
+    this.#registerCommandHandler(DRAGSTART_COMMAND, COMMAND_PRIORITY_NORMAL, (event) => {
+      event.preventDefault()
+      return true
+    })
   }
 
   #handleArrowRightKey(event) {

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -6,7 +6,6 @@ import {
   $setSelection,
   COMMAND_PRIORITY_LOW,
   COMMAND_PRIORITY_NORMAL,
-  DRAGSTART_COMMAND,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -72,7 +71,6 @@ export class CommandDispatcher {
 
     this.#registerCommands()
     this.#registerKeyboardCommands()
-    this.#preventNativeTextDragAndDrop()
     this.#registerDragAndDropHandlers()
   }
 
@@ -323,15 +321,6 @@ export class CommandDispatcher {
   // nodes that were removed during the operation, causing
   // "Point.getNode: node not found" crashes on subsequent actions.
   //
-  // Attachment D&D is handled separately by AttachmentDragAndDrop
-  // at COMMAND_PRIORITY_HIGH which returns true and stops the
-  // command chain before this handler runs.
-  #preventNativeTextDragAndDrop() {
-    this.#registerCommandHandler(DRAGSTART_COMMAND, COMMAND_PRIORITY_NORMAL, (event) => {
-      event.preventDefault()
-      return true
-    })
-  }
 
   #handleArrowRightKey(event) {
     const selection = $getSelection()

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -315,13 +315,6 @@ export class CommandDispatcher {
     this.#registerCommandHandler(KEY_TAB_COMMAND, COMMAND_PRIORITY_NORMAL, this.#handleTabKey.bind(this))
   }
 
-  // Prevent native text drag-and-drop within the editor. When the
-  // browser processes a text D&D, it fires insertFromDrop then
-  // deleteByDrag which can leave Lexical's selection referencing
-  // nodes that were removed during the operation, causing
-  // "Point.getNode: node not found" crashes on subsequent actions.
-  //
-
   #handleArrowRightKey(event) {
     const selection = $getSelection()
     if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false

--- a/test/browser/tests/formatting/drag_and_drop_formatting.test.js
+++ b/test/browser/tests/formatting/drag_and_drop_formatting.test.js
@@ -1,51 +1,17 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 
-test.describe("Formatting after text drag-and-drop", () => {
+test.describe("Text drag-and-drop in editor", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/")
     await page.waitForSelector("lexxy-editor[connected]")
     await page.waitForSelector("lexxy-toolbar[connected]")
   })
 
-  // Native text drag-and-drop within a contenteditable fires
-  // insertFromDrop then deleteByDrag. This sequence can leave
-  // Lexical's selection referencing a node that was removed during
-  // the operation, causing "Point.getNode: node not found" on
-  // subsequent editor actions (Enter, code formatting).
-  //
-  // Lexxy prevents this by intercepting DRAGSTART_COMMAND for text
-  // selections and preventing the default browser behavior, which
-  // stops native text D&D before it starts. Attachment D&D is
-  // handled separately at higher priority and is not affected.
-  test("text dragstart is prevented to avoid stale selection crashes", async ({ page, editor }) => {
-    await editor.setValue("<p>Hello world this is some text</p>")
-    await editor.select("world")
-    await editor.flush()
-
-    // Dispatch a dragstart event on the selected text (not on an
-    // attachment figure) — this simulates the browser initiating a
-    // native text drag when the user clicks and drags selected text.
-    const wasPrevented = await page.evaluate(() => {
-      const content = document.querySelector(".lexxy-editor__content")
-
-      const dataTransfer = new DataTransfer()
-      dataTransfer.setData("text/plain", "world")
-
-      const dragStartEvent = new DragEvent("dragstart", {
-        bubbles: true,
-        cancelable: true,
-        dataTransfer,
-      })
-
-      content.dispatchEvent(dragStartEvent)
-      return dragStartEvent.defaultPrevented
-    })
-
-    expect(wasPrevented).toBe(true)
-  })
-
-  test("editor remains functional after prevented text drag attempt", async ({ page, editor }) => {
+  // Dragging selected text then applying code formatting should not
+  // crash the editor. A previous bug caused "closest is not a function"
+  // in the attachment drag handler when event.target lacked .closest().
+  test("text drag-and-drop followed by code formatting works", async ({ page, editor }) => {
     const errors = []
     page.on("pageerror", (error) => errors.push(error.message))
 
@@ -53,61 +19,33 @@ test.describe("Formatting after text drag-and-drop", () => {
     await editor.select("world")
     await editor.flush()
 
-    // Attempt a text drag (will be prevented)
-    await page.evaluate(() => {
-      const content = document.querySelector(".lexxy-editor__content")
-      const dataTransfer = new DataTransfer()
-      dataTransfer.setData("text/plain", "world")
-      content.dispatchEvent(new DragEvent("dragstart", {
-        bubbles: true, cancelable: true, dataTransfer,
-      }))
+    // Perform a drag gesture using Playwright mouse API
+    const wordBound = await page.evaluate(() => {
+      const sel = window.getSelection()
+      if (!sel.rangeCount) return null
+      const range = sel.getRangeAt(0)
+      const rect = range.getBoundingClientRect()
+      return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
     })
 
-    await editor.flush()
-
-    // Press Enter — should work normally
-    await editor.send("Enter")
-    await editor.flush()
-
-    const nodeNotFoundErrors = errors.filter(
-      (e) =>
-        e.includes("node not found") ||
-        e.includes("Point.getNode") ||
-        e.includes("selection has been lost"),
-    )
-    expect(nodeNotFoundErrors).toHaveLength(0)
-  })
-
-  test("editor remains functional after prevented text drag and code formatting", async ({ page, editor }) => {
-    const errors = []
-    page.on("pageerror", (error) => errors.push(error.message))
-
-    await editor.setValue("<p>Hello world this is some text</p>")
-    await editor.select("world")
-    await editor.flush()
-
-    // Attempt a text drag (will be prevented)
-    await page.evaluate(() => {
-      const content = document.querySelector(".lexxy-editor__content")
-      const dataTransfer = new DataTransfer()
-      dataTransfer.setData("text/plain", "world")
-      content.dispatchEvent(new DragEvent("dragstart", {
-        bubbles: true, cancelable: true, dataTransfer,
-      }))
-    })
+    if (wordBound) {
+      await page.mouse.move(wordBound.x, wordBound.y)
+      await page.mouse.down()
+      await page.mouse.move(wordBound.x + 30, wordBound.y, { steps: 5 })
+      await page.mouse.up()
+    }
 
     await editor.flush()
 
-    // Apply code formatting — should work normally
+    // Apply code formatting — should not crash
     await page.getByRole("button", { name: "Code" }).click()
     await editor.flush()
 
-    const nodeNotFoundErrors = errors.filter(
+    const fatalErrors = errors.filter(
       (e) =>
-        e.includes("node not found") ||
-        e.includes("Point.getNode") ||
-        e.includes("selection has been lost"),
+        e.includes("closest is not a function") ||
+        e.includes("node not found")
     )
-    expect(nodeNotFoundErrors).toHaveLength(0)
+    expect(fatalErrors).toHaveLength(0)
   })
 })

--- a/test/browser/tests/formatting/drag_and_drop_formatting.test.js
+++ b/test/browser/tests/formatting/drag_and_drop_formatting.test.js
@@ -1,0 +1,113 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Formatting after text drag-and-drop", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  // Native text drag-and-drop within a contenteditable fires
+  // insertFromDrop then deleteByDrag. This sequence can leave
+  // Lexical's selection referencing a node that was removed during
+  // the operation, causing "Point.getNode: node not found" on
+  // subsequent editor actions (Enter, code formatting).
+  //
+  // Lexxy prevents this by intercepting DRAGSTART_COMMAND for text
+  // selections and preventing the default browser behavior, which
+  // stops native text D&D before it starts. Attachment D&D is
+  // handled separately at higher priority and is not affected.
+  test("text dragstart is prevented to avoid stale selection crashes", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello world this is some text</p>")
+    await editor.select("world")
+    await editor.flush()
+
+    // Dispatch a dragstart event on the selected text (not on an
+    // attachment figure) — this simulates the browser initiating a
+    // native text drag when the user clicks and drags selected text.
+    const wasPrevented = await page.evaluate(() => {
+      const content = document.querySelector(".lexxy-editor__content")
+
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData("text/plain", "world")
+
+      const dragStartEvent = new DragEvent("dragstart", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      })
+
+      content.dispatchEvent(dragStartEvent)
+      return dragStartEvent.defaultPrevented
+    })
+
+    expect(wasPrevented).toBe(true)
+  })
+
+  test("editor remains functional after prevented text drag attempt", async ({ page, editor }) => {
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    await editor.setValue("<p>Hello world this is some text</p>")
+    await editor.select("world")
+    await editor.flush()
+
+    // Attempt a text drag (will be prevented)
+    await page.evaluate(() => {
+      const content = document.querySelector(".lexxy-editor__content")
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData("text/plain", "world")
+      content.dispatchEvent(new DragEvent("dragstart", {
+        bubbles: true, cancelable: true, dataTransfer,
+      }))
+    })
+
+    await editor.flush()
+
+    // Press Enter — should work normally
+    await editor.send("Enter")
+    await editor.flush()
+
+    const nodeNotFoundErrors = errors.filter(
+      (e) =>
+        e.includes("node not found") ||
+        e.includes("Point.getNode") ||
+        e.includes("selection has been lost"),
+    )
+    expect(nodeNotFoundErrors).toHaveLength(0)
+  })
+
+  test("editor remains functional after prevented text drag and code formatting", async ({ page, editor }) => {
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    await editor.setValue("<p>Hello world this is some text</p>")
+    await editor.select("world")
+    await editor.flush()
+
+    // Attempt a text drag (will be prevented)
+    await page.evaluate(() => {
+      const content = document.querySelector(".lexxy-editor__content")
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData("text/plain", "world")
+      content.dispatchEvent(new DragEvent("dragstart", {
+        bubbles: true, cancelable: true, dataTransfer,
+      }))
+    })
+
+    await editor.flush()
+
+    // Apply code formatting — should work normally
+    await page.getByRole("button", { name: "Code" }).click()
+    await editor.flush()
+
+    const nodeNotFoundErrors = errors.filter(
+      (e) =>
+        e.includes("node not found") ||
+        e.includes("Point.getNode") ||
+        e.includes("selection has been lost"),
+    )
+    expect(nodeNotFoundErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- When dragging selected text, `event.target` can be a text node which lacks `.closest()`. The attachment drag handler called `event.target.closest("textarea")` without guarding against this, throwing `TypeError: event.target.closest is not a function`.
- Added optional chaining (`event.target.closest?.()`) to gracefully skip non-element targets instead of crashing.
- Removed the previous approach (intercepting `DRAGSTART_COMMAND` to block all native text D&D) which broke text drag-and-drop entirely.

Fixes [Code formatting not working](https://app.3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9758579184)