### PR TITLE
Fix missing URL value in Link dialog

### DIFF
--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -55,7 +55,7 @@ export class LinkDropdown extends ToolbarDropdown {
   get #selectedLinkUrl() {
     return this.editor.getEditorState().read(() => {
       const linkNode = this.editorElement.selection.nearestNodeOfType(LinkNode)
-      return linkNode?.getUrl() ?? null
+      return linkNode?.getURL() ?? null
     })
   }
 }

--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -55,7 +55,7 @@ export class LinkDropdown extends ToolbarDropdown {
   get #selectedLinkUrl() {
     return this.editor.getEditorState().read(() => {
       const linkNode = this.editorElement.selection.nearestNodeOfType(LinkNode)
-      return linkNode?.getURL() ?? null
+      return linkNode?.getURL() ?? ""
     })
   }
 }

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -348,4 +348,25 @@ test.describe("Block formatting", () => {
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("https://37signals.com")
   })
+
+  test("link dialog shows empty input when no link is selected", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(HELLO_EVERYONE)
+    await editor.select("everyone")
+    await editor.flush()
+
+    await page.evaluate(() => {
+      const details = document.querySelector(
+        "details:has(summary[name='link'])",
+      )
+      details.open = true
+      details.dispatchEvent(new Event("toggle"))
+    })
+
+    const input = page.locator("lexxy-link-dropdown input[type='url']").first()
+    await expect(input).toBeVisible({ timeout: 2_000 })
+    await expect(input).toHaveValue("")
+  })
 })

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -325,4 +325,27 @@ test.describe("Block formatting", () => {
     const submitCount = await page.evaluate(() => window.__submitCount)
     expect(submitCount).toBe(0)
   })
+
+  test("link dialog shows existing URL when link is selected", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      '<p>Hello <a href="https://37signals.com">everyone</a></p>',
+    )
+    await editor.select("everyone")
+    await editor.flush()
+
+    await page.evaluate(() => {
+      const details = document.querySelector(
+        "details:has(summary[name='link'])",
+      )
+      details.open = true
+      details.dispatchEvent(new Event("toggle"))
+    })
+
+    const input = page.locator("lexxy-link-dropdown input[type='url']").first()
+    await expect(input).toBeVisible({ timeout: 2_000 })
+    await expect(input).toHaveValue("https://37signals.com")
+  })
 })


### PR DESCRIPTION
A [recent change](https://github.com/basecamp/lexxy/pull/945/changes/476c2e512b3993daedf2a96dd435213aa8874c51) broke the link dialog value. This PR fixes that and adds a test against this regression.