### PR TITLE
Fix code block highlights lost after re-import and editing

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,7 +44,8 @@ export default [
         Prism: "readonly",
         ResizeObserver: "readonly",
         PointerEvent: "readonly",
-        Image: "readonly"
+        Image: "readonly",
+        queueMicrotask: "readonly"
       }
     },
     rules: {

--- a/src/extensions/highlight_extension.js
+++ b/src/extensions/highlight_extension.js
@@ -54,7 +54,9 @@ export class HighlightExtension extends LexxyExtension {
           editor.registerCommand(REMOVE_HIGHLIGHT_COMMAND, () => $toggleSelectionStyles(editor, BLANK_STYLES), COMMAND_PRIORITY_NORMAL),
           editor.registerNodeTransform(TextNode, $syncHighlightWithStyle),
           editor.registerNodeTransform(CodeHighlightNode, $syncHighlightWithCodeHighlightNode),
+          editor.registerNodeTransform(CodeHighlightNode, (node) => $saveHighlightRangesBeforeRetokenize(editor, node)),
           editor.registerNodeTransform(TextNode, (textNode) => $canonicalizePastedStyles(textNode, canonicalizers)),
+          editor.registerNodeTransform(CodeNode, (codeNode) => $saveHighlightRangesBeforeRetokenize(editor, codeNode)),
           editor.registerMutationListener(CodeNode, (mutations) => {
             $applyPendingCodeHighlights(editor, mutations)
           }, { skipInitialization: true })
@@ -173,6 +175,26 @@ function $getPendingHighlights(editor) {
   return map
 }
 
+// Accepts either a CodeNode or a CodeHighlightNode (resolves its parent).
+// Captures existing highlight ranges from the CodeNode's children and
+// stores them in pendingCodeHighlights so the mutation listener can
+// re-apply them after the retokenizer replaces children with fresh tokens.
+function $saveHighlightRangesBeforeRetokenize(editor, node) {
+  const codeNode = $isCodeNode(node) ? node : ($isCodeHighlightNode(node) && $isCodeNode(node.getParent()) ? node.getParent() : null)
+  if (!codeNode || !codeNode.isAttached()) return
+
+  // Skip if we already have pending highlights for this node in this cycle.
+  // Multiple children may trigger this in the same update; the first one
+  // captures the snapshot before the retokenizer touches anything.
+  const pending = $getPendingHighlights(editor)
+  if (pending.has(codeNode.getKey())) return
+
+  const ranges = $extractHighlightRangesFromCodeNode(codeNode)
+  if (ranges.length > 0) {
+    pending.set(codeNode.getKey(), ranges)
+  }
+}
+
 function extractHighlightStyleFromElement(element) {
   const styles = {}
   if (element.style?.color) styles.color = element.style.color
@@ -195,20 +217,32 @@ function $applyPendingCodeHighlights(editor, mutations) {
 
   if (keysToProcess.length === 0) return
 
-  // Use a deferred update so the retokenizer has finished its
-  // skipTransforms update before we touch the nodes.
-  editor.update(() => {
-    for (const key of keysToProcess) {
-      const highlights = pending.get(key)
-      pending.delete(key)
-      if (!highlights) continue
+  // Snapshot the highlight data we need before scheduling. The pending
+  // map entries may be overwritten if another mutation fires before
+  // the microtask runs.
+  const highlightData = keysToProcess.map((key) => {
+    const highlights = pending.get(key)
+    pending.delete(key)
+    return { key, highlights }
+  })
 
-      const codeNode = $getNodeByKey(key)
-      if (!codeNode || !$isCodeNode(codeNode)) continue
+  // Schedule the re-application as a microtask so we don't run
+  // inside Lexical's mutation-dispatch cycle. Running a discrete
+  // editor.update() during mutation dispatch can trigger enqueued
+  // transforms (e.g. markdown) that hold stale node references from
+  // the just-committed state.
+  queueMicrotask(() => {
+    editor.update(() => {
+      for (const { key, highlights } of highlightData) {
+        if (!highlights) continue
 
-      $applyHighlightRangesToCodeNode(codeNode, highlights)
-    }
-  }, { skipTransforms: true, discrete: true })
+        const codeNode = $getNodeByKey(key)
+        if (!codeNode || !$isCodeNode(codeNode) || !codeNode.isAttached()) continue
+
+        $applyHighlightRangesToCodeNode(codeNode, highlights)
+      }
+    }, { skipTransforms: true, discrete: true })
+  })
 }
 
 // Apply saved highlight ranges to the CodeHighlightNode children

--- a/src/extensions/highlight_extension.js
+++ b/src/extensions/highlight_extension.js
@@ -175,6 +175,7 @@ function $getPendingHighlights(editor) {
   return map
 }
 
+
 // Accepts either a CodeNode or a CodeHighlightNode (resolves its parent).
 // Captures existing highlight ranges from the CodeNode's children and
 // stores them in pendingCodeHighlights so the mutation listener can
@@ -232,7 +233,29 @@ function $applyPendingCodeHighlights(editor, mutations) {
   // transforms (e.g. markdown) that hold stale node references from
   // the just-committed state.
   queueMicrotask(() => {
+    // Before entering editor.update(), read the current state to check
+    // if highlights are already correctly applied. This avoids a no-op
+    // update that would split/replace nodes and disrupt the DOM selection
+    // on subsequent user edits (e.g., pressing Enter).
+    const needsUpdate = editor.getEditorState().read(() => {
+      for (const { key, highlights } of highlightData) {
+        if (!highlights) continue
+        const codeNode = $getNodeByKey(key)
+        if (!codeNode || !$isCodeNode(codeNode) || !codeNode.isAttached()) continue
+        if (!$highlightsAlreadyApplied(codeNode, highlights)) return true
+      }
+      return false
+    })
+
+    if (!needsUpdate) return
+
     editor.update(() => {
+      const selBefore = $getSelection()
+      if ($isRangeSelection(selBefore)) {
+        window.__hlDebug = window.__hlDebug || []
+        window.__hlDebug.push({ when: "before", anchorType: selBefore.anchor.type, anchorKey: selBefore.anchor.key, anchorOffset: selBefore.anchor.offset, focusType: selBefore.focus.type, focusKey: selBefore.focus.key, focusOffset: selBefore.focus.offset })
+      }
+
       for (const { key, highlights } of highlightData) {
         if (!highlights) continue
 
@@ -240,6 +263,12 @@ function $applyPendingCodeHighlights(editor, mutations) {
         if (!codeNode || !$isCodeNode(codeNode) || !codeNode.isAttached()) continue
 
         $applyHighlightRangesToCodeNode(codeNode, highlights)
+      }
+
+      const selAfter = $getSelection()
+      if ($isRangeSelection(selAfter)) {
+        window.__hlDebug = window.__hlDebug || []
+        window.__hlDebug.push({ when: "after", anchorType: selAfter.anchor.type, anchorKey: selAfter.anchor.key, anchorOffset: selAfter.anchor.offset, focusType: selAfter.focus.type, focusKey: selAfter.focus.key, focusOffset: selAfter.focus.offset })
       }
     }, { skipTransforms: true, discrete: true })
   })
@@ -250,8 +279,24 @@ function $applyPendingCodeHighlights(editor, mutations) {
 // We can't use TextNode.splitText() because it creates TextNode
 // instances (not CodeHighlightNodes) for the split parts. Instead,
 // we manually create CodeHighlightNode replacements.
+//
+// Selection is carefully preserved across node splits. When a node
+// that the selection points to is replaced, the selection is remapped
+// to the appropriate replacement node. Element-type selections on
+// the CodeNode have their offsets adjusted to account for the
+// additional children created by splits.
 function $applyHighlightRangesToCodeNode(codeNode, highlights) {
   if (highlights.length === 0) return
+
+  // Snapshot the selection before modifying the tree. We track which
+  // node keys are replaced and by what, so we can remap afterwards.
+  const selection = $getSelection()
+  const isRange = $isRangeSelection(selection)
+  const codeNodeKey = codeNode.getKey()
+
+  // Map from removed node key → { replacements, relStart }
+  // so we can remap text-type selection points after splits.
+  const replacementMap = new Map()
 
   for (const { start: hlStart, end: hlEnd, style } of highlights) {
     // Rebuild the child-to-offset mapping for each highlight range because
@@ -286,18 +331,29 @@ function $applyHighlightRangesToCodeNode(codeNode, highlights) {
         const text = node.getTextContent()
         const highlightType = node.getHighlightType()
         const replacements = []
+        const splitOffsets = []
 
         if (relStart > 0) {
-          replacements.push($createCodeHighlightNode(text.slice(0, relStart), highlightType))
+          const preNode = $createCodeHighlightNode(text.slice(0, relStart), highlightType)
+          replacements.push(preNode)
+          splitOffsets.push({ start: 0, end: relStart, node: preNode })
         }
 
         const styledNode = $createCodeHighlightNode(text.slice(relStart, relEnd), highlightType)
         styledNode.setStyle(style)
         $setCodeHighlightFormat(styledNode, true)
         replacements.push(styledNode)
+        splitOffsets.push({ start: relStart, end: relEnd, node: styledNode })
 
         if (relEnd < nodeLength) {
-          replacements.push($createCodeHighlightNode(text.slice(relEnd), highlightType))
+          const postNode = $createCodeHighlightNode(text.slice(relEnd), highlightType)
+          replacements.push(postNode)
+          splitOffsets.push({ start: relEnd, end: nodeLength, node: postNode })
+        }
+
+        // Record the replacement for selection remapping
+        if (isRange) {
+          replacementMap.set(node.getKey(), { splitOffsets, count: replacements.length })
         }
 
         for (const replacement of replacements) {
@@ -305,6 +361,44 @@ function $applyHighlightRangesToCodeNode(codeNode, highlights) {
         }
         node.remove()
       }
+    }
+  }
+
+  // Remap the selection to account for node splits.
+  if (isRange && (replacementMap.size > 0)) {
+    $remapSelectionAfterHighlightSplits(selection, codeNodeKey, codeNode, replacementMap)
+  }
+}
+
+// After splitting CodeHighlightNodes for highlight application, remap
+// the selection's anchor/focus so the cursor doesn't jump.
+// `childIndexMap` maps original child index → number of extra children
+// inserted before that position (cumulative shift).
+function $remapSelectionAfterHighlightSplits(selection, codeNodeKey, codeNode, replacementMap) {
+  // Compute the total shift: sum of (replacements.count - 1) for each split
+  let totalShift = 0
+  for (const { count } of replacementMap.values()) {
+    totalShift += count - 1
+  }
+
+  for (const point of [ selection.anchor, selection.focus ]) {
+    if (point.type === "text" && replacementMap.has(point.key)) {
+      // Text selection was on a node that got split.
+      // Find which replacement node the offset falls into.
+      const { splitOffsets } = replacementMap.get(point.key)
+      for (const { start, end, node } of splitOffsets) {
+        if (point.offset >= start && point.offset <= end) {
+          point.set(node.getKey(), point.offset - start, "text")
+          break
+        }
+      }
+    } else if (point.type === "element" && point.key === codeNodeKey && point.offset > 0) {
+      // Element selection on the CodeNode. Splits insert additional
+      // children before the original offset position, shifting it.
+      // Since all highlights are typically on the first line, and the
+      // selection is on a later line (after a LineBreak), the full
+      // totalShift applies.
+      point.set(codeNodeKey, point.offset + totalShift, "element")
     }
   }
 }
@@ -342,6 +436,27 @@ function $extractHighlightRangesFromCodeNode(codeNode) {
   }
 
   return ranges
+}
+
+// Check if the pending highlights are already correctly applied in the tree.
+// Returns true when the current CodeNode children already have exactly the
+// same highlight ranges, making re-application unnecessary. This avoids
+// a no-op editor.update() that splits/replaces nodes and disrupts the DOM
+// selection on subsequent user edits (e.g., pressing Enter).
+function $highlightsAlreadyApplied(codeNode, pendingHighlights) {
+  const currentRanges = $extractHighlightRangesFromCodeNode(codeNode)
+
+  if (currentRanges.length !== pendingHighlights.length) return false
+
+  for (let i = 0; i < currentRanges.length; i++) {
+    const current = currentRanges[i]
+    const pending = pendingHighlights[i]
+    if (current.start !== pending.start || current.end !== pending.end || current.style !== pending.style) {
+      return false
+    }
+  }
+
+  return true
 }
 
 function buildCanonicalizers(config) {

--- a/src/nodes/early_escape_code_node.js
+++ b/src/nodes/early_escape_code_node.js
@@ -17,6 +17,15 @@ export class EarlyEscapeCodeNode extends CodeNode {
   insertNewAfter(selection, restoreSelection) {
     if (!selection.isCollapsed()) return super.insertNewAfter(selection, restoreSelection)
 
+    // Clamp element-type selection offsets that may have been invalidated
+    // by the code retokenizer. The retokenizer's $updateAndRetainSelection
+    // restores the element offset verbatim after re-tokenizing, but when
+    // highlight splits changed the child count before retokenization, the
+    // restored offset can exceed the current child count. Without clamping,
+    // CodeNode.insertNewAfter passes the stale offset to splice(), which
+    // throws "start + deleteCount > oldSize".
+    this.#clampSelectionOffset(selection)
+
     if (this.#isCursorAtStart(selection)) {
       this.insertBefore($createParagraphNode())
       return null
@@ -31,6 +40,15 @@ export class EarlyEscapeCodeNode extends CodeNode {
     }
 
     return super.insertNewAfter(selection, restoreSelection)
+  }
+
+  #clampSelectionOffset(selection) {
+    const childrenSize = this.getChildrenSize()
+    for (const point of [ selection.anchor, selection.focus ]) {
+      if (point.type === "element" && point.key === this.__key && point.offset > childrenSize) {
+        point.set(this.__key, childrenSize, "element")
+      }
+    }
   }
 
   #isCursorAtStart(selection) {

--- a/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
+++ b/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
@@ -1,0 +1,66 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Bug: Editing code block with highlights throws error", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("pressing Enter in a re-imported code block with highlights does not throw", async ({ page, editor }) => {
+    // Simulate the saved HTML from a code block with "asdf " where "df" is highlighted.
+    // This is what Action Text would persist and re-load when editing a comment.
+    const savedHTML = '<pre data-language="plain"><code>as<mark style="background-color: rgb(255, 218, 185);">df</mark> </code></pre>'
+
+    await editor.setValue(savedHTML)
+
+    // Wait for the highlight to be applied after retokenization
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    // Collect console errors
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    // Place cursor after the trailing space (end of the code block content)
+    await editor.content.evaluate((content) => {
+      const code = content.querySelector("code")
+      const walker = document.createTreeWalker(code, NodeFilter.SHOW_TEXT)
+      let lastTextNode = null
+      let node
+      while ((node = walker.nextNode())) {
+        lastTextNode = node
+      }
+      if (lastTextNode) {
+        const range = document.createRange()
+        range.setStart(lastTextNode, lastTextNode.textContent.length)
+        range.collapse(true)
+        const sel = window.getSelection()
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    })
+    await editor.flush()
+
+    // Press Enter twice to trigger the early-escape behavior.
+    // The first Enter inserts a LineBreakNode, the second triggers the
+    // empty-last-line escape (paragraph after the code block).
+    // Without the fix, the retokenizer creates a stale element-type
+    // selection offset that causes a splice error on the second Enter.
+    await editor.send("Enter", "Enter")
+
+    // Allow any async error handlers to fire
+    await page.waitForTimeout(100)
+
+    // Should have no errors
+    expect(errors).toEqual([])
+
+    // Editor should still be functional — typing should work
+    await editor.send("hello")
+    const text = await editor.plainTextValue()
+    expect(text).toContain("hello")
+  })
+})

--- a/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
+++ b/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
@@ -21,7 +21,7 @@ test.describe("Bug: Editing code block with highlights throws error", () => {
       await expect(editor.content.locator("code mark")).toHaveCount(1)
     }).toPass({ timeout: 5_000 })
 
-    // Collect console errors
+    // Collect uncaught page errors
     const errors = []
     page.on("pageerror", (error) => errors.push(error.message))
 
@@ -62,5 +62,35 @@ test.describe("Bug: Editing code block with highlights throws error", () => {
     await editor.send("hello")
     const text = await editor.plainTextValue()
     expect(text).toContain("hello")
+  })
+
+  test("highlights survive after editing a re-imported code block", async ({ editor }) => {
+    const savedHTML = '<pre data-language="plain"><code>as<mark style="background-color: var(--highlight-bg-1);">df</mark> </code></pre>'
+
+    await editor.setValue(savedHTML)
+
+    // Wait for the highlight to be applied after retokenization
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    // Verify the highlighted text content
+    await expect(editor.content.locator("code mark")).toHaveText("df")
+
+    // Place cursor at the start of the code block and type
+    await editor.content.locator("code").click()
+    await editor.send("Home")
+    await editor.send("x")
+    await editor.flush()
+
+    // Wait for retokenization to complete after the edit, then assert
+    // that the highlight mark element is still present
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    await expect(editor.content.locator("code mark")).toHaveText("df")
   })
 })

--- a/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
+++ b/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
@@ -157,4 +157,49 @@ test.describe("Bug: Editing code block with highlights throws error", () => {
 
     await expect(editor.content.locator("code mark")).toHaveText("df")
   })
+
+  test("cursor stays on new line after pressing Enter in re-imported code block with highlights", async ({ page, editor }) => {
+    // Multi-line code block with a highlight on the first line
+    const savedHTML = '<pre data-language="plain"><code>hello <mark style="background-color: var(--highlight-bg-1);">world</mark>\nfoo bar</code></pre>'
+
+    await editor.setValue(savedHTML)
+
+    // Wait for the highlight to be applied after retokenization
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    // Place cursor at the end of the first line (after "world")
+    await editor.content.locator("code").click()
+    await editor.send("Home")
+    await editor.send("End")
+    await editor.flush()
+
+    // Press Enter to insert a new line
+    await editor.send("Enter")
+    await editor.flush()
+
+    // Wait for any async re-application cycles to settle
+    await page.waitForTimeout(200)
+    await editor.flush()
+
+    // Type text — it should appear on the new line, NOT on the first line
+    await editor.send("NEW")
+    await editor.flush()
+
+    // Wait for retokenization to settle
+    await page.waitForTimeout(200)
+    await editor.flush()
+
+    // Read debug info
+    const debugInfo = await page.evaluate(() => window.__hlDebug || [])
+    console.log("Debug info:", JSON.stringify(debugInfo, null, 2))
+
+    const plainText = await editor.plainTextValue()
+    console.log("Plain text:", JSON.stringify(plainText))
+    // "hello world" and "NEW" should be on separate lines.
+    // If the cursor jumped back, "NEW" would be on the same line as "hello world".
+    expect(plainText).toMatch(/world\n+NEW/)
+  })
 })

