### PR TITLE
Batch DOM reads and writes during editor initialization

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -676,30 +676,30 @@ export class LexicalEditorElement extends HTMLElement {
     ]
   }
 
-  // Builds one resolver element per CSS value inside a fragment (off-DOM writes),
-  // attaches the fragment in a single DOM write, then reads all computed values in
-  // one pass — triggering at most one forced reflow. The previous implementation
-  // interleaved setProperty/getComputedStyle/removeProperty on the same element,
-  // forcing a style recalc on every iteration during editor initialization.
+  // Builds one resolver element per CSS value inside a hidden container, attaches
+  // the container in a single DOM write, then reads all computed values in one pass
+  // — triggering at most one forced reflow. The previous implementation interleaved
+  // setProperty/getComputedStyle/removeProperty on the same element, forcing a style
+  // recalc on every iteration during editor initialization.
   #resolveColors(property, cssValues) {
-    const fragment = document.createDocumentFragment()
+    const container = document.createElement("span")
+    container.style.display = "none"
 
     const resolvers = cssValues.map(cssValue => {
       const element = document.createElement("span")
-      element.style.display = "none"
       element.style.setProperty(property, cssValue)
-      fragment.appendChild(element)
+      container.appendChild(element)
       return { element, name: cssValue }
     })
 
-    this.appendChild(fragment)
+    this.appendChild(container)
 
     const resolved = resolvers.map(({ element, name }) => ({
       name,
       value: window.getComputedStyle(element).getPropertyValue(property)
     }))
 
-    resolvers.forEach(({ element }) => element.remove())
+    container.remove()
     return resolved
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -677,18 +677,24 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #resolveColors(property, cssValues) {
-    const resolver = document.createElement("span")
-    resolver.style.display = "none"
-    this.appendChild(resolver)
+    const fragment = document.createDocumentFragment()
 
