### PR TITLE
Self-heal when turbo:before-cache fires without a body replacement

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -394,8 +394,22 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #handleTurboBeforeCache = (event) => {
-    if (!this.closest("[data-turbo-permanent]")) {
-      this.#reset()
+    if (this.closest("[data-turbo-permanent]")) return
+
+    this.valueBeforeDisconnect = this.value
+    this.#reset()
+
+    // turbo:before-cache can fire without a subsequent body replacement (e.g. when
+    // a Turbo visit's URL matches the current page, or this editor lives inside a
+    // turbo-frame that isn't being rendered). If we're still connected when the
+    // next load fires, reinitialize — otherwise the editor is left with no
+    // contenteditable and the user can't type.
+    registerEventListener(document, "turbo:load", this.#reinitializeIfStranded, { once: true })
+  }
+
+  #reinitializeIfStranded = () => {
+    if (this.isConnected && !this.editorContentElement) {
+      this.connectedCallback()
     }
   }
 

--- a/test/browser/tests/editor/reconnect.test.js
+++ b/test/browser/tests/editor/reconnect.test.js
@@ -43,6 +43,26 @@ test.describe("Reconnect", () => {
     await expect(editorEl.locator("lexxy-table-tools")).toHaveCount(1)
     await expect(editorEl.locator("lexxy-code-language-picker")).toHaveCount(1)
   })
+
+  test("editor recovers when turbo:before-cache fires without a body replacement", async ({ page, editor }) => {
+    await editor.focus()
+    await editor.send("Hello")
+
+    await page.evaluate(() => {
+      document.dispatchEvent(new Event("turbo:before-cache"))
+      document.dispatchEvent(new Event("turbo:load"))
+    })
+
+    await editor.waitForConnected()
+    await expect(page.locator("lexxy-editor .lexxy-editor__content")).toBeVisible()
+
+    await editor.focus()
+    await editor.send(" world")
+
+    const text = await editor.plainTextValue()
+    expect(text).toContain("Hello")
+    expect(text).toContain(" world")
+  })
 })
 
 test.describe("Reconnect with extension toolbar buttons", () => {


### PR DESCRIPTION
## Summary

`turbo:before-cache` can fire on visits that don't actually replace the body — e.g. when the visit's URL matches the current page, or when the editor lives inside a turbo-frame that isn't being rendered. In those cases, the editor's `#reset()` strips the contenteditable but `connectedCallback` never fires again, leaving the user unable to type.

PR #977 addressed one manifestation of this for editors inside `[data-turbo-permanent]`. This PR handles the broader case.

## Reproduction

In Basecamp (BC5), on a card page:

1. Click **Add your comment** to toggle the comment editor open
2. Click the card title to enter edit mode
3. Click **Never Mind** to exit

The comment editor's toolbar remains but the textarea is gone — the contenteditable has been removed, and there's no way back without a full page refresh.

The Turbo event trace is the smoking gun:

```
turbo:before-frame-render → card-details  (edit form → view)
turbo:frame-render / turbo:frame-load
turbo:before-visit → turbo:visit → turbo:before-cache → turbo:load
```

No `turbo:before-render` / `turbo:render` — the body is never swapped. So `#reset()` runs on every `lexxy-editor` on the page, but elements that aren't replaced never get their `connectedCallback` re-fired.

## Fix

- Save `valueBeforeDisconnect` before `#reset()` so any user-typed content survives
- Register a one-shot `turbo:load` listener that reinitializes the editor if it's still connected but missing its `editorContentElement`
- Keep the `[data-turbo-permanent]` skip from #977 — for editors the user is actively typing in, preserving focus/selection is nicer than reset + reinit

## Why not drop `#resetBeforeTurboCaches` entirely?

That would be the purest fix (rely only on `disconnectedCallback`, the actual lifecycle signal — see [basecamp/bc3#10466](https://github.com/basecamp/bc3/pull/10466) for the same-shaped fix in the chat controllers). But the `before-cache` cleanup serves a legitimate purpose: without it, Turbo's cached page snapshot contains the JS-built toolbar + contenteditable, and `connectedCallback` would append duplicates when the user navigates back. So we have to keep cleaning up; we just have to make the cleanup recoverable.

## Test plan

- [x] New Playwright test dispatches `turbo:before-cache` + `turbo:load` without any DOM swap, then verifies the editor recovers and accepts typed input
- [x] All reconnect tests pass (`yarn test:browser:chromium reconnect`)
- [x] Full chromium browser suite passes (317 passed, 2 unrelated attachment flakes)
- [x] Unit tests pass (80/80)
- [x] Manually verified in a local Basecamp dev server with this branch linked: the comment editor survives the Never Mind flow and is typeable afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)