### PR TITLE
Fix toolbar focusability for hidden items

### DIFF
--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -7,6 +7,7 @@ import { getNonce } from "../helpers/csp_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 import { handleRollingTabIndex } from "../helpers/accessibility_helper"
 import ToolbarIcons from "./toolbar_icons"
+import { isActiveAndVisible } from "../helpers/html_helper"
 
 export class LexicalToolbarElement extends HTMLElement {
   static observedAttributes = [ "connected" ]
@@ -328,7 +329,7 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   get #focusableItems() {
-    return Array.from(this.querySelectorAll(":scope button, :scope > details > summary"))
+    return Array.from(this.querySelectorAll(":scope button, :scope > details > summary")).filter(isActiveAndVisible)
   }
 
   get #toolbarItems() {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -158,7 +158,8 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #handleEditorFocus = () => {
-    this.#focusableItems[0].tabIndex = 0
+    const firstVisible = this.#focusableItems.find(isActiveAndVisible)
+    if (firstVisible) firstVisible.tabIndex = 0
   }
 
   #handleEditorBlur = () => {
@@ -329,7 +330,7 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   get #focusableItems() {
-    return Array.from(this.querySelectorAll(":scope button, :scope > details > summary")).filter(isActiveAndVisible)
+    return Array.from(this.querySelectorAll(":scope button, :scope > details > summary"))
   }
 
   get #toolbarItems() {

--- a/src/helpers/accessibility_helper.js
+++ b/src/helpers/accessibility_helper.js
@@ -1,3 +1,5 @@
+import { isActiveAndVisible } from "./html_helper"
+
 export function handleRollingTabIndex(elements, event) {
   const previousActiveElement = document.activeElement
 
@@ -79,8 +81,4 @@ class NextElementFinder {
   #unsetTabIndex(elements) {
     elements.forEach(element => element.tabIndex = -1)
   }
-}
-
-function isActiveAndVisible(element) {
-  return element && !element.disabled && element.checkVisibility()
 }

--- a/src/helpers/html_helper.js
+++ b/src/helpers/html_helper.js
@@ -59,3 +59,7 @@ export function generateDomId(prefix) {
 export function extractPlainTextFromHtml(innerHtml = "") {
   return parseHtml(innerHtml).body.textContent.trim()
 }
+
+export function isActiveAndVisible(element) {
+  return element && !element.disabled && element.checkVisibility()
+}


### PR DESCRIPTION
If the first item in the toolbar was hidden, the toolbar was not keyboard accessible with `Shift+Tab`, as `tabindex="0"` was being set on the hidden item.