### PR TITLE
Skip turbo:before-cache reset for editors inside turbo-permanent elements

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -392,7 +392,9 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #handleTurboBeforeCache = (event) => {
-    this.#reset()
+    if (!this.closest("[data-turbo-permanent]")) {
+      this.#reset()
+    }
   }
 
   #synchronizeWithChanges() {


### PR DESCRIPTION
## Summary

- Lexxy editors inside `[data-turbo-permanent]` containers are no longer reset during `turbo:before-cache`
- These editors are excluded from Turbo's page snapshot, so resetting them is unnecessary and destructive — their `connectedCallback` never fires again to restore the editor

## Problem

When a Turbo page visit occurs, Lexxy's `turbo:before-cache` handler calls `#reset()` on every editor, removing the internal contenteditable div. For editors inside `[data-turbo-permanent]` elements, the element stays in the DOM (never disconnected/reconnected), so `connectedCallback` never fires to recreate the editor. This permanently locks the user out of that editor until a full page refresh.

In Basecamp, this manifests as the sidebar ping text input disappearing after entering and exiting card edit mode.

## Test plan

- [x] Open a page with a Lexxy editor inside a `[data-turbo-permanent]` element (e.g. sidebar ping in Basecamp)
- [x] Trigger a full Turbo page visit (e.g. enter card edit mode via title click, then click "Never Mind")
- [x] Verify the editor remains functional after navigation
- [ ] Verify editors outside `[data-turbo-permanent]` still reset correctly on `turbo:before-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)