### PR TITLE
Fix bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -50,6 +50,10 @@ echo "== Installing Playwright browsers =="
 npx playwright install
 
 echo "== Preparing database =="
-bin/rails db:prepare
+if [ "${USE_RAILS_WITHOUT_ACTION_TEXT_ADAPTER:-false}" != "true" ]; then
+  bin/rails app:db:prepare
+else
+  bin/rails db:prepare
+fi
 
 echo "== Setup complete! =="


### PR DESCRIPTION
The `bin/setup` script does use the up to date rails command. It seems like on rails head, the `db:prepare` gets namespaced under `app`:

```
bin/rails -h | grep db
  dbconsole    Start a console for the database specified in config/database.yml
               (short-cut alias: "db")
DEPRECATION WARNING: rails/tasks/statistics.rake is deprecated and will be removed in Rails 8.2 without replacement.
 (called from Kernel#load at /Users/leea/personal/lexxy/Rakefile:6)
app:db:create                          Create the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or ...
...
app:db:prepare                         Run setup if database does not exist, or run migrations if it does
app:db:reset                           Drop and recreate all databases from their schema for the current environment and load the seeds
app:db:rollback                        Roll the schema back to the previous version (specify steps w/ STEP=n)
...
app:db:seed                            Load the seed data from db/seeds.rb
app:db:seed:replant                    Truncate tables of each database for current environment and load the seeds
app:db:setup                           Create all databases, load all schemas, and initialize with the seed data (use db:reset to also drop all databases first)
app:db:version                         Retrieve the current schema version number
app:test:db                            Reset the database and run `bin/rails test`
db:create                              Create the database from config/database.yml for the current Rails.env (use db:create:all to create all databases in the config)
db:drop                                Drop the database for the current Rails.env (use db:drop:all to drop all databases)
db:fixtures:load                       Load fixtures into the current environment's database
db:migrate                             Migrate the database (options: VERSION=x, VERBOSE=false)
db:migrate:status                      Display status of migrations
db:rollback                            Roll the schema back to the previous version (specify steps w/ STEP=n)
db:schema:dump                         Create a database schema file (either db/schema.rb or db/structure.sql, depending on `config.active_record.schema_format`)
db:schema:load                         Load a schema.rb file into the database
db:seed                                Load the seed data from db/seeds.rb
db:setup                               Create the database, load the schema, and initialize with the seed data (use db:reset to also drop the database first)
db:system:change                       Change `config/database.yml` and your database gem to the target database
db:version                             Retrieve the current schema version number

bin/rails -v
Rails 8.2.0.alpha
```

I used an llm to modify `bin/setup` since I'm not proficient in bash.

This was the issue running when pulling latest lexxy and trying to run `bin/setup`:
```
bin/setup
== Installing actionlint ==
== Installing shellcheck ==
== Installing zizmor ==
== Installing Ruby dependencies ==
Bundle complete! 15 Gemfile dependencies, 106 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
2 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
== Installing JavaScript dependencies ==
yarn install v1.22.22
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.07s.
== Building JavaScript assets ==
yarn run v1.22.22
$ rollup -c

./src/index.js → ./app/assets/javascript/lexxy.js, ./app/assets/javascript/lexxy.min.js...
created ./app/assets/javascript/lexxy.js, ./app/assets/javascript/lexxy.min.js in 2.8s
✨  Done in 3.21s.
== Installing Playwright browsers ==
== Preparing database ==
DEPRECATION WARNING: rails/tasks/statistics.rake is deprecated and will be removed in Rails 8.2 without replacement.
 (called from Kernel#load at /Users/leea/personal/lexxy/Rakefile:6)
Unrecognized command "db:prepare" (Rails::Command::UnrecognizedCommandError)
Did you mean?  db:create
```