### PR TITLE
Fix pasting text with blank lines breaking out of code blocks

### DIFF
--- a/src/nodes/early_escape_code_node.js
+++ b/src/nodes/early_escape_code_node.js
@@ -1,4 +1,4 @@
-import { $createParagraphNode } from "lexical"
+import { $createParagraphNode, $hasUpdateTag, PASTE_TAG } from "lexical"
 import { CodeNode } from "@lexical/code"
 import { $getNearestNodeOfType } from "@lexical/utils"
 import { $isAtNodeStart, $isCursorOnLastLine, $trimTrailingBlankNodes } from "../helpers/lexical_helper"
@@ -15,9 +15,9 @@ export class EarlyEscapeCodeNode extends CodeNode {
   }
 
   insertNewAfter(selection, restoreSelection) {
-    if (!selection.isCollapsed()) return super.insertNewAfter(selection, restoreSelection)
-
-    if (this.#isCursorAtStart(selection)) {
+    if ($hasUpdateTag(PASTE_TAG) || !selection.isCollapsed()) {
+      return super.insertNewAfter(selection, restoreSelection)
+    } else if (this.#isCursorAtStart(selection)) {
       return this.#insertParagraphBefore()
     } else if (this.#isCursorOnWhitespaceOnlyLastLine(selection)) {
       return this.#insertBlankLineBelow(selection, restoreSelection)

--- a/test/browser/tests/paste/paste_into_code_block.test.js
+++ b/test/browser/tests/paste/paste_into_code_block.test.js
@@ -1,0 +1,53 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+test.describe("Paste — Code block", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("pasting text with blank lines into a code block keeps all content inside", async ({ editor }) => {
+    await editor.setValue("<pre><code>existing code</code></pre>")
+    await editor.content.locator("code").click()
+    await editor.send("End")
+    await editor.flush()
+
+    await editor.paste("line one\n\nline two\n\nline three")
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      const code = content.locator("code")
+      await expect(code).toHaveCount(1)
+      await expect(code).toContainText("existing code")
+      await expect(code).toContainText("line one")
+      await expect(code).toContainText("line two")
+      await expect(code).toContainText("line three")
+
+      // No content should have escaped to paragraphs outside the code block
+      const outerParagraphs = content.locator(":scope > p:not(.provisional-paragraph)")
+      await expect(outerParagraphs).toHaveCount(0)
+    })
+  })
+
+  test("pasting text with blank lines into an empty code block keeps all content inside", async ({ editor }) => {
+    await editor.click()
+    await editor.clickToolbarButton("insertCodeBlock")
+    await editor.flush()
+
+    await editor.paste("function hello() {\n  console.log('hi')\n\n  return true\n}")
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      const code = content.locator("code")
+      await expect(code).toHaveCount(1)
+      await expect(code).toContainText("function hello()")
+      await expect(code).toContainText("return true")
+
+      const outerParagraphs = content.locator(":scope > p:not(.provisional-paragraph)")
+      await expect(outerParagraphs).toHaveCount(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Pasting text with blank lines (two consecutive newlines) into a code block caused content to break out into separate paragraphs
- Root cause: during paste, Lexical calls `insertNewAfter()` for each newline; when a blank line creates an empty last line, `EarlyEscapeCodeNode`'s escape logic fires mid-paste, splitting content out
- Fix: added a `$hasUpdateTag(PASTE_TAG)` guard at the top of `insertNewAfter()` — during paste operations, delegate to the base `CodeNode` behavior which keeps content inside the block. Normal Enter-to-escape is unaffected.

Fixes [Basecamp card #9765146588](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9765146588): Pasting block w/ 2 newlines breaks out of codeblock