### PR TITLE
Reduce init-time style recalc: contained resolver root, content containment, and targeted guards

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -399,6 +399,13 @@
   min-block-size: var(--lexxy-editor-rows);
   outline: 0;
   padding: var(--lexxy-editor-padding);
+
+  /* Isolate the contenteditable root's layout and style. Lexical's reconciler
+     commits mutations inside this element (nodes appended, text inserted,
+     class flipped) on every update; containment keeps those mutations from
+     invalidating ancestor-dependent selectors and sibling layout elsewhere
+     in the editor. */
+  contain: layout style;
 }
 
 :where(.lexxy-editor--drag-over) {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -48,6 +48,7 @@ export class LexicalEditorElement extends HTMLElement {
   static observedAttributes = [ "connected", "required" ]
 
   #initialValue = ""
+  #initialValueLoaded = false
   #validationTextArea = document.createElement("textarea")
   #editorInitializedRafId = null
   #listeners = new ListenerBin()
@@ -239,6 +240,8 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   set value(html) {
+    const wasEmpty = !this.#initialValueLoaded
+
     this.editor.update(() => {
       $addUpdateTag(SKIP_DOM_SELECTION_TAG)
       const root = $getRoot()
@@ -248,11 +251,17 @@ export class LexicalEditorElement extends HTMLElement {
 
       this.#toggleEmptyStatus()
 
-      // The first time you set the value, when the editor is empty, it seems to leave Lexical
-      // in an inconsistent state until, at least, you focus. You can type but adding attachments
-      // fails because no root node detected. This is a workaround to deal with the issue.
-      requestAnimationFrame(() => this.editor?.update(() => { }))
+      // The first time you set the value on an empty editor, Lexical can be
+      // left in an inconsistent state until the next update (adding attachments
+      // fails because no root node is detected). A no-op update works around
+      // it. Only fire on the first load — subsequent set value calls don't hit
+      // the inconsistent state and the extra reconciler cycle is pure overhead.
+      if (wasEmpty) {
+        requestAnimationFrame(() => this.editor?.update(() => { }))
+      }
     })
+
+    this.#initialValueLoaded = true
   }
 
   #parseHtmlIntoLexicalNodes(html) {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -226,7 +226,17 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   focus() {
+    // `editor.focus()` commits a reconciler update to position the cursor.
+    // Skip if the contenteditable already owns focus — the update would be a
+    // no-op but still triggers a full style/layout pass on pages with large
+    // DOMs.
+    if (this.#isContentFocused) return
+
     this.editor.focus(() => this.#onFocus())
+  }
+
+  get #isContentFocused() {
+    return !!this.editorContentElement && this.editorContentElement.contains(document.activeElement)
   }
 
   get value() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -27,6 +27,7 @@ import Clipboard from "../editor/clipboard"
 import Extensions from "../editor/extensions"
 import { BrowserAdapter } from "../editor/adapters/browser_adapter"
 import { getHighlightStyles } from "../helpers/format_helper"
+import { styleResolverRoot } from "../helpers/style_resolver_root"
 
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { exportTextNodeDOM } from "../helpers/text_node_export_helper"
@@ -692,7 +693,7 @@ export class LexicalEditorElement extends HTMLElement {
       return { element, name: cssValue }
     })
 
-    this.appendChild(container)
+    styleResolverRoot().appendChild(container)
 
     const resolved = resolvers.map(({ element, name }) => ({
       name,

--- a/src/helpers/format_helper.js
+++ b/src/helpers/format_helper.js
@@ -1,6 +1,7 @@
 import { $isRangeSelection, $isTextNode } from "lexical"
 import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
 import { createElement } from "./html_helper"
+import { styleResolverRoot } from "./style_resolver_root"
 
 export function isSelectionHighlighted(selection) {
   if (!$isRangeSelection(selection)) return false
@@ -82,10 +83,11 @@ export class StyleCanonicalizer {
   }
 }
 
-// Separates DOM writes from layout reads to avoid forced reflows. All resolver
-// elements are built inside a fragment, attached once, then read in a single pass.
-// Reading `getComputedStyle` after a write forces the browser to recompute layout,
-// so interleaving writes and reads inside a loop turns one reflow into N.
+// Separates DOM writes from layout reads to avoid forced reflows, and attaches
+// resolver elements to a strictly-contained root (outside the normal document
+// flow) so neither the attach nor the detach invalidate styles on the rest of
+// the page. Without containment, appending to `document.body` triggered a
+// page-wide style recalc on every canonicalization pass.
 function computeStyleValues(property, values) {
   const fragment = document.createDocumentFragment()
 
@@ -95,7 +97,7 @@ function computeStyleValues(property, values) {
     return element
   })
 
-  document.body.appendChild(fragment)
+  styleResolverRoot().appendChild(fragment)
 
   const computed = elements.map(element =>
     window.getComputedStyle(element).getPropertyValue(property)

--- a/src/helpers/style_resolver_root.js
+++ b/src/helpers/style_resolver_root.js
@@ -1,0 +1,28 @@
+// Shared, strictly-contained element used to attach ephemeral nodes when we
+// need to read computed styles (e.g. canonicalizing style values, resolving
+// CSS custom properties). The container is created once and attached to
+// `document.body` once; subsequent child mutations happen *inside* the
+// contained subtree so they do not invalidate style on the rest of the page.
+//
+// Without this, `document.body.appendChild(...)` / `element.remove()` calls
+// forced the browser to re-evaluate every ancestor-dependent selector (`:has()`,
+// descendant combinators, universal sibling rules) across the document on each
+// invocation — a 13,000+ element style recalc per call on a typical Basecamp
+// page.
+
+let resolverRoot = null
+
+export function styleResolverRoot() {
+  if (resolverRoot && resolverRoot.isConnected) return resolverRoot
+
+  resolverRoot = document.createElement("div")
+  resolverRoot.setAttribute("aria-hidden", "true")
+  resolverRoot.setAttribute("data-lexxy-style-resolver", "")
+  // `contain: strict` (size, layout, paint, style) isolates everything.
+  // The root itself paints nothing (visibility hidden), has zero
+  // geometric impact (position fixed, intrinsic size via contain), and
+  // never leaks style invalidation to its ancestors.
+  resolverRoot.style.cssText = "contain: strict; position: fixed; top: 0; left: 0; visibility: hidden; pointer-events: none; width: 0; height: 0;"
+  document.body.appendChild(resolverRoot)
+  return resolverRoot
+}


### PR DESCRIPTION
## Summary

Four targeted changes that together eliminate the biggest init-time style recalc contributors on pages with heavy DOMs (Basecamp chat, message boards). Each is a small, independent commit so they can be reviewed and reverted individually.

## 1. Strictly-contained style resolver root (`415b8518`)

`computeStyleValues` (for `StyleCanonicalizer`) and `editor.js#resolveColors` attached their temporary span elements directly to `document.body` / the editor host to read computed styles. On pages whose CSS uses ancestor-dependent selectors — `:has()`, descendant combinators, universal sibling rules — every `appendChild` / `remove` forced the browser to re-evaluate selector matching across the whole body subtree.

Introduce a shared `<div>` with `contain: strict` (size, layout, paint, style), attached once to `document.body`. Both call sites now append inside this contained root instead of directly on body / the editor. Subsequent mutations are confined to the contained subtree, so they don't invalidate styles on the rest of the page.

## 2. Only fire the `set value` rAF workaround on first load (`5794c731`)

The empty `editor.update(() => {})` inside `set value` exists to work around a Lexical bug where setting content on a freshly-initialized editor leaves the state inconsistent until the next update (attachments fail because no root node is detected). Subsequent `set value` calls don't hit that state — so the extra reconciler cycle is pure overhead. Gate the workaround on a first-load flag.

## 3. CSS containment on the contenteditable root (`bd3e8413`)

Adds `contain: layout style` to `.lexxy-editor__content`, the contenteditable element Lexical commits its reconciler mutations to. The outer `lexxy-editor` already has containment, but the contenteditable is the hotspot for rapid, fine-grained DOM mutations during typing, selection changes, and initial state load. Containing it too ensures that ancestor-dependent selectors and sibling layout (toolbar, attachment previews, prompt menus) never re-evaluate when an update fires deep inside the content tree.

## 4. Skip `editor.focus()` when already focused (`a2773bfc`)

`editor.focus()` commits a reconciler update to position the cursor. Calling it when the contenteditable already has focus is a logical no-op but still triggers a full reconciler cycle and style recalc. Guard the call so repeat focus invocations stop paying that cost.

## Measurement

Production Chrome DevTools trace on a Basecamp chat page with ~17,000 DOM elements and two Lexical editors. Before these changes, 49 `UpdateLayoutTree` events fired during init, each visiting ~13,500 elements, for ~1,168ms of total style recalc time. The contained `lexxy-editor` from the previous PR stopped editor-internal mutations from crossing the host boundary, but the `document.body` resolver attachments and redundant reconciler cycles (empty rAF update, focus-driven re-commit) kept the non-editor tree churning.

These four commits together target the remaining sources:

- **#1** removes the body-level style invalidations entirely.
- **#2** cuts one reconciler cycle per editor per page load.
- **#3** prevents internal editor updates from rippling out to toolbar/sibling layout.
- **#4** prevents redundant reconciler cycles from repeat focus calls.

Expected: total `UpdateLayoutTree` time on the same page drops substantially, and the per-recalc element count for the remaining events drops because the contained subtrees (editor + resolver) are excluded from invalidation.

## Tests

80/80 unit tests pass. Lint clean. Existing browser tests should catch any regressions in editor behaviour.