### PR TITLE
Isolate lexxy-editor style and layout with CSS containment

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -17,6 +17,13 @@
   position: relative;
   transition: opacity 150ms;
 
+  /* Isolate the editor's style/layout so changes inside don't invalidate the
+     rest of the page. Editor init mutates many descendants (adapter nodes,
+     toolbar, content root) and without containment each mutation invalidates
+     ancestor selectors (`:has()`, cascaded custom properties) across the
+     whole document. */
+  contain: layout style;
+
   p.provisional-paragraph {
     display: block;
 


### PR DESCRIPTION
## Summary

Adds `contain: layout style` to `lexxy-editor` so the editor's style and layout are isolated from its surroundings.

## Why

Editor initialization mutates many descendants (adapter nodes, toolbar, content root) in sequence. Without containment, each mutation invalidates ancestor-dependent selectors (`:has()`, inherited custom properties, descendant combinators) across the whole document, so every style recalc walks the entire document tree.

On a Basecamp chat page with ~13,500 DOM elements, Chrome traces show each editor init firing three style recalcs that each re-examine all ~13,500 elements. With two editors on the page that's six 50ms recalcs during initial render — plus all the post-init recalcs triggered by typing, selection changes, and so on.

## Measurement

Same page, same number of editors, same content.

**Before:** `UpdateLayoutTree` events touching 13,488 elements each, ~50ms per recalc. Total ~593ms across init.
**After:** `UpdateLayoutTree` events touching 6,913 elements each, ~28–35ms per recalc. Total ~365ms across init.

That's a ~38% drop in total style recalc time and ~48% fewer elements re-evaluated per event.

## Safety

`contain: layout style` means:
- The editor's layout computation is independent of its siblings — internal size/position changes never trigger layout outside the editor.
- Style invalidation doesn't cross the boundary in either direction.

Does **not** prevent paint or size containment. The editor still paints normally and its intrinsic size still participates in the page layout. Selection, focus, and cursor positioning all continue to work across the boundary (they're browser-native and unaffected by `contain: layout style`).