### PR TITLE
Expose allowed style properties via extensions

### DIFF
--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -2,37 +2,7 @@ import DOMPurify from "dompurify"
 import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
 
 const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
-
 const DEFAULT_ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
-
-let allowedStyleProperties = new Set(DEFAULT_ALLOWED_STYLE_PROPERTIES)
-
-function styleFilterHook(_currentNode, hookEvent) {
-  if (hookEvent.attrName === "style" && hookEvent.attrValue) {
-    const styles = { ...getStyleObjectFromCSS(hookEvent.attrValue) }
-    const sanitizedStyles = { }
-
-    for (const property in styles) {
-      if (allowedStyleProperties.has(property)) {
-        sanitizedStyles[property] = styles[property]
-      }
-    }
-
-    if (Object.keys(sanitizedStyles).length) {
-      hookEvent.attrValue = getCSSFromStyleObject(sanitizedStyles)
-    } else {
-      hookEvent.keepAttr = false
-    }
-  }
-}
-
-DOMPurify.addHook("uponSanitizeAttribute", styleFilterHook)
-
-DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-  if (data.tagName === "strong" || data.tagName === "em") {
-    node.removeAttribute("class")
-  }
-})
 
 export { DOMPurify }
 
@@ -48,13 +18,46 @@ export function buildConfig(allowedElements, allowedStyles = []) {
     }
   }
 
-  allowedStyleProperties = new Set([ ...DEFAULT_ALLOWED_STYLE_PROPERTIES, ...allowedStyles ])
+  const allowedStyleProperties = new Set([ ...DEFAULT_ALLOWED_STYLE_PROPERTIES, ...allowedStyles ])
 
   return {
-    ALLOWED_TAGS: Object.keys(tagAttributes),
-    ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
-    ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
-    ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
-    SAFE_FOR_XML: false // So that it does not strip attributes that contains serialized HTML (like content)
+    config: {
+      ALLOWED_TAGS: Object.keys(tagAttributes),
+      ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
+      ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
+      ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
+      SAFE_FOR_XML: false // So that it does not strip attributes that contains serialized HTML (like content)
+    },
+    hooks: {
+      uponSanitizeAttribute: buildStyleFilterHook(allowedStyleProperties),
+      uponSanitizeElement: stripInlineFormattingClass
+    }
+  }
+}
+
+function buildStyleFilterHook(allowedStyleProperties) {
+  return (_currentNode, hookEvent) => {
+    if (hookEvent.attrName !== "style" || !hookEvent.attrValue) return
+
+    const styles = { ...getStyleObjectFromCSS(hookEvent.attrValue) }
+    const sanitizedStyles = {}
+
+    for (const property in styles) {
+      if (allowedStyleProperties.has(property)) {
+        sanitizedStyles[property] = styles[property]
+      }
+    }
+
+    if (Object.keys(sanitizedStyles).length) {
+      hookEvent.attrValue = getCSSFromStyleObject(sanitizedStyles)
+    } else {
+      hookEvent.keepAttr = false
+    }
+  }
+}
+
+function stripInlineFormattingClass(node, data) {
+  if (data.tagName === "strong" || data.tagName === "em") {
+    node.removeAttribute("class")
   }
 }

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -3,7 +3,9 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 
 const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
 