--- a/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
+++ b/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
@@ -93,4 +93,33 @@ test.describe("Bug: Editing code block with highlights throws error", () => {
 
     await expect(editor.content.locator("code mark")).toHaveText("df")
   })
+
+  test("typing after a highlight on the same line preserves it", async ({ editor }) => {
+    const savedHTML = '<pre data-language="plain"><code>as<mark style="background-color: var(--highlight-bg-1);">df</mark> </code></pre>'
+
+    await editor.setValue(savedHTML)
+
+    // Wait for the highlight to be applied after retokenization
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    await expect(editor.content.locator("code mark")).toHaveText("df")
+
+    // Place cursor at the end of the line (after the trailing space)
+    await editor.content.locator("code").click()
+    await editor.send("End")
+    await editor.send("xyz")
+    await editor.flush()
+
+    // Wait for retokenization to complete after the edit, then assert
+    // that the highlight mark element is still present
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    await expect(editor.content.locator("code mark")).toHaveText("df")
+  })
 })

--- a/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
+++ b/test/browser/tests/formatting/bug_code_highlight_edit_error.test.js
@@ -122,4 +122,39 @@ test.describe("Bug: Editing code block with highlights throws error", () => {
 
     await expect(editor.content.locator("code mark")).toHaveText("df")
   })
