### PR TITLE
Ctrl/cmd+click to open links without `contenteditable=false`

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -68,6 +68,10 @@
     outline-offset: var(--lexxy-focus-ring-offset);
   }
 
+  &[data-links-openable] a {
+    cursor: pointer;
+  }
+
   /* Tables */
   /* ------------------------------------------------------------------------ */
 

--- a/src/extensions/link_opener_extension.js
+++ b/src/extensions/link_opener_extension.js
@@ -1,7 +1,9 @@
-import { defineExtension } from "lexical"
-import { IS_APPLE, mergeRegister } from "@lexical/utils"
-import { registerEventListener } from "../helpers/listener_helper.js"
-import LexxyExtension from "./lexxy_extension.js"
+import { $findMatchingParent, $getNearestNodeFromDOMNode, CLICK_COMMAND, COMMAND_PRIORITY_NORMAL, defineExtension, mergeRegister } from "lexical"
+import { $isLinkNode } from "@lexical/link"
+import { IS_APPLE } from "@lexical/utils"
+import { registerEventListener } from "../helpers/listener_helper"
+import { delay } from "../helpers/timing_helpers"
+import LexxyExtension from "./lexxy_extension"
 
 export class LinkOpenerExtension extends LexxyExtension {
   get enabled() {
@@ -11,53 +13,57 @@ export class LinkOpenerExtension extends LexxyExtension {
   get lexicalExtension() {
     return defineExtension({
       name: "lexxy/link-opener",
-      register: () => {
-        return mergeRegister(
-          registerEventListener(window, "keydown", this.#update.bind(this)),
-          registerEventListener(window, "keyup", this.#update.bind(this)),
-          registerEventListener(window, "blur", this.#disable.bind(this)),
-          registerEventListener(window, "focus", this.#refresh.bind(this))
-        )
-      }
+      register: (editor) => mergeRegister(
+        editor.registerCommand(CLICK_COMMAND, this.#handleClick.bind(this), COMMAND_PRIORITY_NORMAL),
+        registerEventListener(this.editorElement.editorContentElement, "auxclick", this.#handleAuxClick.bind(this)),
+        registerEventListener(window, "keydown", this.#handleKey.bind(this)),
+        registerEventListener(window, "keyup", this.#handleKey.bind(this)),
+        registerEventListener(window, "focus", this.#handleFocus.bind(this))
+      )
     })
   }
 
-  #update(event) {
+  #handleClick(event) {
     if (this.#isModified(event)) {
-      this.#enable()
+      return $openLink(event.target)
     } else {
-      this.#disable()
+      return false
     }
   }
 
-  #refresh() {
-    // Chrome dispatches events without modifier keys *for a while* after changing tabs
-    setTimeout(() => {
-      window.addEventListener("mousemove", this.#update.bind(this), { once: true })
-    }, 200)
+  #handleAuxClick(event) {
+    if (event.button === 1) {
+      this.editorElement.editor.read(() => $openLink(event.target))
+    }
+  }
+
+  #handleKey(event) {
+    this.#updateOpenableAttribute(event)
+  }
+
+  // Chrome dispatches events without modifier keys *for a while* after changing tabs
+  async #handleFocus() {
+    await delay(200)
+    this.editorElement.addEventListener("mousemove", this.#updateOpenableAttribute.bind(this), { once: true })
+  }
+
+  #updateOpenableAttribute(event) {
+    this.editorElement.toggleAttribute("data-links-openable", this.#isModified(event))
   }
 
   #isModified(event) {
     return IS_APPLE ? event.metaKey : event.ctrlKey
   }
+}
 
-  #enable() {
-    for (const anchor of this.#anchors) {
-      anchor.setAttribute("contenteditable", "false")
-      anchor.setAttribute("target", "_blank")
-      anchor.setAttribute("rel", "noopener noreferrer")
-    }
-  }
-
-  #disable() {
-    for (const anchor of this.#anchors) {
-      anchor.removeAttribute("contenteditable")
-      anchor.removeAttribute("target")
-      anchor.removeAttribute("rel")
-    }
-  }
-
-  get #anchors() {
-    return this.editorElement.editorContentElement?.querySelectorAll("a") ?? []
+function $openLink(target) {
+  const node = $getNearestNodeFromDOMNode(target)
+  const linkNode = $findMatchingParent(node, $isLinkNode)
+  if (linkNode) {
+    const url = linkNode.sanitizeUrl(linkNode.getURL())
+    window.open(url, "_blank", "noopener,noreferrer")
+    return true
+  } else {
+    return false
   }
 }

--- a/src/helpers/timing_helpers.js
+++ b/src/helpers/timing_helpers.js
@@ -26,6 +26,10 @@ export function debounceAsync(fn, wait) {
   }
 }
 
+export function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 export function nextFrame() {
   return new Promise(requestAnimationFrame)
 }

--- a/test/browser/tests/editor/link_opener.test.js
+++ b/test/browser/tests/editor/link_opener.test.js
@@ -11,50 +11,40 @@ test.describe("Link opener", () => {
     await editor.flush()
   })
 
-  test("holding modifier makes links non-editable", async ({ page, editor }) => {
+  test("modifier+click opens the link in a new tab", async ({ editor, context }) => {
     const anchor = editor.content.locator("a")
 
-    await expect(anchor).not.toHaveAttribute("contenteditable")
-    await page.keyboard.down(modifier)
-    await expect(anchor).toHaveAttribute("contenteditable", "false")
-    await page.keyboard.up(modifier)
-    await expect(anchor).not.toHaveAttribute("contenteditable")
+    const [newPage] = await Promise.all([
+      context.waitForEvent("page"),
+      anchor.click({ modifiers: [modifier] }),
+    ])
+
+    await newPage.waitForLoadState("load")
+    expect(newPage.url()).toBe("https://example.com/")
   })
 
-  test("holding modifier sets target and rel on links", async ({ page, editor }) => {
+  test("plain click does not open the link", async ({ editor, context }) => {
     const anchor = editor.content.locator("a")
 
-    await page.keyboard.down(modifier)
-    await expect(anchor).toHaveAttribute("target", "_blank")
-    await expect(anchor).toHaveAttribute("rel", "noopener noreferrer")
-    await page.keyboard.up(modifier)
-    await expect(anchor).not.toHaveAttribute("target")
-    await expect(anchor).not.toHaveAttribute("rel")
+    await anchor.click()
+    const newPage = await context.waitForEvent("page", { timeout: 200 }).catch(() => null)
+
+    expect(newPage).toBeNull()
   })
 
-  test("applies to all links in the editor", async ({ editor, page }) => {
-    await editor.setValue(
-      '<p><a href="https://a.com">first</a> and <a href="https://b.com">second</a></p>',
-    )
-    await editor.flush()
-
-    const anchors = editor.content.locator("a")
-
+  test("holding modifier sets data-links-openable on the editor", async ({ page, editor }) => {
+    await expect(editor.locator).not.toHaveAttribute("data-links-openable")
     await page.keyboard.down(modifier)
-    await expect(anchors.nth(0)).toHaveAttribute("contenteditable", "false")
-    await expect(anchors.nth(1)).toHaveAttribute("contenteditable", "false")
+    await expect(editor.locator).toHaveAttribute("data-links-openable")
     await page.keyboard.up(modifier)
-    await expect(anchors.nth(0)).not.toHaveAttribute("contenteditable")
-    await expect(anchors.nth(1)).not.toHaveAttribute("contenteditable")
+    await expect(editor.locator).not.toHaveAttribute("data-links-openable")
   })
 
-  test("clears link attributes on window blur", async ({ page, editor }) => {
+  test("does not set contenteditable on links when modifier is held", async ({ page, editor }) => {
     const anchor = editor.content.locator("a")
 
     await page.keyboard.down(modifier)
-    await expect(anchor).toHaveAttribute("contenteditable", "false")
-
-    await page.evaluate(() => window.dispatchEvent(new Event("blur")))
     await expect(anchor).not.toHaveAttribute("contenteditable")
+    await page.keyboard.up(modifier)
   })
 })


### PR DESCRIPTION
The current [link opener](https://github.com/basecamp/lexxy/pull/976) has [issues with cursor movement](https://app.3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9798515282#__recording_9803371340).

Replaces that with a `CLICK_COMMAND` and separate modifier key tracking for cursor styling. Threw in an `auxclick` handler for opening with middle-mouse.