### PR TITLE
Fix code block escape when last line contains only whitespace

### DIFF
--- a/src/nodes/early_escape_code_node.js
+++ b/src/nodes/early_escape_code_node.js
@@ -45,7 +45,13 @@ export class EarlyEscapeCodeNode extends CodeNode {
     if (!$isCursorOnLastLine(selection)) return false
 
     const textContent = this.getTextContent()
-    return textContent === "" || textContent.endsWith("\n")
+    if (textContent === "" || textContent.endsWith("\n")) return true
+
+    const lastNewlineIndex = textContent.lastIndexOf("\n")
+    if (lastNewlineIndex === -1) return false
+
+    const lastLine = textContent.slice(lastNewlineIndex + 1)
+    return lastLine.trim() === ""
   }
 
 }

--- a/src/nodes/early_escape_code_node.js
+++ b/src/nodes/early_escape_code_node.js
@@ -22,6 +22,11 @@ export class EarlyEscapeCodeNode extends CodeNode {
       return null
     }
 
+    if (this.#isCursorOnWhitespaceOnlyLastLine(selection)) {
+      $trimTrailingBlankNodes(this)
+      return super.insertNewAfter(selection, restoreSelection)
+    }
+
     if (this.#isCursorOnEmptyLastLine(selection)) {
       $trimTrailingBlankNodes(this)
 
@@ -45,13 +50,16 @@ export class EarlyEscapeCodeNode extends CodeNode {
     if (!$isCursorOnLastLine(selection)) return false
 
     const textContent = this.getTextContent()
-    if (textContent === "" || textContent.endsWith("\n")) return true
+    return textContent === "" || textContent.endsWith("\n")
+  }
 
+  #isCursorOnWhitespaceOnlyLastLine(selection) {
+    if (!$isCursorOnLastLine(selection)) return false
+
+    const textContent = this.getTextContent()
     const lastNewlineIndex = textContent.lastIndexOf("\n")
-    if (lastNewlineIndex === -1) return false
-
-    const lastLine = textContent.slice(lastNewlineIndex + 1)
-    return lastLine.trim() === ""
+    const lastLine = lastNewlineIndex === -1 ? textContent : textContent.slice(lastNewlineIndex + 1)
+    return lastLine.length > 0 && lastLine.trim() === ""
   }
 
 }

--- a/src/nodes/early_escape_code_node.js
+++ b/src/nodes/early_escape_code_node.js
@@ -18,24 +18,14 @@ export class EarlyEscapeCodeNode extends CodeNode {
     if (!selection.isCollapsed()) return super.insertNewAfter(selection, restoreSelection)
 
     if (this.#isCursorAtStart(selection)) {
-      this.insertBefore($createParagraphNode())
-      return null
-    }
-
-    if (this.#isCursorOnWhitespaceOnlyLastLine(selection)) {
-      $trimTrailingBlankNodes(this)
+      return this.#insertParagraphBefore()
+    } else if (this.#isCursorOnWhitespaceOnlyLastLine(selection)) {
+      return this.#insertBlankLineBelow(selection, restoreSelection)
+    } else if (this.#isCursorOnEmptyLastLine(selection)) {
+      return this.#escapeToNewParagraphAfter()
+    } else {
       return super.insertNewAfter(selection, restoreSelection)
     }
-
-    if (this.#isCursorOnEmptyLastLine(selection)) {
-      $trimTrailingBlankNodes(this)
-
-      const paragraph = $createParagraphNode()
-      this.insertAfter(paragraph)
-      return paragraph
-    }
-
-    return super.insertNewAfter(selection, restoreSelection)
   }
 
   #isCursorAtStart(selection) {
@@ -62,4 +52,21 @@ export class EarlyEscapeCodeNode extends CodeNode {
     return lastLine.length > 0 && lastLine.trim() === ""
   }
 