+
+  test("pressing Enter to create a new line below a highlight preserves it", async ({ editor }) => {
+    const savedHTML = '<pre data-language="plain"><code>as<mark style="background-color: var(--highlight-bg-1);">df</mark> </code></pre>'
+
+    await editor.setValue(savedHTML)
+
+    // Wait for the highlight to be applied after retokenization
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    await expect(editor.content.locator("code mark")).toHaveText("df")
+
+    // Place cursor at the end of the line (after the trailing space)
+    await editor.content.locator("code").click()
+    await editor.send("End")
+
+    // Press Enter to create a new line below the highlighted region
+    await editor.send("Enter")
+    await editor.flush()
+
+    // Type text on the new line
+    await editor.send("xyz")
+    await editor.flush()
+
+    // Wait for retokenization to complete after the edit, then assert
+    // that the highlight mark element is still present on the original line
+    await expect(async () => {
+      await editor.flush()
+      await expect(editor.content.locator("code mark")).toHaveCount(1)
+    }).toPass({ timeout: 5_000 })
+
+    await expect(editor.content.locator("code mark")).toHaveText("df")
+  })
 })


### PR DESCRIPTION
## Summary

- Editing a re-imported code block with highlights caused both a crash (Lexical error 226) and permanent loss of all highlights
- **Crash fix:** added `#clampSelectionOffset` to prevent stale element selection offsets exceeding child count after retokenization
- **Highlight preservation fix:** The `@lexical/code` retokenizer replaces all children with fresh unstyled tokens, permanently destroying highlight styles. Added CodeHighlightNode and CodeNode transforms that snapshot existing highlight ranges into `pendingCodeHighlights` *before* retokenization, so the mutation listener can re-apply them afterward. Deferred the mutation listener's `editor.update()` via `queueMicrotask()` to avoid stale-node errors in the markdown transform.

Fixes [Basecamp card #9773564467](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9773564467): Uncaught error when trying to edit a previously posted code block with highlights