### PR TITLE
Skip no-op aria-pressed/aria-disabled writes on toolbar buttons

### DIFF
--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -94,7 +94,10 @@ export class HighlightDropdown extends ToolbarDropdown {
 
     this.#colorButtons.forEach(button => {
       const matchesSelection = button.dataset.value === textColor || button.dataset.value === backgroundColor
-      button.setAttribute("aria-pressed", matchesSelection)
+      const next = matchesSelection.toString()
+      if (button.getAttribute("aria-pressed") !== next) {
+        button.setAttribute("aria-pressed", next)
+      }
     })
 
     const hasHighlight = textColor !== NO_STYLE || backgroundColor !== NO_STYLE

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -224,7 +224,7 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   #selectOption(listItem) {
-    this.#clearSelection()
+    this.#clearListItemSelection()
     listItem.toggleAttribute("aria-selected", true)
     listItem.scrollIntoView({ block: "nearest", behavior: "smooth" })
     listItem.focus()
@@ -234,16 +234,26 @@ export class LexicalPromptElement extends HTMLElement {
       this.#editorElement.focus()
     })
 
-    this.#editorContentElement.setAttribute("aria-controls", this.popoverElement.id)
-    this.#editorContentElement.setAttribute("aria-activedescendant", listItem.id)
-    this.#editorContentElement.setAttribute("aria-haspopup", "listbox")
+    this.#setEditorAssociationAttribute("aria-controls", this.popoverElement.id)
+    this.#setEditorAssociationAttribute("aria-activedescendant", listItem.id)
+    this.#setEditorAssociationAttribute("aria-haspopup", "listbox")
+  }
+
+  #clearListItemSelection() {
+    this.#listItemElements.forEach((item) => { item.toggleAttribute("aria-selected", false) })
   }
 
   #clearSelection() {
-    this.#listItemElements.forEach((item) => { item.toggleAttribute("aria-selected", false) })
+    this.#clearListItemSelection()
     this.#editorContentElement.removeAttribute("aria-controls")
     this.#editorContentElement.removeAttribute("aria-activedescendant")
     this.#editorContentElement.removeAttribute("aria-haspopup")
+  }
+
+  #setEditorAssociationAttribute(name, value) {
+    if (this.#editorContentElement.getAttribute(name) !== value) {
+      this.#editorContentElement.setAttribute(name, value)
+    }
   }
 
   #positionPopover() {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -240,15 +240,23 @@ export class LexicalToolbarElement extends HTMLElement {
   #setButtonPressed(name, isPressed) {
     const button = this.querySelector(`[name="${name}"]`)
     if (button) {
-      button.setAttribute("aria-pressed", isPressed.toString())
+      const next = isPressed.toString()
+      if (button.getAttribute("aria-pressed") !== next) {
+        button.setAttribute("aria-pressed", next)
+      }
     }
   }
 
   #setButtonDisabled(name, isDisabled) {
     const button = this.querySelector(`[name="${name}"]`)
     if (button) {
-      button.disabled = isDisabled
-      button.setAttribute("aria-disabled", isDisabled.toString())
+      if (button.disabled !== isDisabled) {
+        button.disabled = isDisabled
+      }
+      const next = isDisabled.toString()
+      if (button.getAttribute("aria-disabled") !== next) {
+        button.setAttribute("aria-disabled", next)
+      }
     }
   }
 


### PR DESCRIPTION
### Summary

The toolbar registers a Lexical registerUpdateListener that fires on every editor update — i.e., every keystroke — and unconditionally rewrites aria-pressed on ~16 toolbar buttons, aria-disabled on undo/redo, and aria-pressed on the color buttons in the highlight dropdown. Most of these writes are no-ops value-wise ("false" → "false"), but Chrome still invalidates element style on every setAttribute call.

Under normal conditions this is cheap. When another part of the page triggers a global style invalidation in the same frame as a keystroke (e.g. a Turbo broadcast-refresh flipping aria-busy on <html>), each no-op write forces Chrome to flush the pending recalc synchronously to commit the attribute change. With ~20 writes per keystroke and ~2.3k descendants to restyle, the cost piles up into hundreds of ms of blocking per keystroke.

Gating each write on an actual value change eliminates the no-op cost.

### Measured impact

Reproduction: Basecamp card table (~3.2k element DOM) open in one tab, new-card modal with Lexxy notes field focused in a second tab. A background script moves cards in the first tab once per second, which triggers broadcast_refresh_later on every move and morphs <html>[aria-busy] on every descendant.

Per-keystroke cost (median over ~150 real keystrokes, measured from beforeinput to post-rAF macrotask):

```
┌──────────────────────────┬────────┬──────────┬──────────┬────────┐
│        Condition         │  p50   │   p90    │   p99    │  avg   │
├──────────────────────────┼────────┼──────────┼──────────┼────────┤
│ Lexxy, no churn          │  14 ms │    50 ms │   108 ms │  24 ms │
├──────────────────────────┼────────┼──────────┼──────────┼────────┤
│ Lexxy, churn on — before │ 591 ms │ 1,300 ms │ 1,806 ms │ 670 ms │
├──────────────────────────┼────────┼──────────┼──────────┼────────┤
│ Lexxy, churn on — after  │ 219 ms │   602 ms │ 1,725 ms │ 290 ms │
├──────────────────────────┼────────┼──────────┼──────────┼────────┤
│ Relative change          │  −63 % │    −54 % │     −4 % │  −57 % │
└──────────────────────────┴────────┴──────────┴──────────┴────────┘
```

Plain <input> in the same modal under the same churn: p50 36 ms, p90 437 ms — confirming the broadcast-induced style invalidation is the trigger; the patch addresses Lexxy's amplifier on top of that.

### Change

- src/elements/toolbar.js — #setButtonPressed / #setButtonDisabled read before writing and skip if the attribute is already in the target state.
- src/elements/dropdown/highlight.js — same guard on the color buttons' aria-pressed.

Observable behavior is unchanged: attribute values end at the same state as before; only redundant writes are skipped.

### Tests

- yarn lint — clean
- yarn test (Vitest) — 80/80 passed
- yarn test:browser:chromium (Playwright) — 315 passed (3 preexisting flakes in attachments.test.js, unrelated)