### PR TITLE
Honor permitted-attachment-types across the editor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,9 +45,10 @@ Editors support the following options, configurable using presets and element at
 
 - `toolbar`: Pass `false` to disable the toolbar entirely, pass the ID of a `<lexxy-toolbar>` element to use as an external toolbar, or pass an object to configure individual toolbar buttons. By default, the toolbar is bootstrapped and displayed above the editor.
   - `toolbar.upload`: Control which upload button(s) appear in the toolbar. Accepts `"file"`, `"image"`, or `"both"` (default). The image button restricts the file picker to images and videos (`accept="image/*,video/*"`), which triggers the native photo/video picker on iOS and Android. The file button opens an unrestricted file picker.
-- `attachments`: Pass `false` to disable attachments completely. By default, attachments are supported, including paste and drag & drop support.
+- `attachments`: Pass `false` to disable attachments completely. By default, attachments are supported, including paste and drag & drop support. For finer-grained control — keeping attachments enabled while restricting which content types are accepted — use `permittedAttachmentTypes`.
 - `markdown`: Pass `false` to disable Markdown support.
 - `multiLine`: Pass `false` to force single line editing.
+- `permittedAttachmentTypes`: Restrict the editor to a specific allowlist of attachment content types. Unset (the default) permits any content type. Example: `<lexxy-editor permitted-attachment-types="application/vnd.basecamp.mention application/vnd.basecamp.opengraph-embed"></lexxy-editor>`.
 - `richText`: Pass `false` to disable rich text editing.
 
 The toolbar is considered part of the editor for `lexxy:focus` and `lexxy:blur` events. If the toolbar registers event or lexical handlers, it should expose a `dispose()` function which will be called on editor disconnect.

--- a/docs/events.md
+++ b/docs/events.md
@@ -32,6 +32,7 @@ Fired when a file is dropped or inserted into the editor.
 
 - Access the file via `event.detail.file`.
 - Call `event.preventDefault()` to cancel the upload and prevent attaching the file.
+- Lexxy itself listens for this event to enforce `permittedAttachmentTypes` and will call `event.preventDefault()` for files whose MIME type is not in the allowlist.
 
 ## `lexxy:upload-start`
 