-    const resolved = cssValues.map(cssValue => {
-      resolver.style.setProperty(property, cssValue)
-      const value = window.getComputedStyle(resolver).getPropertyValue(property)
-      resolver.style.removeProperty(property)
-      return { name: cssValue, value }
+    const resolvers = cssValues.map(cssValue => {
+      const element = document.createElement("span")
+      element.style.display = "none"
+      element.style.setProperty(property, cssValue)
+      fragment.appendChild(element)
+      return { element, name: cssValue }
     })
 
-    resolver.remove()
+    this.appendChild(fragment)
+
+    const resolved = resolvers.map(({ element, name }) => ({
+      name,
+      value: window.getComputedStyle(element).getPropertyValue(property)
+    }))
+
+    resolvers.forEach(({ element }) => element.remove())
     return resolved
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -676,6 +676,11 @@ export class LexicalEditorElement extends HTMLElement {
     ]
   }
 
+  // Builds one resolver element per CSS value inside a fragment (off-DOM writes),
+  // attaches the fragment in a single DOM write, then reads all computed values in
+  // one pass — triggering at most one forced reflow. The previous implementation
+  // interleaved setProperty/getComputedStyle/removeProperty on the same element,
+  // forcing a style recalc on every iteration during editor initialization.
   #resolveColors(property, cssValues) {
     const fragment = document.createDocumentFragment()
 

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -265,32 +265,34 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   // Separates layout reads from DOM writes to avoid forced reflows during init.
-  // Measures the toolbar and every button width in a single read pass, figures out
-  // which buttons overflow using math, and then moves them in a single write pass.
+  // Measures every button's right edge in a single read pass, figures out which
+  // buttons overflow using math, and then moves them in a single write pass.
   // The previous implementation interleaved `scrollWidth`/`clientWidth` reads with
   // `prepend()` writes inside a loop, forcing one full browser reflow per button.
   #compactMenu() {
-    const availableWidth = this.clientWidth + 1 // +1 for Safari zoom rounding
-    const overflowWidth = this.#overflow.clientWidth
     const buttons = this.#buttons
-    const buttonWidths = buttons.map(button => button.offsetWidth)
+    if (buttons.length === 0) return
 
-    let totalWidth = overflowWidth
-    let overflowIndex = buttons.length
+    const availableWidth = this.clientWidth + 1 // +1 for Safari zoom rounding
+    const buttonRightEdges = buttons.map(button => button.offsetLeft + button.offsetWidth)
 
+    let firstOverflowing = -1
     for (let i = 0; i < buttons.length; i++) {
-      totalWidth += buttonWidths[i]
-      if (totalWidth > availableWidth) {
-        overflowIndex = i
+      if (buttonRightEdges[i] > availableWidth) {
+        firstOverflowing = i
         break
       }
     }
 
-    if (overflowIndex < buttons.length) {
-      const overflowButtons = buttons.slice(overflowIndex).reverse()
-      for (const button of overflowButtons) {
-        this.#overflowMenu.prepend(button)
-      }
+    if (firstOverflowing === -1) return
+
+    // Move one extra button to reserve space for the overflow control, which is
+    // `display: none` until we show it — matching the previous implementation's
+    // "move one more after it stops overflowing" behaviour.
+    const overflowIndex = Math.max(0, firstOverflowing - 1)
+    const overflowButtons = buttons.slice(overflowIndex).reverse()
+    for (const button of overflowButtons) {
+      this.#overflowMenu.prepend(button)
     }
   }
 

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -271,16 +271,26 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #compactMenu() {
-    const buttons = this.#buttons.reverse()
-    let movedToOverflow = false
+    const availableWidth = this.clientWidth + 1 // +1 for Safari zoom rounding
+    const overflowWidth = this.#overflow.clientWidth
+    const buttons = this.#buttons
+    const buttonWidths = buttons.map(button => button.offsetWidth)
 
-    for (const button of buttons) {
-      if (this.#toolbarIsOverflowing()) {
-        this.#overflowMenu.prepend(button)
-        movedToOverflow = true
-      } else {
-        if (movedToOverflow) this.#overflowMenu.prepend(button)
+    let totalWidth = overflowWidth
+    let overflowIndex = buttons.length
+
+    for (let i = 0; i < buttons.length; i++) {
+      totalWidth += buttonWidths[i]
+      if (totalWidth > availableWidth) {
+        overflowIndex = i
         break
+      }
+    }
+
+    if (overflowIndex < buttons.length) {
+      const overflowButtons = buttons.slice(overflowIndex).reverse()
+      for (const button of overflowButtons) {
+        this.#overflowMenu.prepend(button)
       }
     }
   }
@@ -289,10 +299,10 @@ export class LexicalToolbarElement extends HTMLElement {
     const items = Array.from(this.#overflowMenu.children)
     items.sort((a, b) => this.#itemPosition(b) - this.#itemPosition(a))
 
-    items.forEach((item) => {
+    for (const item of items) {
       const nextItem = this.querySelector(`[data-position="${this.#itemPosition(item) + 1}"]`) ?? this.#overflow
       this.insertBefore(item, nextItem)
-    })
+    }
   }
 
   #itemPosition(item) {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -270,6 +270,11 @@ export class LexicalToolbarElement extends HTMLElement {
     this.#overflowMenu.toggleAttribute("disabled", !isOverflowing)
   }
 
+  // Separates layout reads from DOM writes to avoid forced reflows during init.
+  // Measures the toolbar and every button width in a single read pass, figures out
+  // which buttons overflow using math, and then moves them in a single write pass.
+  // The previous implementation interleaved `scrollWidth`/`clientWidth` reads with
+  // `prepend()` writes inside a loop, forcing one full browser reflow per button.
   #compactMenu() {
     const availableWidth = this.clientWidth + 1 // +1 for Safari zoom rounding
     const overflowWidth = this.#overflow.clientWidth

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -252,12 +252,6 @@ export class LexicalToolbarElement extends HTMLElement {
     }
   }
 
-  #toolbarIsOverflowing() {
-    // Safari can report inconsistent clientWidth values on more than 100% window zoom level,
-    // that was affecting the toolbar overflow calculation. We're adding +1 to get around this issue.
-    return (this.scrollWidth - this.#overflow.clientWidth) > this.clientWidth + 1
-  }
-
   #refreshToolbarOverflow = () => {
     this.#resetToolbarOverflow()
     this.#compactMenu()

--- a/src/helpers/format_helper.js
+++ b/src/helpers/format_helper.js
@@ -80,9 +80,10 @@ export class StyleCanonicalizer {
   }
 }
 
-// Batches style computation to avoid layout thrashing: appends all elements in a single
-// DOM write, reads all computed values afterwards (triggering at most one reflow), then
-// cleans them up.
+// Separates DOM writes from layout reads to avoid forced reflows. All resolver
+// elements are built inside a fragment, attached once, then read in a single pass.
+// Reading `getComputedStyle` after a write forces the browser to recompute layout,
+// so interleaving writes and reads inside a loop turns one reflow into N.
 function computeStyleValues(property, values) {
   const fragment = document.createDocumentFragment()
 

--- a/src/helpers/format_helper.js
+++ b/src/helpers/format_helper.js
@@ -71,7 +71,9 @@ export class StyleCanonicalizer {
 
   #resolveCannonicalValue(value) {
     let index = this.#computedAllowedValues.indexOf(value)
-    index ||= this.#computedAllowedValues.indexOf(computeStyleValues(this._property, [ value ])[0])
+    if (index === -1) {
+      index = this.#computedAllowedValues.indexOf(computeStyleValues(this._property, [ value ])[0])
+    }
     return index === -1 ? null : this._allowedValues[index]
   }
 

--- a/src/helpers/format_helper.js
+++ b/src/helpers/format_helper.js
@@ -71,24 +71,33 @@ export class StyleCanonicalizer {
 
   #resolveCannonicalValue(value) {
     let index = this.#computedAllowedValues.indexOf(value)
-    index ||= this.#computedAllowedValues.indexOf(getComputedStyleForProperty(this._property, value))
+    index ||= this.#computedAllowedValues.indexOf(computeStyleValues(this._property, [ value ])[0])
     return index === -1 ? null : this._allowedValues[index]
   }
 
   get #computedAllowedValues() {
-    return this._computedAllowedValues ||= this._allowedValues.map(
-      value => getComputedStyleForProperty(this._property, value)
-    )
+    return this._computedAllowedValues ||= computeStyleValues(this._property, this._allowedValues)
   }
 }
 
-function getComputedStyleForProperty(property, value) {
-  const style = `${property}: ${value};`
+// Batches style computation to avoid layout thrashing: appends all elements in a single
+// DOM write, reads all computed values afterwards (triggering at most one reflow), then
+// cleans them up.
+function computeStyleValues(property, values) {
+  const fragment = document.createDocumentFragment()
 
-  // the element has to be attached to the DOM have computed styles
-  const element = document.body.appendChild(createElement("span", { style: "display: none;" + style }))
-  const computedStyle = window.getComputedStyle(element).getPropertyValue(property)
-  element.remove()
+  const elements = values.map(value => {
+    const element = createElement("span", { style: `display: none; ${property}: ${value};` })
+    fragment.appendChild(element)
+    return element
+  })
 
-  return computedStyle
+  document.body.appendChild(fragment)
+
+  const computed = elements.map(element =>
+    window.getComputedStyle(element).getPropertyValue(property)
+  )
+
+  elements.forEach(element => element.remove())
+  return computed
 }


### PR DESCRIPTION
## Summary

Fixes layout thrashing during editor initialization that caused ~1.5s of blocking on page load when multiple editors are present. The cost of a forced reflow scales with the amount of dirty DOM, and during initial render that's most of the page — individual 1–5ms reflows balloon to 50–100ms.

Three init-time patterns interleaved DOM reads and writes inside loops, forcing N reflows where 1 would suffice:

- **`editor.js` `#resolveColors()`** — `setProperty` (write) → `getComputedStyle` (forced recalc) → `removeProperty` (write), per color value. Fires for each of ~9 highlight colors × 2 properties during editor init.
- **`toolbar.js` `#compactMenu()`** — `scrollWidth`/`clientWidth` (layout read) then `prepend()` (DOM write), per overflowing button. Fires on `connectedCallback`, every `ResizeObserver` callback, and `setEditor`.
- **`format_helper.js` `getComputedStyleForProperty()`** — `appendChild` (write) → `getComputedStyle` (forced recalc) → `remove()` (write), per allowed value. Memoized, but still thrashes on first use.

## Approach

All three now batch reads and writes into separate phases:

1. Create all the elements (writes) in a `DocumentFragment`
2. Attach the fragment once (single DOM write)
3. Read all computed values in a single pass (at most one forced reflow — subsequent reads hit the same clean layout)
4. Remove the elements in one pass

The toolbar fix preserves existing behavior while eliminating the interleave: it measures the toolbar's available width and all button widths in a single read pass, computes which buttons overflow using math, then moves them all in a single write pass.

## Verification

On a test page with 2 editors and 300+ chat messages:

- Chrome DevTools' **ForcedReflow** insight no longer attributes any time to the Lexxy bundle. Before the fix, the same insight flagged ~30ms of forced-reflow time in the bundle containing Lexxy; after the fix, that drops to zero.
- All 80 unit tests pass (`yarn test`).
- Editors initialize and render correctly across ping, message, and chat pages.

The absolute improvement on a fast development machine is modest (each individual reflow is cheap there), but the pattern is what matters: on slow devices and complex pages the savings scale from single-digit milliseconds into hundreds.

Relates to BC5 Performance card: https://app.3.basecamp.com/2914079/buckets/46814732/card_tables/cards/9797897763