-const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
+const DEFAULT_ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
+
+let allowedStyleProperties = new Set(DEFAULT_ALLOWED_STYLE_PROPERTIES)
 
 function styleFilterHook(_currentNode, hookEvent) {
   if (hookEvent.attrName === "style" && hookEvent.attrValue) {
@@ -11,7 +13,7 @@ function styleFilterHook(_currentNode, hookEvent) {
     const sanitizedStyles = { }
 
     for (const property in styles) {
-      if (ALLOWED_STYLE_PROPERTIES.includes(property)) {
+      if (allowedStyleProperties.has(property)) {
         sanitizedStyles[property] = styles[property]
       }
     }
@@ -34,7 +36,7 @@ DOMPurify.addHook("uponSanitizeElement", (node, data) => {
 
 export { DOMPurify }
 
-export function buildConfig(allowedElements ) {
+export function buildConfig(allowedElements, allowedStyles = []) {
   const tagAttributes = {}
 
   for (const element of allowedElements) {
@@ -45,6 +47,8 @@ export function buildConfig(allowedElements ) {
       tagAttributes[element.tag].push(...element.attributes)
     }
   }
+
+  allowedStyleProperties = new Set([ ...DEFAULT_ALLOWED_STYLE_PROPERTIES, ...allowedStyles ])
 
   return {
     ALLOWED_TAGS: Object.keys(tagAttributes),

--- a/src/editor/extensions.js
+++ b/src/editor/extensions.js
@@ -47,6 +47,10 @@ export default class Extensions {
     return this.enabledExtensions.flatMap(ext => ext.allowedElements)
   }
 
+  get allowedStyles() {
+    return this.enabledExtensions.flatMap(ext => ext.allowedStyles)
+  }
+
   get #lexxyToolbar() {
     return this.lexxyElement.toolbar
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -751,7 +751,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #configureSanitizer(editor) {
-    setSanitizerConfig(this.#getAllowedElements(editor))
+    setSanitizerConfig(this.#getAllowedElements(editor), this.extensions.allowedStyles)
   }
 
   #getAllowedElements(editor) {

--- a/src/extensions/lexxy_extension.js
+++ b/src/extensions/lexxy_extension.js
@@ -26,6 +26,10 @@ export default class LexxyExtension {
     return []
   }
 
+  get allowedStyles() {
+    return []
+  }
+
   initializeToolbar(_lexxyToolbar) {
 
   }

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -1,8 +1,8 @@
 import { DOMPurify, buildConfig } from "../config/dom_purify"
 
-export function setSanitizerConfig(allowedTags) {
+export function setSanitizerConfig(allowedTags, allowedStyles = []) {
   DOMPurify.clearConfig()
-  DOMPurify.setConfig(buildConfig(allowedTags))
+  DOMPurify.setConfig(buildConfig(allowedTags, allowedStyles))
 }
 
 export function sanitize(html) {

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -1,10 +1,31 @@
 import { DOMPurify, buildConfig } from "../config/dom_purify"
 
+let currentHooks = {}
+const registeredHookEvents = new Set()
+
 export function setSanitizerConfig(allowedTags, allowedStyles = []) {
+  const { config, hooks } = buildConfig(allowedTags, allowedStyles)
+
+  currentHooks = hooks
+  for (const event of Object.keys(hooks)) {
+    ensureHookRegistered(event)
+  }
+
   DOMPurify.clearConfig()
-  DOMPurify.setConfig(buildConfig(allowedTags, allowedStyles))
+  DOMPurify.setConfig(config)
 }
 
 export function sanitize(html) {
   return DOMPurify.sanitize(html)
+}
+
+function ensureHookRegistered(event) {
+  if (registeredHookEvents.has(event)) return
+
+  DOMPurify.addHook(event, (...args) => {
+    const hook = currentHooks[event]
+    if (typeof hook === "function") return hook(...args)
+  })
+
+  registeredHookEvents.add(event)
 }

--- a/test/javascript/unit/config/dom_purify.test.js
+++ b/test/javascript/unit/config/dom_purify.test.js
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest"
+import { DOMPurify, buildConfig } from "src/config/dom_purify"
+
+function configure(allowedElements, allowedStyles) {
+  DOMPurify.clearConfig()
+  DOMPurify.setConfig(buildConfig(allowedElements, allowedStyles))
+}
+
+test("buildConfig exposes allowed tags", () => {
+  const config = buildConfig([ "p", "strong" ])
+  expect(config.ALLOWED_TAGS).toEqual([ "p", "strong" ])
+})
+
+test("keeps default style properties when allowedStyles is omitted", () => {
+  configure([ "p" ])
+  const sanitized = DOMPurify.sanitize('<p style="color: red; font-weight: bold;">x</p>')
+  expect(sanitized).toContain("color: red")
+  expect(sanitized).not.toContain("font-weight")
+})
+
+test("allowedStyles extends the default style allowlist", () => {
+  configure([ "p" ], [ "font-weight", "text-align" ])
+  const sanitized = DOMPurify.sanitize('<p style="font-weight: bold; text-align: center; line-height: 2;">x</p>')
+  expect(sanitized).toContain("font-weight: bold")
+  expect(sanitized).toContain("text-align: center")
+  expect(sanitized).not.toContain("line-height")
+})
+
+test("text-align is not allowed by default", () => {
+  configure([ "p" ])
+  const sanitized = DOMPurify.sanitize('<p style="text-align: center;">x</p>')
+  expect(sanitized).not.toContain("text-align")
+})
+
+test("rebuilding without extra styles restores the default allowlist", () => {
+  configure([ "p" ], [ "font-weight" ])
+  configure([ "p" ])
+  const sanitized = DOMPurify.sanitize('<p style="font-weight: bold; color: red;">x</p>')
+  expect(sanitized).not.toContain("font-weight")
+  expect(sanitized).toContain("color: red")
+})

--- a/test/javascript/unit/config/dom_purify.test.js
+++ b/test/javascript/unit/config/dom_purify.test.js
@@ -1,25 +1,27 @@
 import { expect, test } from "vitest"
 import { DOMPurify, buildConfig } from "src/config/dom_purify"
+import { setSanitizerConfig } from "src/helpers/sanitization_helper"
 
-function configure(allowedElements, allowedStyles) {
-  DOMPurify.clearConfig()
-  DOMPurify.setConfig(buildConfig(allowedElements, allowedStyles))
-}
-
-test("buildConfig exposes allowed tags", () => {
-  const config = buildConfig([ "p", "strong" ])
+test("buildConfig exposes allowed tags on the config object", () => {
+  const { config } = buildConfig([ "p", "strong" ])
   expect(config.ALLOWED_TAGS).toEqual([ "p", "strong" ])
 })
 
+test("buildConfig returns hooks alongside config", () => {
+  const { hooks } = buildConfig([ "p" ])
+  expect(typeof hooks.uponSanitizeAttribute).toBe("function")
+  expect(typeof hooks.uponSanitizeElement).toBe("function")
+})
+
 test("keeps default style properties when allowedStyles is omitted", () => {
-  configure([ "p" ])
+  setSanitizerConfig([ "p" ])
   const sanitized = DOMPurify.sanitize('<p style="color: red; font-weight: bold;">x</p>')
   expect(sanitized).toContain("color: red")
   expect(sanitized).not.toContain("font-weight")
 })
 
 test("allowedStyles extends the default style allowlist", () => {
-  configure([ "p" ], [ "font-weight", "text-align" ])
+  setSanitizerConfig([ "p" ], [ "font-weight", "text-align" ])
   const sanitized = DOMPurify.sanitize('<p style="font-weight: bold; text-align: center; line-height: 2;">x</p>')
   expect(sanitized).toContain("font-weight: bold")
   expect(sanitized).toContain("text-align: center")
@@ -27,15 +29,35 @@ test("allowedStyles extends the default style allowlist", () => {
 })
 
 test("text-align is not allowed by default", () => {
-  configure([ "p" ])
+  setSanitizerConfig([ "p" ])
   const sanitized = DOMPurify.sanitize('<p style="text-align: center;">x</p>')
   expect(sanitized).not.toContain("text-align")
 })
 
 test("rebuilding without extra styles restores the default allowlist", () => {
-  configure([ "p" ], [ "font-weight" ])
-  configure([ "p" ])
+  setSanitizerConfig([ "p" ], [ "font-weight" ])
+  setSanitizerConfig([ "p" ])
   const sanitized = DOMPurify.sanitize('<p style="font-weight: bold; color: red;">x</p>')
   expect(sanitized).not.toContain("font-weight")
   expect(sanitized).toContain("color: red")
+})
+
+test("strips class attribute from strong/em via uponSanitizeElement hook", () => {
+  setSanitizerConfig([ "strong", "em" ])
+  const sanitized = DOMPurify.sanitize('<strong class="bold">x</strong><em class="italic">y</em>')
+  expect(sanitized).not.toContain("class")
+})
+
+test("preserves host-registered DOMPurify hooks across reconfiguration", () => {
+  let externalHookCalls = 0
+  const externalHook = () => { externalHookCalls++ }
+  DOMPurify.addHook("uponSanitizeElement", externalHook)
+
+  try {
+    setSanitizerConfig([ "p" ])
+    DOMPurify.sanitize("<p>hello</p>")
+    expect(externalHookCalls).toBeGreaterThan(0)
+  } finally {
+    DOMPurify.removeHook("uponSanitizeElement", externalHook)
+  }
 })


### PR DESCRIPTION
## Summary
- Extensions can now contribute allowed CSS properties through an `allowedStyles` getter, mirroring how `allowedElements` contributes tags/attributes.
- Default style allowlist remains `color` and `background-color`. Anything beyond that (e.g. `text-align`, `font-weight`) is opt-in per-extension.
- `buildConfig` becomes a pure function returning `{ config, hooks }`. `sanitization_helper` removes previous hooks and registers the fresh ones before applying the DOMPurify config — no more module-level mutable state or import-time `addHook` side effects.

## Motivation
Host apps embedding Lexxy sometimes need additional style properties sanitized through (e.g. text alignment, custom typography) without forking the editor or exposing the full `style` attribute. This mirrors the existing `allowedElements` extension hook so the same pattern works for both tags/attributes and styles.

## Usage
```js
class MyExtension extends LexxyExtension {
  get allowedStyles() { return [ "text-align", "font-weight" ] }
}
```

## Test plan
- [x] \`yarn test --run\` — 87/87 pass (added unit tests for default filtering, opt-in, rebuild reset, strong/em class stripping, and hook shape)
- [x] \`yarn lint\` — clean
- [x] \`yarn build\` — rollup bundle rebuilt