+  #insertParagraphBefore() {
+    this.insertBefore($createParagraphNode())
+    return null
+  }
+
+  #insertBlankLineBelow(selection, restoreSelection) {
+    super.insertNewAfter(selection, restoreSelection)
+    this.getLastChild().remove()
+    return null
+  }
+
+  #escapeToNewParagraphAfter() {
+    $trimTrailingBlankNodes(this)
+    const paragraph = $createParagraphNode()
+    this.insertAfter(paragraph)
+    return paragraph
+  }
 }

--- a/test/browser/tests/formatting/code_block_navigation.test.js
+++ b/test/browser/tests/formatting/code_block_navigation.test.js
@@ -53,6 +53,12 @@ test.describe("Code block navigation", () => {
     await editor.send("Enter")
     await editor.flush()
 
+    // Verify cursor is still inside the code block after first Enter
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toContainText("hello")
+      await expect(content.locator("p").filter({ hasText: /\S/ })).toHaveCount(0)
+    })
+
     // Second Enter: should exit the code block
     await editor.send("Enter")
     await editor.flush()

--- a/test/browser/tests/formatting/code_block_navigation.test.js
+++ b/test/browser/tests/formatting/code_block_navigation.test.js
@@ -36,6 +36,36 @@ test.describe("Code block navigation", () => {
     })
   })
 
+  test("pressing Enter twice exits code block when last line contains only whitespace", async ({ editor }) => {
+    // Create a code block and type content with a whitespace-only last line
+    await editor.click()
+    await editor.send("```")
+    await editor.send("Enter")
+    await editor.flush()
+
+    // Type some content, then a new line with only spaces
+    await editor.send("hello")
+    await editor.send("Enter")
+    await editor.send("   ")
+    await editor.flush()
+
+    // First Enter: should clear the whitespace, making the last line empty
+    await editor.send("Enter")
+    await editor.flush()
+
+    // Second Enter: should exit the code block
+    await editor.send("Enter")
+    await editor.flush()
+
+    await editor.send("outside text")
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toContainText("hello")
+      await expect(content.locator("code")).not.toContainText("outside text")
+      await expect(content.locator("p").filter({ hasText: "outside text" })).toHaveCount(1)
+    })
+  })
+
   test("code block content is preserved after inserting paragraph before it", async ({ editor }) => {
     await editor.setValue("<pre><code>line one\nline two</code></pre>")
 

--- a/test/browser/tests/formatting/code_block_navigation.test.js
+++ b/test/browser/tests/formatting/code_block_navigation.test.js
@@ -49,17 +49,17 @@ test.describe("Code block navigation", () => {
     await editor.send("   ")
     await editor.flush()
 
-    // First Enter: should clear the whitespace, making the last line empty
+    // First Enter: clears the whitespace-only line, cursor lands on an empty last line
     await editor.send("Enter")
     await editor.flush()
 
-    // Verify cursor is still inside the code block after first Enter
+    // Still inside the code block — no paragraphs should exist at all
     await assertEditorContent(editor, async (content) => {
       await expect(content.locator("code")).toContainText("hello")
-      await expect(content.locator("p").filter({ hasText: /\S/ })).toHaveCount(0)
+      await expect(content.locator("p:not(.provisional-paragraph)")).toHaveCount(0)
     })
 
-    // Second Enter: should exit the code block
+    // Second Enter: cursor is on an empty last line, so it escapes the code block
     await editor.send("Enter")
     await editor.flush()
 


### PR DESCRIPTION
## Summary

- Users couldn't escape a code block by pressing Enter when the cursor was on a line containing only whitespace (spaces/tabs)
- Root cause: `#isCursorOnEmptyLastLine` checked `textContent.endsWith("\n")` — when the last line had only whitespace, text ended with spaces not `\n`, so the escape path never triggered
- Fix: added `#isCursorOnWhitespaceOnlyLastLine` to detect whitespace-only last lines. First Enter clears the whitespace (removes the trailing whitespace child, leaves cursor on an empty last line). Second Enter triggers the normal empty-last-line escape (trims trailing blank nodes, inserts paragraph after the code block). This is consistent with the existing two-Enter escape for lines with content.

Fixes [Basecamp card #9813963984](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9813963984): Can't escape the code field