### PR TITLE
Fix broken code block styling for CLI-generated content

### DIFF
--- a/src/helpers/code_highlighting_helper.js
+++ b/src/helpers/code_highlighting_helper.js
@@ -2,11 +2,37 @@ import { createElement } from "./html_helper"
 import Prism from "../config/prism"
 
 export function highlightCode() {
-  const elements = document.querySelectorAll("pre[data-language]")
+  const elements = document.querySelectorAll("pre[data-language], pre:has(> code)")
 
   elements.forEach(preElement => {
+    normalizeNestedCodeElement(preElement)
     highlightElement(preElement)
   })
+}
+
+// CLI tools and markdown converters produce <pre><code class="language-ruby">...</code></pre>.
+// Normalize this to <pre data-language="ruby">...</pre> so highlightElement() can process it,
+// and prevent double styling from nested <pre> + <code> elements.
+function normalizeNestedCodeElement(preElement) {
+  const codeChild = preElement.querySelector(":scope > code")
+  if (!codeChild) return
+
+  if (!preElement.hasAttribute("data-language")) {
+    const language = languageFromClassList(codeChild)
+    if (language) {
+      preElement.setAttribute("data-language", language)
+    }
+  }
+
+  codeChild.replaceWith(...codeChild.childNodes)
+}
+
+function languageFromClassList(element) {
+  for (const cls of element.classList) {
+    const match = cls.match(/^language-(.+)$/)
+    if (match) return match[1]
+  }
+  return null
 }
 
 function highlightElement(preElement) {

--- a/test/system/cli_code_block_test.rb
+++ b/test/system/cli_code_block_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class CliCodeBlockTest < ApplicationSystemTestCase
+  test "code block with nested pre>code from CLI is highlighted correctly" do
+    post = posts(:empty)
+    # CLI-generated HTML: markdown code fences produce <pre><code class="language-ruby">
+    post.update!(body: '<pre><code class="language-ruby">def hello
+  puts "world"
+end</code></pre>')
+
+    visit post_path(post)
+
+    # highlightCode() should process CLI-style <pre><code class="language-*"> and produce
+    # a single <code data-language="ruby"> with Prism syntax highlighting
+    assert_selector "code[data-language='ruby']"
+    assert_selector "code span.token.keyword", text: "def"
+
+    # There should be no nested <pre><code> structure left (which causes double styling)
+    assert_no_selector "pre code"
+  end
+
+  test "code block with nested pre>code without language class renders as a proper code block" do
+    post = posts(:empty)
+    # CLI might also produce code blocks without language annotation
+    post.update!(body: '<pre><code>puts "hello world"</code></pre>')
+
+    visit post_path(post)
+
+    # Even without a language, the nested <code> should not create broken double-box styling.
+    # The <pre> should remain as a block-level code element without a redundant inner <code>.
+    assert_no_selector "pre > code"
+  end
+
+  test "code block with pre data-language from CLI uses newlines instead of br" do
+    post = posts(:empty)
+    # Some CLI tools might produce <pre data-language> with newlines instead of <br>
+    post.update!(body: "<pre data-language=\"ruby\">def hello\n  puts \"world\"\nend</pre>")
+
+    visit post_path(post)
+
+    # highlightCode() should handle newlines (not just <br>) and produce highlighted output
+    assert_selector "code[data-language='ruby']"
+    assert_selector "code span.token.keyword", text: "def"
+  end
+end


### PR DESCRIPTION
## Summary

- CLI tools and markdown converters produce `<pre><code class="language-ruby">` which differs from Lexxy's native `<pre data-language="ruby">` format
- This caused double styling (box-within-a-box from both `<pre>` and `<code>` getting background/padding) and no syntax highlighting (selector only matched `pre[data-language]`)
- Added `normalizeNestedCodeElement()` that extracts the language from `<code class="language-*">`, promotes it to `data-language` on `<pre>`, and unwraps the inner `<code>` element before Prism runs

Fixes [Basecamp card #9786748122](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9786748122): Code content generated in CLI break styles