--- a/docs/prompts/inline-attachments.md
+++ b/docs/prompts/inline-attachments.md
@@ -57,3 +57,4 @@ Two important additional notes to use action text with custom attachments:
 
 * Each `<lexxy-prompt-item>` must include a `sgid` attribute with the [global id that Action Text will use to find the associated model](https://guides.rubyonrails.org/action_text_overview.html#signed-globalid).
 * The `<lexxy-prompt>` must include a `name` attribute that will determine the content type of the attachment. For example, for `name= "mention"`, the attachment will be saved as `application/vnd.actiontext.mention`.
+* The editor must have `attachments` enabled and, if `permittedAttachmentTypes` is set, the prompt's content type must be in the allowlist. Otherwise the prompt will not activate.

--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -30,6 +30,7 @@ module Lexxy
               if node["url"].blank?
                 attachment = ActionText::Attachment.from_node(node)
                 node["content"] = render_action_text_attachment(attachment).to_json
+                node["content-type"] ||= attachment.content_type
               end
               node
             end

--- a/src/config/lexxy.js
+++ b/src/config/lexxy.js
@@ -13,6 +13,7 @@ const presets = new Configuration({
     attachments: true,
     markdown: true,
     multiLine: true,
+    permittedAttachmentTypes: null,
     richText: true,
     toolbar: {
       upload: "both"

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -42,7 +42,7 @@ export default class Contents {
     this.editor.update(() => {
       if ($hasUpdateTag(PASTE_TAG)) this.#stripTableCellColorStyles(doc)
 
-      const nodes = $generateFilteredNodesFromDOM(this.editor, doc, this.editorElement)
+      const nodes = $generateFilteredNodesFromDOM(this.editorElement, doc)
       if (!this.#insertUploadNodes(nodes)) {
         this.insertAtCursor(...nodes)
       }
@@ -603,7 +603,7 @@ export default class Contents {
   }
 
   #createHtmlNodeWith(html) {
-    const htmlNodes = $generateFilteredNodesFromDOM(this.editor, parseHtml(html), this.editorElement)
+    const htmlNodes = $generateFilteredNodesFromDOM(this.editorElement, parseHtml(html))
     return htmlNodes[0] || $createParagraphNode()
   }
 

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -4,7 +4,7 @@ import {
   HISTORY_MERGE_TAG, PASTE_TAG
 } from "lexical"
 
-import { $generateNodesFromDOM } from "@lexical/html"
+import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
 import { $createCodeNode, $isCodeNode } from "@lexical/code"
 import { $createHeadingNode, $createQuoteNode, $isQuoteNode } from "@lexical/rich-text"
 import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
@@ -42,7 +42,7 @@ export default class Contents {
     this.editor.update(() => {
       if ($hasUpdateTag(PASTE_TAG)) this.#stripTableCellColorStyles(doc)
 
-      const nodes = $generateNodesFromDOM(this.editor, doc)
+      const nodes = $generateFilteredNodesFromDOM(this.editor, doc, this.editorElement)
       if (!this.#insertUploadNodes(nodes)) {
         this.insertAtCursor(...nodes)
       }
@@ -591,16 +591,19 @@ export default class Contents {
 
   #createCustomAttachmentNodeWithHtml(html, options = {}) {
     const attachmentConfig = typeof options === "object" ? options : {}
-
+    const contentType = attachmentConfig.contentType || "text/html"
+    if (!this.editorElement.permitsAttachmentContentType(contentType)) {
+      return this.#createHtmlNodeWith(html)
+    }
     return new CustomActionTextAttachmentNode({
       sgid: attachmentConfig.sgid || null,
-      contentType: "text/html",
-      innerHtml: html
+      contentType,
+      innerHtml: html,
     })
   }
 
   #createHtmlNodeWith(html) {
-    const htmlNodes = $generateNodesFromDOM(this.editor, parseHtml(html))
+    const htmlNodes = $generateFilteredNodesFromDOM(this.editor, parseHtml(html), this.editorElement)
     return htmlNodes[0] || $createParagraphNode()
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -175,7 +175,7 @@ export class LexicalEditorElement extends HTMLElement {
   #parsePermittedAttachmentTypes() {
     const raw = this.dataset.permittedAttachmentTypes
     if (raw == null) return null
-    return raw.split(/\s+/).filter(t => t && t !== "false")
+    return Object.freeze(raw.split(/\s+/).filter(t => t && t !== "false"))
   }
 
   get isEmpty() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -300,7 +300,7 @@ export class LexicalEditorElement extends HTMLElement {
 
   #parseHtmlIntoLexicalNodes(html) {
     if (!html) html = "<p></p>"
-    const nodes = $generateFilteredNodesFromDOM(this.editor, parseHtml(`${html}`), this)
+    const nodes = $generateFilteredNodesFromDOM(this, parseHtml(`${html}`))
 
     return nodes
       .filter(this.#isNotWhitespaceOnlyNode)

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -167,15 +167,21 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   permitsAttachmentContentType(contentType) {
-    if (this.getAttribute("attachments") === "false") return false
-    const list = this.#permittedAttachmentTypes
-    return list === null || list.includes(contentType)
+    if (this.getAttribute("attachments") === "false") {
+      return false
+    } else {
+      const list = this.#permittedAttachmentTypes
+      return list === null || list.includes(contentType)
+    }
   }
 
   #parsePermittedAttachmentTypes() {
     const raw = this.dataset.permittedAttachmentTypes
-    if (raw == null) return null
-    return Object.freeze(raw.split(/\s+/).filter(t => t && t !== "false"))
+    if (raw == null) {
+      return null
+    } else {
+      return Object.freeze(raw.split(/\s+/).filter(t => t && t !== "false"))
+    }
   }
 
   get isEmpty() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -54,7 +54,6 @@ export class LexicalEditorElement extends HTMLElement {
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
-  #permittedAttachmentTypes = null
 
   constructor() {
     super()
@@ -66,7 +65,6 @@ export class LexicalEditorElement extends HTMLElement {
     this.id ||= generateDomId("lexxy-editor")
     this.config = new Configuration(this)
     this.extensions = new Extensions(this)
-    this.#permittedAttachmentTypes = this.#parsePermittedAttachmentTypes()
 
     this.editor = this.#createEditor()
     this.#disposables.push(this.editor)
@@ -163,24 +161,21 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   get permittedAttachmentTypes() {
-    return this.#permittedAttachmentTypes
-  }
-
-  permitsAttachmentContentType(contentType) {
-    if (this.getAttribute("attachments") === "false") {
-      return false
-    } else {
-      const list = this.#permittedAttachmentTypes
-      return list === null || list.includes(contentType)
-    }
-  }
-
-  #parsePermittedAttachmentTypes() {
-    const raw = this.getAttribute("permitted-attachment-types")
+    const raw = this.config.get("permittedAttachmentTypes")
     if (raw == null) {
       return null
     } else {
-      return Object.freeze(raw.split(/\s+/).filter(t => t && t !== "false"))
+      const tokens = Array.isArray(raw) ? raw : String(raw).split(/\s+/)
+      return Object.freeze(tokens.filter(t => t && t !== "false"))
+    }
+  }
+
+  permitsAttachmentContentType(contentType) {
+    if (!this.supportsAttachments) {
+      return false
+    } else {
+      const list = this.permittedAttachmentTypes
+      return list === null || list.includes(contentType)
     }
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -5,7 +5,8 @@ import { AutoLinkNode, LinkNode } from "@lexical/link"
 import { $getNearestNodeOfType } from "@lexical/utils"
 import { registerPlainText } from "@lexical/plain-text"
 import { HeadingNode, QuoteNode, registerRichText } from "@lexical/rich-text"
-import { $generateHtmlFromNodes, $generateNodesFromDOM } from "@lexical/html"
+import { $generateHtmlFromNodes } from "@lexical/html"
+import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
 import { CodeHighlightNode, CodeNode, registerCodeHighlighting } from "@lexical/code"
 import { TRANSFORMERS, registerMarkdownShortcuts } from "@lexical/markdown"
 import { HORIZONTAL_DIVIDER } from "../editor/markdown/horizontal_divider_transformer"
@@ -53,6 +54,7 @@ export class LexicalEditorElement extends HTMLElement {
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
+  #permittedAttachmentTypes = null
 
   constructor() {
     super()
@@ -64,6 +66,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.id ||= generateDomId("lexxy-editor")
     this.config = new Configuration(this)
     this.extensions = new Extensions(this)
+    this.#permittedAttachmentTypes = this.#parsePermittedAttachmentTypes()
 
     this.editor = this.#createEditor()
     this.#disposables.push(this.editor)
@@ -157,6 +160,22 @@ export class LexicalEditorElement extends HTMLElement {
 
   get blobUrlTemplate() {
     return this.dataset.blobUrlTemplate
+  }
+
+  get permittedAttachmentTypes() {
+    return this.#permittedAttachmentTypes
+  }
+
+  permitsAttachmentContentType(contentType) {
+    if (this.getAttribute("attachments") === "false") return false
+    const list = this.#permittedAttachmentTypes
+    return list === null || list.includes(contentType)
+  }
+
+  #parsePermittedAttachmentTypes() {
+    const raw = this.dataset.permittedAttachmentTypes
+    if (raw == null) return null
+    return raw.split(/\s+/).filter(t => t && t !== "false")
   }
 
   get isEmpty() {
@@ -281,7 +300,7 @@ export class LexicalEditorElement extends HTMLElement {
 
   #parseHtmlIntoLexicalNodes(html) {
     if (!html) html = "<p></p>"
-    const nodes = $generateNodesFromDOM(this.editor, parseHtml(`${html}`))
+    const nodes = $generateFilteredNodesFromDOM(this.editor, parseHtml(`${html}`), this)
 
     return nodes
       .filter(this.#isNotWhitespaceOnlyNode)
@@ -313,11 +332,22 @@ export class LexicalEditorElement extends HTMLElement {
     this.#handleEnter()
     this.#registerFocusEvents()
     this.#registerHistoryEvents()
+    this.#registerFileAcceptFilter()
     this.#attachDebugHooks()
     this.#attachToolbar()
     this.#configureSanitizer()
     this.#loadInitialValue()
     this.#resetBeforeTurboCaches()
+  }
+
+  #registerFileAcceptFilter() {
+    this.#listeners.track(
+      registerEventListener(this, "lexxy:file-accept", (event) => {
+        if (!this.permitsAttachmentContentType(event.detail.file.type)) {
+          event.preventDefault()
+        }
+      })
+    )
   }
 
   #createEditor() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -176,7 +176,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #parsePermittedAttachmentTypes() {
-    const raw = this.dataset.permittedAttachmentTypes
+    const raw = this.getAttribute("permitted-attachment-types")
     if (raw == null) {
       return null
     } else {

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -436,7 +436,7 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   #buildEditableTextNodes(template) {
-    return $generateFilteredNodesFromDOM(this.#editor, parseHtml(`${template.innerHTML}`), this.#editorElement)
+    return $generateFilteredNodesFromDOM(this.#editorElement, parseHtml(`${template.innerHTML}`))
   }
 
   #insertTemplatesAsAttachments(templates, stringToReplace, fallbackSgid = null) {

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -123,9 +123,10 @@ export class LexicalPromptElement extends HTMLElement {
     const el = this.#editorElement
     if (el.getAttribute("attachments") === "false") return false
 
-    const perItem = Array.from(this.querySelectorAll("template[type='editor']"))
-      .map(t => t.getAttribute("content-type")).filter(Boolean)
-    const types = perItem.length ? perItem : [ this.#defaultPromptContentType ]
+    const templates = Array.from(this.querySelectorAll("template[type='editor']"))
+    const types = templates.length
+      ? templates.map(t => t.getAttribute("content-type") || this.#defaultPromptContentType)
+      : [ this.#defaultPromptContentType ]
     return types.some(t => el.permitsAttachmentContentType(t))
   }
 

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -121,13 +121,15 @@ export class LexicalPromptElement extends HTMLElement {
 
   get #promptContentTypePermitted() {
     const el = this.#editorElement
-    if (el.getAttribute("attachments") === "false") return false
-
-    const templates = Array.from(this.querySelectorAll("template[type='editor']"))
-    const types = templates.length
-      ? templates.map(t => t.getAttribute("content-type") || this.#defaultPromptContentType)
-      : [ this.#defaultPromptContentType ]
-    return types.some(t => el.permitsAttachmentContentType(t))
+    if (el.getAttribute("attachments") === "false") {
+      return false
+    } else {
+      const templates = Array.from(this.querySelectorAll("template[type='editor']"))
+      const types = templates.length
+        ? templates.map(t => t.getAttribute("content-type") || this.#defaultPromptContentType)
+        : [ this.#defaultPromptContentType ]
+      return types.some(t => el.permitsAttachmentContentType(t))
+    }
   }
 
   #addCursorPositionListener() {

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -6,7 +6,7 @@ import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_atta
 import InlinePromptSource from "../editor/prompt/inline_source"
 import DeferredPromptSource from "../editor/prompt/deferred_source"
 import RemoteFilterSource from "../editor/prompt/remote_filter_source"
-import { $generateNodesFromDOM } from "@lexical/html"
+import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
 import { debounce, nextFrame } from "../helpers/timing_helpers"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 
@@ -84,6 +84,8 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   #addTriggerListener() {
+    if (!this.#promptContentTypePermitted) return
+
     this.#popoverListeners.track(this.#editor.registerUpdateListener(({ editorState }) => {
       editorState.read(() => {
         if (this.#selection.isInsideCodeBlock) return
@@ -115,6 +117,16 @@ export class LexicalPromptElement extends HTMLElement {
         }
       })
     }))
+  }
+
+  get #promptContentTypePermitted() {
+    const el = this.#editorElement
+    if (el.getAttribute("attachments") === "false") return false
+
+    const perItem = Array.from(this.querySelectorAll("template[type='editor']"))
+      .map(t => t.getAttribute("content-type")).filter(Boolean)
+    const types = perItem.length ? perItem : [ this.#defaultPromptContentType ]
+    return types.some(t => el.permitsAttachmentContentType(t))
   }
 
   #addCursorPositionListener() {
@@ -423,7 +435,7 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   #buildEditableTextNodes(template) {
-    return $generateNodesFromDOM(this.#editor, parseHtml(`${template.innerHTML}`))
+    return $generateFilteredNodesFromDOM(this.#editor, parseHtml(`${template.innerHTML}`), this.#editorElement)
   }
 
   #insertTemplatesAsAttachments(templates, stringToReplace, fallbackSgid = null) {
@@ -435,8 +447,10 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   #buildAttachmentNodes(templates, fallbackSgid = null) {
-    return templates.map(
-      template => this.#buildAttachmentNode(
+    return templates
+      .filter(template => this.#editorElement.permitsAttachmentContentType(
+        template.getAttribute("content-type") || this.#defaultPromptContentType))
+      .map(template => this.#buildAttachmentNode(
         template.innerHTML,
         template.getAttribute("content-type") || this.#defaultPromptContentType,
         template.getAttribute("sgid") || fallbackSgid

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -121,7 +121,7 @@ export class LexicalPromptElement extends HTMLElement {
 
   get #promptContentTypePermitted() {
     const el = this.#editorElement
-    if (el.getAttribute("attachments") === "false") {
+    if (!el.supportsAttachments) {
       return false
     } else {
       const templates = Array.from(this.querySelectorAll("template[type='editor']"))

--- a/src/helpers/attachment_filter_helper.js
+++ b/src/helpers/attachment_filter_helper.js
@@ -1,4 +1,5 @@
 import { $generateNodesFromDOM } from "@lexical/html"
+import { $descendantsMatching } from "@lexical/utils"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 
@@ -11,7 +12,8 @@ export function filterDisallowedAttachmentNodes(nodes, editorElement) {
   return nodes
     .filter(node => !isDisallowedAttachment(node, editorElement))
     .map(node => {
-      walkChildren(node, editorElement)
+      $descendantsMatching([ node ], descendant => isDisallowedAttachment(descendant, editorElement))
+        .forEach(descendant => descendant.remove())
       return node
     })
 }
@@ -22,15 +24,4 @@ function isDisallowedAttachment(node, editorElement) {
     node instanceof ActionTextAttachmentNode
   return isAttachmentNode &&
          !editorElement.permitsAttachmentContentType(node.contentType)
-}
-
-function walkChildren(node, editorElement) {
-  if (typeof node.getChildren !== "function") return
-  node.getChildren().forEach(child => {
-    if (isDisallowedAttachment(child, editorElement)) {
-      child.remove()
-    } else {
-      walkChildren(child, editorElement)
-    }
-  })
 }

--- a/src/helpers/attachment_filter_helper.js
+++ b/src/helpers/attachment_filter_helper.js
@@ -3,8 +3,8 @@ import { $descendantsMatching } from "@lexical/utils"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 
-export function $generateFilteredNodesFromDOM(editor, doc, editorElement) {
-  const nodes = $generateNodesFromDOM(editor, doc)
+export function $generateFilteredNodesFromDOM(editorElement, doc) {
+  const nodes = $generateNodesFromDOM(editorElement.editor, doc)
   return filterDisallowedAttachmentNodes(nodes, editorElement)
 }
 

--- a/src/helpers/attachment_filter_helper.js
+++ b/src/helpers/attachment_filter_helper.js
@@ -1,0 +1,36 @@
+import { $generateNodesFromDOM } from "@lexical/html"
+import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
+import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
+
+export function $generateFilteredNodesFromDOM(editor, doc, editorElement) {
+  const nodes = $generateNodesFromDOM(editor, doc)
+  return filterDisallowedAttachmentNodes(nodes, editorElement)
+}
+
+export function filterDisallowedAttachmentNodes(nodes, editorElement) {
+  return nodes
+    .filter(node => !isDisallowedAttachment(node, editorElement))
+    .map(node => {
+      walkChildren(node, editorElement)
+      return node
+    })
+}
+
+function isDisallowedAttachment(node, editorElement) {
+  const isAttachmentNode =
+    node instanceof CustomActionTextAttachmentNode ||
+    node instanceof ActionTextAttachmentNode
+  return isAttachmentNode &&
+         !editorElement.permitsAttachmentContentType(node.contentType)
+}
+
+function walkChildren(node, editorElement) {
+  if (typeof node.getChildren !== "function") return
+  node.getChildren().forEach(child => {
+    if (isDisallowedAttachment(child, editorElement)) {
+      child.remove()
+    } else {
+      walkChildren(child, editorElement)
+    }
+  })
+}

--- a/test/browser/fixtures/attachments-empty-permitted-list.html
+++ b/test/browser/fixtures/attachments-empty-permitted-list.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments on, empty permitted list</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="">
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/attachments-empty-permitted-list.html
+++ b/test/browser/fixtures/attachments-empty-permitted-list.html
@@ -17,7 +17,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="">
+        permitted-attachment-types="">
       </lexxy-editor>
     </div>
   </form>

--- a/test/browser/fixtures/attachments-false.html
+++ b/test/browser/fixtures/attachments-false.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments disabled</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="false">
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/attachments-permitted-image-png.html
+++ b/test/browser/fixtures/attachments-permitted-image-png.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments Permitted image/png</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="image/png"></lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/attachments-permitted-image-png.html
+++ b/test/browser/fixtures/attachments-permitted-image-png.html
@@ -13,7 +13,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="image/png"></lexxy-editor>
+        permitted-attachment-types="image/png"></lexxy-editor>
     </div>
   </form>
 

--- a/test/browser/fixtures/attachments-permitted-og-embed.html
+++ b/test/browser/fixtures/attachments-permitted-og-embed.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments permitted: OG embed</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="application/vnd.basecamp.opengraph-embed">
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/attachments-permitted-og-embed.html
+++ b/test/browser/fixtures/attachments-permitted-og-embed.html
@@ -17,7 +17,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="application/vnd.basecamp.opengraph-embed">
+        permitted-attachment-types="application/vnd.basecamp.opengraph-embed">
       </lexxy-editor>
     </div>
   </form>

--- a/test/browser/fixtures/attachments-sentinel-false.html
+++ b/test/browser/fixtures/attachments-sentinel-false.html
@@ -17,7 +17,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="false">
+        permitted-attachment-types="false">
       </lexxy-editor>
     </div>
   </form>

--- a/test/browser/fixtures/attachments-sentinel-false.html
+++ b/test/browser/fixtures/attachments-sentinel-false.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments on, sentinel "false" permitted list</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="false">
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/attachments-unset-permitted-list.html
+++ b/test/browser/fixtures/attachments-unset-permitted-list.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments on, unset permitted list</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true">
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/mentions-custom-element.html
+++ b/test/browser/fixtures/mentions-custom-element.html
@@ -17,7 +17,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="application/vnd.basecamp.mention">
+        permitted-attachment-types="application/vnd.basecamp.mention">
         <lexxy-prompt trigger="@" name="mention">
           <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
             <template type="menu">

--- a/test/browser/fixtures/mentions-custom-element.html
+++ b/test/browser/fixtures/mentions-custom-element.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Mentions with Custom Element</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="application/vnd.basecamp.mention">
+        <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
+            <template type="menu">
+              <span class="person person--prompt-item">Alice</span>
+            </template>
+            <template type="editor" content-type="application/vnd.basecamp.mention">
+              <bc-mention class="mentionable-person" gid="gid://test/Person/1">
+                <span class="person--inline">Alice</span>
+              </bc-mention>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+
+        <lexxy-prompt trigger="#" name="mention" insert-editable-text>
+          <lexxy-prompt-item search="Jane" sgid="test-sgid-jane">
+            <template type="menu">
+              <span class="person person--prompt-item">Jane</span>
+            </template>
+            <template type="editor" content-type="application/vnd.basecamp.mention">
+              <a href="/people/jane"><img src="/avatar-jane.png" class="person--avatar" alt="">Jane</a>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/prompt-attachments-false.html
+++ b/test/browser/fixtures/prompt-attachments-false.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Prompt with attachments=false</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="false">
+        <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
+            <template type="menu">
+              <span class="person person--prompt-item">Alice</span>
+            </template>
+            <template type="editor" content-type="application/vnd.basecamp.mention">
+              <bc-mention class="mentionable-person" gid="gid://test/Person/1">
+                <span class="person--inline">Alice</span>
+              </bc-mention>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/prompt-disallowed-content-type.html
+++ b/test/browser/fixtures/prompt-disallowed-content-type.html
@@ -17,7 +17,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="application/vnd.actiontext.mention">
+        permitted-attachment-types="application/vnd.actiontext.mention">
         <lexxy-prompt trigger="@" name="mention">
           <lexxy-prompt-item search="Example" sgid="test-sgid-embed">
             <template type="menu">

--- a/test/browser/fixtures/prompt-disallowed-content-type.html
+++ b/test/browser/fixtures/prompt-disallowed-content-type.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Prompt with Disallowed Content-Type</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="application/vnd.actiontext.mention">
+        <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="Example" sgid="test-sgid-embed">
+            <template type="menu">
+              <span class="embed embed--prompt-item">Example</span>
+            </template>
+            <template type="editor" content-type="application/vnd.basecamp.opengraph-embed">
+              <span class="embed embed--inline">Example</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/prompt-mixed-templates.html
+++ b/test/browser/fixtures/prompt-mixed-templates.html
@@ -17,7 +17,7 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        data-permitted-attachment-types="application/vnd.actiontext.mention">
+        permitted-attachment-types="application/vnd.actiontext.mention">
         <lexxy-prompt trigger="@" name="mention">
           <lexxy-prompt-item search="Example" sgid="test-sgid-mixed">
             <template type="menu">

--- a/test/browser/fixtures/prompt-mixed-templates.html
+++ b/test/browser/fixtures/prompt-mixed-templates.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Prompt with Mixed Templates</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        attachments="true"
+        data-permitted-attachment-types="application/vnd.actiontext.mention">
+        <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="Example" sgid="test-sgid-mixed">
+            <template type="menu">
+              <span class="person person--prompt-item">Example</span>
+            </template>
+            <template type="editor" content-type="application/vnd.basecamp.opengraph-embed">
+              <span class="embed embed--inline">Example</span>
+            </template>
+            <template type="editor">
+              <span class="person--inline">Example</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/attachments/default_and_sentinel.test.js
+++ b/test/browser/tests/attachments/default_and_sentinel.test.js
@@ -7,7 +7,7 @@ const mixedAttachments = [
   `<div><bc-attachment sgid="test-sgid-image" content-type="image/png" content="&lt;img src=&quot;/example.png&quot;&gt;"></bc-attachment></div>`,
 ].join("")
 
-test.describe("data-permitted-attachment-types default and sentinel behavior", () => {
+test.describe("permitted-attachment-types default and sentinel behavior", () => {
   test("unset attribute accepts all content-types on import", async ({ page, editor }) => {
     await page.goto("/attachments-unset-permitted-list.html")
     await page.waitForSelector("lexxy-editor[connected]")

--- a/test/browser/tests/attachments/default_and_sentinel.test.js
+++ b/test/browser/tests/attachments/default_and_sentinel.test.js
@@ -1,0 +1,49 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const mixedAttachments = [
+  `<div><bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment></div>`,
+  `<div><bc-attachment sgid="test-sgid-og" content-type="application/vnd.basecamp.opengraph-embed" content="&lt;a href=&quot;https://example.com&quot;&gt;Example&lt;/a&gt;"></bc-attachment></div>`,
+  `<div><bc-attachment sgid="test-sgid-image" content-type="image/png" content="&lt;img src=&quot;/example.png&quot;&gt;"></bc-attachment></div>`,
+].join("")
+
+test.describe("data-permitted-attachment-types default and sentinel behavior", () => {
+  test("unset attribute accepts all content-types on import", async ({ page, editor }) => {
+    await page.goto("/attachments-unset-permitted-list.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue(mixedAttachments)
+    await editor.flush()
+
+    await expect(
+      editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.mention']"),
+    ).toHaveCount(1)
+    await expect(
+      editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.opengraph-embed']"),
+    ).toHaveCount(1)
+    await expect(
+      editor.content.locator("bc-attachment[content-type='image/png']"),
+    ).toHaveCount(1)
+
+    const serialized = await editor.value()
+    expect(serialized).toContain(`content-type="application/vnd.basecamp.mention"`)
+    expect(serialized).toContain(`content-type="application/vnd.basecamp.opengraph-embed"`)
+    expect(serialized).toContain(`content-type="image/png"`)
+  })
+
+  test('literal "false" sentinel produces empty permitted list, stripping all attachments', async ({ page, editor }) => {
+    await page.goto("/attachments-sentinel-false.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue(mixedAttachments)
+    await editor.flush()
+
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("bc-attachment")
+    expect(serialized).not.toContain("application/vnd.basecamp.mention")
+    expect(serialized).not.toContain("application/vnd.basecamp.opengraph-embed")
+    expect(serialized).not.toContain("image/png")
+  })
+})

--- a/test/browser/tests/attachments/empty_list_vs_disabled.test.js
+++ b/test/browser/tests/attachments/empty_list_vs_disabled.test.js
@@ -4,7 +4,7 @@ import { expect } from "@playwright/test"
 const mentionAttachment = `<div><bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment></div>`
 
 test.describe("Empty permitted list vs attachments=false import equivalence (F-21)", () => {
-  test("attachments=true with empty data-permitted-attachment-types strips all attachments on import", async ({ page, editor }) => {
+  test("attachments=true with empty permitted-attachment-types strips all attachments on import", async ({ page, editor }) => {
     await page.goto("/attachments-empty-permitted-list.html")
     await page.waitForSelector("lexxy-editor[connected]")
 

--- a/test/browser/tests/attachments/empty_list_vs_disabled.test.js
+++ b/test/browser/tests/attachments/empty_list_vs_disabled.test.js
@@ -1,0 +1,32 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const mentionAttachment = `<div><bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment></div>`
+
+test.describe("Empty permitted list vs attachments=false import equivalence (F-21)", () => {
+  test("attachments=true with empty data-permitted-attachment-types strips all attachments on import", async ({ page, editor }) => {
+    await page.goto("/attachments-empty-permitted-list.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue(mentionAttachment)
+    await editor.flush()
+
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("bc-attachment")
+  })
+
+  test("attachments=false strips all attachments on import", async ({ page, editor }) => {
+    await page.goto("/attachments-false.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue(mentionAttachment)
+    await editor.flush()
+
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("bc-attachment")
+  })
+})

--- a/test/browser/tests/attachments/file_accept_filter.test.js
+++ b/test/browser/tests/attachments/file_accept_filter.test.js
@@ -1,7 +1,7 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 
-test.describe("Internal lexxy:file-accept listener honors data-permitted-attachment-types", () => {
+test.describe("Internal lexxy:file-accept listener honors permitted-attachment-types", () => {
   test("disallowed file MIME is rejected by the internal lexxy:file-accept listener", async ({ page }) => {
     await page.goto("/mentions-custom-element.html")
     await page.waitForSelector("lexxy-editor[connected]")

--- a/test/browser/tests/attachments/file_accept_filter.test.js
+++ b/test/browser/tests/attachments/file_accept_filter.test.js
@@ -1,0 +1,49 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Internal lexxy:file-accept listener honors data-permitted-attachment-types", () => {
+  test("disallowed file MIME is rejected by the internal lexxy:file-accept listener", async ({ page }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    const prevented = await page.evaluate(() => {
+      const editor = document.querySelector("lexxy-editor")
+      const file = new File([ "" ], "photo.png", { type: "image/png" })
+      const event = new CustomEvent("lexxy:file-accept", { detail: { file }, cancelable: true, bubbles: true })
+      editor.dispatchEvent(event)
+      return event.defaultPrevented
+    })
+
+    expect(prevented).toBe(true)
+  })
+
+  test("permitted file MIME is not rejected by the internal lexxy:file-accept listener", async ({ page }) => {
+    await page.goto("/attachments-enabled.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    const prevented = await page.evaluate(() => {
+      const editor = document.querySelector("lexxy-editor")
+      const file = new File([ "" ], "photo.png", { type: "image/png" })
+      const event = new CustomEvent("lexxy:file-accept", { detail: { file }, cancelable: true, bubbles: true })
+      editor.dispatchEvent(event)
+      return event.defaultPrevented
+    })
+
+    expect(prevented).toBe(false)
+  })
+
+  test("file MIME matching an explicit allowlist entry is not rejected", async ({ page }) => {
+    await page.goto("/attachments-permitted-image-png.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    const prevented = await page.evaluate(() => {
+      const editor = document.querySelector("lexxy-editor")
+      const file = new File([ "" ], "photo.png", { type: "image/png" })
+      const event = new CustomEvent("lexxy:file-accept", { detail: { file }, cancelable: true, bubbles: true })
+      editor.dispatchEvent(event)
+      return event.defaultPrevented
+    })
+
+    expect(prevented).toBe(false)
+  })
+})

--- a/test/browser/tests/attachments/import_filter.test.js
+++ b/test/browser/tests/attachments/import_filter.test.js
@@ -1,0 +1,86 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const imageAttachment = `<div><bc-attachment sgid="test-sgid-image" content-type="image/png" content="&lt;img src=&quot;/example.png&quot;&gt;"></bc-attachment></div>`
+
+const mentionAttachment = `<div><bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment></div>`
+
+const imageAttachmentInTable = `<figure class="lexxy-content__table-wrapper"><table><thead><tr><th>Header</th></tr></thead><tbody><tr><td><bc-attachment sgid="test-sgid-image" content-type="image/png" content="&lt;img src=&quot;/example.png&quot;&gt;"></bc-attachment></td></tr></tbody></table></figure>`
+
+const attachmentWithoutContentType = `<div><bc-attachment sgid="test-sgid-untyped" content="&lt;img src=&quot;/example.png&quot;&gt;"></bc-attachment></div>`
+
+test.describe("Attachment import filter honors data-permitted-attachment-types", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("disallowed attachment content-type is stripped on import", async ({ page, editor }) => {
+    await editor.setValue(imageAttachment)
+    await editor.flush()
+
+    await expect(editor.content.locator("bc-attachment[content-type='image/png']")).toHaveCount(0)
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+    await expect(editor.content.locator("img")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain(`content-type="image/png"`)
+    expect(serialized).not.toContain("bc-attachment")
+    expect(serialized).not.toContain("<img")
+  })
+
+  test("permitted attachment content-type survives import", async ({ page, editor }) => {
+    await editor.setValue(mentionAttachment)
+    await editor.flush()
+
+    await expect(
+      editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.mention']"),
+    ).toHaveCount(1)
+  })
+
+  test("disallowed attachment nested in a table cell is stripped, table survives", async ({ page, editor }) => {
+    await editor.setValue(imageAttachmentInTable)
+    await editor.flush()
+
+    await expect(editor.content.locator("table")).toHaveCount(1)
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+    await expect(editor.content.locator("bc-attachment[content-type='image/png']")).toHaveCount(0)
+    await expect(editor.content.locator("td img")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).toContain("<table")
+    expect(serialized).not.toContain("bc-attachment")
+    expect(serialized).not.toContain(`content-type="image/png"`)
+    expect(serialized).not.toContain("<img")
+  })
+
+  test("bc-attachment without content-type attribute is stripped on strict allowlist", async ({ page, editor }) => {
+    await editor.setValue(attachmentWithoutContentType)
+    await editor.flush()
+
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("bc-attachment")
+  })
+
+  test("insert-editable-text prompt template with nested <img> does not produce an attachment node", async ({ page, editor }) => {
+    await editor.send("#")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(0)
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("action-text-attachment")
+    expect(serialized).not.toContain("bc-attachment")
+    expect(serialized).not.toContain("<img")
+    expect(serialized).toContain("Jane")
+    expect(serialized).toContain('href="/people/jane"')
+  })
+})

--- a/test/browser/tests/attachments/import_filter.test.js
+++ b/test/browser/tests/attachments/import_filter.test.js
@@ -9,7 +9,7 @@ const imageAttachmentInTable = `<figure class="lexxy-content__table-wrapper"><ta
 
 const attachmentWithoutContentType = `<div><bc-attachment sgid="test-sgid-untyped" content="&lt;img src=&quot;/example.png&quot;&gt;"></bc-attachment></div>`
 
-test.describe("Attachment import filter honors data-permitted-attachment-types", () => {
+test.describe("Attachment import filter honors permitted-attachment-types", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/mentions-custom-element.html")
     await page.waitForSelector("lexxy-editor[connected]")

--- a/test/browser/tests/attachments/import_filter.test.js
+++ b/test/browser/tests/attachments/import_filter.test.js
@@ -73,8 +73,8 @@ test.describe("Attachment import filter honors data-permitted-attachment-types",
     await editor.send("Enter")
     await editor.flush()
 
-    await expect(editor.content.locator("action-text-attachment")).toHaveCount(0)
-    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(0)
+    await expect(editor.content.locator("img")).toHaveCount(0)
 
     const serialized = await editor.value()
     expect(serialized).not.toContain("action-text-attachment")

--- a/test/browser/tests/paste/og_embed_roundtrip.test.js
+++ b/test/browser/tests/paste/og_embed_roundtrip.test.js
@@ -1,0 +1,46 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const ogEmbedAttachment = `<p><bc-attachment sgid="test-sgid-og" content-type="application/vnd.basecamp.opengraph-embed" content="&lt;a href=&quot;https://example.com&quot;&gt;Example&lt;/a&gt;"></bc-attachment></p>`
+
+test.describe("OG embed round-trip through setValue", () => {
+  test("permitting editor preserves OG attachment across setValue round-trip", async ({ page, editor }) => {
+    await page.goto("/attachments-permitted-og-embed.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue(ogEmbedAttachment)
+    await editor.flush()
+
+    await expect(
+      editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.opengraph-embed']"),
+    ).toHaveCount(1)
+
+    const firstSerialized = await editor.value()
+    expect(firstSerialized).toContain(`content-type="application/vnd.basecamp.opengraph-embed"`)
+    expect(firstSerialized).toContain(`sgid="test-sgid-og"`)
+
+    await editor.setValue(firstSerialized)
+    await editor.flush()
+
+    await expect(
+      editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.opengraph-embed']"),
+    ).toHaveCount(1)
+
+    const secondSerialized = await editor.value()
+    expect(secondSerialized).toBe(firstSerialized)
+  })
+
+  test("non-permitting editor strips OG attachment on import", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue(ogEmbedAttachment)
+    await editor.flush()
+
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("application/vnd.basecamp.opengraph-embed")
+    expect(serialized).not.toContain("bc-attachment")
+  })
+})

--- a/test/browser/tests/paste/programmatic_insert_fallback.test.js
+++ b/test/browser/tests/paste/programmatic_insert_fallback.test.js
@@ -1,0 +1,44 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const ogEmbedHtml = '<div class="og-preview"><a href="https://example.com"><img src="/og-thumb.png" alt="">Title</a></div>'
+
+test.describe("Programmatic insert falls back to plain HTML when content-type is disallowed", () => {
+  test("disallowed attachment content-type via lexxy:insert-link falls back to plain HTML", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await editor.waitForConnected()
+
+    await page.evaluate((html) => {
+      document.querySelector("lexxy-editor").addEventListener("lexxy:insert-link", (event) => {
+        event.detail.replaceLinkWith(html, {
+          attachment: {
+            contentType: "application/vnd.basecamp.opengraph-embed",
+            sgid: "test-sgid-embed",
+          },
+        })
+      })
+    }, ogEmbedHtml)
+
+    await editor.paste("https://example.com")
+    await editor.flush()
+
+    // Structural invariants:
+    //  (1) the fallback inserted content produces exactly one anchor,
+    //  (2) that anchor has the input HTML's href, and
+    //  (3) the anchor's only text content is "Title" — the nested <img> was stripped inside #createHtmlNodeWith
+    const anchor = editor.content.locator("a")
+    await expect(anchor).toHaveCount(1)
+    await expect(anchor).toHaveAttribute("href", "https://example.com")
+    await expect(anchor).toHaveText("Title")
+
+    // Negative structural invariants: no attachment node, no <img> anywhere,
+    // in either the live DOM or the serialized value.
+    await expect(editor.content.locator("bc-attachment")).toHaveCount(0)
+    await expect(editor.content.locator("img")).toHaveCount(0)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("bc-attachment")
+    expect(serialized).not.toContain("<img")
+    expect(serialized).not.toContain(`content-type="application/vnd.basecamp.opengraph-embed"`)
+  })
+})

--- a/test/browser/tests/paste/xss_sanitization.test.js
+++ b/test/browser/tests/paste/xss_sanitization.test.js
@@ -109,4 +109,22 @@ test.describe("Paste — XSS sanitization via action-text-attachment content", (
       await expect(content.locator("action-text-attachment .person--name")).toHaveText("Michael Berger")
     })
   })
+
+  test("strips onclick handler from bc-attachment wrapper while preserving sgid", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    const mentionWithOnclick = `<div><bc-attachment onclick="alert(1)" sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment></div>`
+
+    await editor.setValue(mentionWithOnclick)
+    await editor.flush()
+
+    const attachment = editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.mention']")
+    await expect(attachment).toHaveCount(1)
+    await expect(attachment).not.toHaveAttribute("onclick", /.*/)
+
+    const serialized = await editor.value()
+    expect(serialized).not.toContain("onclick")
+    expect(serialized).toContain(`sgid="test-sgid-alice"`)
+  })
 })

--- a/test/browser/tests/prompts/prompt_suppression.test.js
+++ b/test/browser/tests/prompts/prompt_suppression.test.js
@@ -1,0 +1,34 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt activation is gated on data-permitted-attachment-types", () => {
+  test("prompt does not activate when its content-type is not in the editor's allowlist", async ({ page, editor }) => {
+    await page.goto("/prompt-disallowed-content-type.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toHaveCount(0)
+  })
+
+  test("prompt activates normally when its content-type is in the editor's allowlist", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
+
+  test("prompt does not activate when editor has attachments=\"false\"", async ({ page, editor }) => {
+    await page.goto("/prompt-attachments-false.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toHaveCount(0)
+  })
+})

--- a/test/browser/tests/prompts/prompt_suppression.test.js
+++ b/test/browser/tests/prompts/prompt_suppression.test.js
@@ -31,4 +31,14 @@ test.describe("Prompt activation is gated on data-permitted-attachment-types", (
     const popover = page.locator(".lexxy-prompt-menu--visible")
     await expect(popover).toHaveCount(0)
   })
+
+  test("prompt activates when any template resolves to a permitted content-type, including templates without an explicit content-type attribute", async ({ page, editor }) => {
+    await page.goto("/prompt-mixed-templates.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
 })

--- a/test/browser/tests/prompts/prompt_suppression.test.js
+++ b/test/browser/tests/prompts/prompt_suppression.test.js
@@ -1,7 +1,7 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 
-test.describe("Prompt activation is gated on data-permitted-attachment-types", () => {
+test.describe("Prompt activation is gated on permitted-attachment-types", () => {
   test("prompt does not activate when its content-type is not in the editor's allowlist", async ({ page, editor }) => {
     await page.goto("/prompt-disallowed-content-type.html")
     await page.waitForSelector("lexxy-editor[connected]")

--- a/test/dummy/app/views/people/_person.html.erb
+++ b/test/dummy/app/views/people/_person.html.erb
@@ -1,1 +1,1 @@
-<em><%= person.name %></em> (<strong><%= person.initials %></strong>)
+<bc-mention gid="<%= person.to_gid %>"><em><%= person.name %></em> (<strong><%= person.initials %></strong>)</bc-mention>

--- a/test/dummy/config/initializers/action_text.rb
+++ b/test/dummy/config/initializers/action_text.rb
@@ -1,0 +1,6 @@
+Rails.application.config.to_prepare do
+  ActionText::ContentHelper.allowed_tags = ActionText::ContentHelper.sanitizer.class.allowed_tags +
+    [ ActionText::Attachment.tag_name, "figure", "figcaption", "bc-mention" ]
+  ActionText::ContentHelper.allowed_attributes = ActionText::ContentHelper.sanitizer.class.allowed_attributes +
+    ActionText::Attachment::ATTRIBUTES + [ "gid" ]
+end

--- a/test/helpers/lexxy/tag_helper_test.rb
+++ b/test/helpers/lexxy/tag_helper_test.rb
@@ -17,7 +17,7 @@ class Lexxy::TagHelperTest < ActionView::TestCase
         attachment = value.at("action-text-attachment")
 
         assert_equal "Hello ", value.text
-        assert_equal "<em>James Anderson</em> (<strong>JA</strong>)", JSON.parse(attachment["content"])
+        assert_equal %(<bc-mention gid="#{people(:james).to_gid}"><em>James Anderson</em> (<strong>JA</strong>)</bc-mention>), JSON.parse(attachment["content"])
       end
     end
   end

--- a/test/helpers/lexxy/tag_helper_test.rb
+++ b/test/helpers/lexxy/tag_helper_test.rb
@@ -18,6 +18,7 @@ class Lexxy::TagHelperTest < ActionView::TestCase
 
         assert_equal "Hello ", value.text
         assert_equal %(<bc-mention gid="#{people(:james).to_gid}"><em>James Anderson</em> (<strong>JA</strong>)</bc-mention>), JSON.parse(attachment["content"])
+        assert_equal "application/vnd.actiontext.mention", attachment["content-type"]
       end
     end
   end

--- a/test/javascript/unit/editor/permitted_attachment_types.test.js
+++ b/test/javascript/unit/editor/permitted_attachment_types.test.js
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { createTestEditor, destroyTestEditor } from "../helpers/editor_helper"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+describe("permittedAttachmentTypes getter", () => {
+  test("returns a frozen array so hosts cannot mutate internal state", async () => {
+    editorElement = await createTestEditor({
+      attributes: { "data-permitted-attachment-types": "application/vnd.basecamp.mention" }
+    })
+
+    const list = editorElement.permittedAttachmentTypes
+
+    expect(Object.isFrozen(list)).toBe(true)
+    expect(() => list.push("image/png")).toThrow(TypeError)
+  })
+})

--- a/test/javascript/unit/editor/permitted_attachment_types.test.js
+++ b/test/javascript/unit/editor/permitted_attachment_types.test.js
@@ -10,7 +10,7 @@ afterEach(async () => {
 describe("permittedAttachmentTypes getter", () => {
   test("returns a frozen array so hosts cannot mutate internal state", async () => {
     editorElement = await createTestEditor({
-      attributes: { "data-permitted-attachment-types": "application/vnd.basecamp.mention" }
+      attributes: { "permitted-attachment-types": "application/vnd.basecamp.mention" }
     })
 
     const list = editorElement.permittedAttachmentTypes

--- a/test/javascript/unit/editor/permitted_attachment_types.test.js
+++ b/test/javascript/unit/editor/permitted_attachment_types.test.js
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, test } from "vitest"
 import { createTestEditor, destroyTestEditor } from "../helpers/editor_helper"
+import Lexxy from "src/config/lexxy"
 
 let editorElement
 
 afterEach(async () => {
   await destroyTestEditor(editorElement)
+  Lexxy.configure({ default: { permittedAttachmentTypes: null } })
 })
 
 describe("permittedAttachmentTypes getter", () => {
@@ -17,5 +19,13 @@ describe("permittedAttachmentTypes getter", () => {
 
     expect(Object.isFrozen(list)).toBe(true)
     expect(() => list.push("image/png")).toThrow(TypeError)
+  })
+
+  test("reflects JS configuration", async () => {
+    Lexxy.configure({ default: { permittedAttachmentTypes: [ "application/vnd.basecamp.mention" ] } })
+
+    editorElement = await createTestEditor()
+
+    expect([ ...editorElement.permittedAttachmentTypes ]).toEqual([ "application/vnd.basecamp.mention" ])
   })
 })

--- a/test/javascript/unit/helpers/editor_helper.js
+++ b/test/javascript/unit/helpers/editor_helper.js
@@ -35,6 +35,12 @@ export async function createTestEditor(options = {}) {
     element.setAttribute("value", options.value)
   }
 
+  if (options.attributes) {
+    for (const [ name, value ] of Object.entries(options.attributes)) {
+      element.setAttribute(name, value)
+    }
+  }
+
   document.body.appendChild(element)
 
   // Wait for requestAnimationFrame callbacks (lexxy:initialize, dispatchHighlightColors)

--- a/test/system/mention_round_trip_test.rb
+++ b/test/system/mention_round_trip_test.rb
@@ -1,0 +1,35 @@
+require "application_system_test_case"
+
+class MentionRoundTripTest < ApplicationSystemTestCase
+  test "mention attachment round-trips through edit, save, show, and re-edit" do
+    post = posts(:hello_james)
+    person = people(:james)
+
+    visit edit_post_path(post)
+    wait_for_editor
+
+    assert_editor_value_has_mention_for(person)
+
+    click_on "Update Post"
+
+    within "article.post" do
+      assert_selector %(action-text-attachment[sgid][content-type="application/vnd.actiontext.mention"] bc-mention[gid="#{person.to_gid}"]), text: person.name
+    end
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    assert_editor_value_has_mention_for(person)
+  end
+
+  private
+    def assert_editor_value_has_mention_for(person)
+      value = Capybara.string(find_editor.value)
+      attachment = value.find(%(action-text-attachment[content-type="application/vnd.actiontext.mention"]))
+      assert attachment[:sgid].present?
+
+      mention_markup = CGI.unescapeHTML(attachment["content"])
+      mention_fragment = Capybara.string(mention_markup)
+      mention_fragment.assert_selector %(bc-mention[gid="#{person.to_gid}"]), text: person.name
+    end
+end


### PR DESCRIPTION
Honor data-permitted-attachment-types across the editor

The motivation for this work is a long-standing round-trip bug in host apps that want to support only certain attachment shapes on a given form — for example, mentions and OG embeds but not file uploads. With Lexxy honoring a per-editor allowlist directly, hosts can declare `permitted-attachment-types` and keep `attachments=true`: saved mentions and embeds continue to render, while new file drops, disallowed programmatic inserts, and disallowed prompt activations are all rejected at the editor boundary.

Lexxy now reads `data-permitted-attachment-types` on `<lexxy-editor>` and enforces it at every attachment entry point. The attribute becomes a first-class per-editor allowlist, and the custom element exposes two new methods that host apps can consult directly: a `permittedAttachmentTypes` getter that returns the parsed token list (or `null` when the attribute is absent), and a `permitsAttachmentContentType(contentType)` predicate that returns whether a given content-type is currently allowed.

Four consumers plug into that predicate:

1. HTML import. A new helper, `$generateFilteredNodesFromDOM`, wraps `$generateNodesFromDOM` at every call site in the import path — value-set, insertDOM, programmatic HTML insert, and prompt editable-text insertion. The wrapper walks the generated nodes and their descendants, dropping any attachment node whose content-type is not permitted, so that nested cases (such as a disallowed attachment inside a table cell) are caught as well as top-level ones.

2. File drops and pastes. An internal `lexxy:file-accept` listener, registered at editor initialization, calls `event.preventDefault()` when the dropped file's MIME is disallowed. Host listeners can still stack on top, because the internal listener installs before the `lexxy:initialize` event fires, so any host code that registers its own handler on initialize retains last-word semantics.

3. Prompt activation. A prompt whose declared template content-type is not permitted never installs its trigger listener, so its popover never appears on the page. The activation gate also short-circuits to "not permitted" when the editor is `attachments=false`.

4. Programmatic insertion. The `lexxy:insert-link` event's `replaceLinkWith` and `insertBelowLink` callbacks now fall back to plain HTML (which itself routes through the import filter, so any attachment-producing tags nested inside the fallback HTML are also dropped) when the requested content-type is disallowed, rather than unconditionally constructing an attachment node as before.

The predicate also returns `false` for every content-type when the editor is `attachments=false`, which means that case and a declared-but-empty allowlist are observationally equivalent for import, upload, and prompt-activation paths.

The attribute is parsed once at `connectedCallback` and cached on the element, matching Lexxy's existing init-only convention for configuration attributes; a host that needs to change the allowlist at runtime should disconnect and reconnect the element. As a backwards compatibility aid for consumers that still emit the legacy `"false"` string sentinel, the getter strips a literal `"false"` token from the parsed list, so that sentinel reduces to an empty list rather than a permit-only-the-word-`false` list.

An unset attribute preserves today's default: everything is permitted and no filtering happens. External consumers that do not set the attribute see no behavior change. Consumers that do set it get editor-level enforcement for free, rather than having to implement the allowlist check themselves.

New Playwright tests under `test/browser/tests/attachments/`, `test/browser/tests/prompts/`, and `test/browser/tests/paste/` cover import filtering, nested-in-table stripping, file-MIME rejection, prompt suppression by both content-type and `attachments=false`, programmatic-insert fallback shape, OG-embed round-trip, default and sentinel behaviors, and the XSS sanitization of arbitrary attachment attributes. A new dummy-app system test, `test/system/mention_round_trip_test.rb`, verifies the complete Action Text round-trip — an `<action-text-attachment>` wrapper containing a `<bc-mention>` element — through the edit, save, render, and re-edit cycle.
