### PR TITLE
Coalesce per-keystroke update listeners to the next animation frame

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -20,6 +20,7 @@ import { createElement, dispatch, generateDomId, parseHtml } from "../helpers/ht
 import { isAttachmentSpacerTextNode } from "../helpers/lexical_helper"
 import { sanitize, setSanitizerConfig } from "../helpers/sanitization_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
+import { coalesceOnFrame } from "../helpers/timing_helpers"
 import LexicalToolbar from "./toolbar"
 import Configuration from "../editor/configuration"
 import Contents from "../editor/contents"
@@ -420,13 +421,14 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #synchronizeWithChanges() {
-    this.#listeners.track(this.editor.registerUpdateListener(({ editorState }) => {
+    const synchronize = coalesceOnFrame(() => {
       this.#clearCachedValues()
       this.#internalFormValue = this.value
       this.#toggleEmptyStatus()
       this.#setValidity()
       this.#dispatchAttributesChange()
-    }))
+    })
+    this.#listeners.track(this.editor.registerUpdateListener(synchronize))
   }
 
   #clearCachedValues() {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -8,6 +8,7 @@ import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 import { handleRollingTabIndex } from "../helpers/accessibility_helper"
 import ToolbarIcons from "./toolbar_icons"
 import { isActiveAndVisible } from "../helpers/html_helper"
+import { coalesceOnFrame } from "../helpers/timing_helpers"
 
 export class LexicalToolbarElement extends HTMLElement {
   static observedAttributes = [ "connected" ]
@@ -178,18 +179,18 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #monitorSelectionChanges() {
-    this.#listeners.track(this.editor.registerUpdateListener(() => {
+    const refresh = coalesceOnFrame(() => {
       this.editor.getEditorState().read(() => {
         this.#updateButtonStates()
         this.#closeDropdowns()
       })
-    }))
+    })
+    this.#listeners.track(this.editor.registerUpdateListener(refresh))
   }
 
   #monitorHistoryChanges() {
-    this.#listeners.track(this.editor.registerUpdateListener(() => {
-      this.#updateUndoRedoButtonStates()
-    }))
+    const refresh = coalesceOnFrame(() => this.#updateUndoRedoButtonStates())
+    this.#listeners.track(this.editor.registerUpdateListener(refresh))
   }
 
   #updateUndoRedoButtonStates() {

--- a/src/helpers/timing_helpers.js
+++ b/src/helpers/timing_helpers.js
@@ -33,3 +33,25 @@ export function delay(ms) {
 export function nextFrame() {
   return new Promise(requestAnimationFrame)
 }
+
+// Wraps `fn` so that repeated invocations within the same animation frame
+// collapse into a single call on the next frame, using the latest arguments.
+// Useful for observer callbacks (e.g. Lexical `registerUpdateListener`) that
+// reflect editor state to UI and don't need to run synchronously inside the
+// triggering event's frame.
+export function coalesceOnFrame(fn) {
+  let rafId = null
+  let latestArgs = null
+
+  return function (...args) {
+    latestArgs = args
+    if (rafId !== null) return
+
+    rafId = requestAnimationFrame(() => {
+      rafId = null
+      const call = latestArgs
+      latestArgs = null
+      fn.apply(this, call)
+    })
+  }
+}


### PR DESCRIPTION
### Summary

Three Lexical registerUpdateListener callbacks run synchronously on every editor update (i.e. every keystroke):

- LexicalToolbarElement#monitorSelectionChanges → walks the selection, refreshes aria-pressed/aria-disabled on ~16 toolbar buttons, closes dropdowns.
- LexicalToolbarElement#monitorHistoryChanges → refreshes undo/redo button state.
- LexicalEditorElement#synchronizeWithChanges → re-serializes the editor to HTML via this.value, updates the internal form value, re-runs the validity check, and dispatches lexxy:change.

None of this observer work needs to land in the same frame as the triggering keystroke. A one-frame deferral is imperceptible to users (the toolbar's pressed state ~16 ms late, a lexxy:change event ~16 ms late) but pulls the work off the
input-handling critical path — which matters when the page is under layout-invalidation pressure from something else (e.g. a Turbo broadcast-refresh flipping aria-busy on <html>). Under that pressure, every DOM mutation the listeners do forces
Chrome to flush a pending full-document style recalc; deferring them means the keystroke frame only pays for the Lexical reconciler's own minimal writes plus the browser's caret layout.

Add a small coalesceOnFrame(fn) helper in timing_helpers.js that collapses repeated calls within a single animation frame into one invocation on the next frame (using the latest arguments). Wrap each of the three update listeners with it.

This is independent of (and stacks with) #1001, but either can land first.

### Measured impact

Reproduction: Basecamp card table (~3.2k element DOM) open in one tab, new-card modal with a Lexxy notes field focused in another. A background script moves cards once per second, causing a Turbo broadcast_refresh_later each time, which flips
aria-busy on <html> and invalidates style on ~2.3k descendants.

Per-keystroke cost (median over ~150–220 real keystrokes, measured from beforeinput to post-rAF macrotask):

```
┌─────────────────────────────────────────────────────┬────────┬──────────┬──────────┬────────┬──────────────────────┐
│                      Condition                      │  p50   │   p90    │   p99    │  avg   │ Long tasks in sample │
├─────────────────────────────────────────────────────┼────────┼──────────┼──────────┼────────┼──────────────────────┤
│ Lexxy, no churn (baseline)                          │  14 ms │    50 ms │   108 ms │  24 ms │                    0 │
├─────────────────────────────────────────────────────┼────────┼──────────┼──────────┼────────┼──────────────────────┤
│ Lexxy, churn on — unpatched                         │ 591 ms │ 1,300 ms │ 1,806 ms │ 670 ms │                   70 │
├─────────────────────────────────────────────────────┼────────┼──────────┼──────────┼────────┼──────────────────────┤
│ Lexxy, churn on — #1001 only (aria-write guard)     │ 219 ms │   602 ms │ 1,725 ms │ 290 ms │                  104 │
├─────────────────────────────────────────────────────┼────────┼──────────┼──────────┼────────┼──────────────────────┤
│ Lexxy, churn on — this PR + #1001, run 1 (174 keys) │  17 ms │    34 ms │    55 ms │  19 ms │                   10 │
├─────────────────────────────────────────────────────┼────────┼──────────┼──────────┼────────┼──────────────────────┤
│ Lexxy, churn on — this PR + #1001, run 2 (220 keys) │  15 ms │    32 ms │    68 ms │  19 ms │                   27 │
└─────────────────────────────────────────────────────┴────────┴──────────┴──────────┴────────┴──────────────────────┘
```

For reference, a plain <input> in the same modal under the same churn measured p50 36 ms, p90 437 ms — so with both patches applied, Lexxy is faster than a native input under the same load and sits within a few ms of its own no-churn baseline
at the median.

### Change

- src/helpers/timing_helpers.js — new coalesceOnFrame(fn) helper: returns a wrapped function that, when called repeatedly in one frame, runs fn at most once on the next frame with the most recent arguments.
- src/elements/toolbar.js — #monitorSelectionChanges and #monitorHistoryChanges wrap their registerUpdateListener callbacks with coalesceOnFrame.
- src/elements/editor.js — #synchronizeWithChanges does the same.

Observable behavior is unchanged: toolbar state still reflects the current selection, the internal form value still tracks content, lexxy:change still fires on real content changes. The only difference is a one-frame deferral of these observer
effects.

Tests

- yarn lint — clean
- `yarn test` (Vitest) — 80/80 passed
- `yarn test:browser:chromium` (Playwright) — 314 passed, 4 flaky in `attachments/*` (same preexisting flakes observed on #1001 and on `main`; unrelated to this change — they pass on retry)