### PR TITLE
Fix code block copy/paste: preserve newlines and always paste as plain text

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -16,7 +16,13 @@ export default class Clipboard {
   paste(event) {
     const clipboardData = event.clipboardData
 
-    if (!clipboardData || this.#isPastingIntoCodeBlock()) return false
+    if (!clipboardData) return false
+
+    if (this.#isPastingIntoCodeBlock()) {
+      this.#pastePlainTextIntoCodeBlock(clipboardData)
+      event.preventDefault()
+      return true
+    }
 
     if (this.#isPlainTextOrURLPasted(clipboardData)) {
       this.#pastePlainText(clipboardData)
@@ -63,6 +69,16 @@ export default class Clipboard {
     })
 
     return result
+  }
+
+  #pastePlainTextIntoCodeBlock(clipboardData) {
+    const text = clipboardData.getData("text/plain")
+    if (!text) return
+
+    this.editor.update(() => {
+      const selection = $getSelection()
+      if ($isRangeSelection(selection)) selection.insertRawText(text)
+    }, { tag: PASTE_TAG })
   }
 
   #pastePlainText(clipboardData) {

--- a/src/helpers/code_highlighting_helper.js
+++ b/src/helpers/code_highlighting_helper.js
@@ -29,7 +29,7 @@ function highlightElement(preElement) {
     applyHighlightRanges(codeElement, highlights)
   }
 
-  preElement.replaceWith(codeElement)
+  preElement.replaceChildren(codeElement)
 }
 
 // Walk the DOM tree inside a <pre> element and build a list of

--- a/test/browser/tests/paste/code_block_copy.test.js
+++ b/test/browser/tests/paste/code_block_copy.test.js
@@ -1,0 +1,37 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Paste — Code block copy preserves newlines", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("pasting a highlighted code block preserves newlines", async ({
+    page,
+    editor,
+  }) => {
+    await editor.click()
+
+    // After highlightCode() runs on a rendered view, the stored <pre> is
+    // replaced with <pre><code data-language="...">…highlighted…</code></pre>.
+    // The <pre> wrapper preserves whitespace so that literal \n characters in
+    // the text survive the browser's copy-to-clipboard serialization.
+    //
+    // Simulate pasting this highlighted HTML into the editor.
+    const html = '<pre><code data-language="ruby">' +
+      '<span class="token keyword">set</span> vlans 100\n' +
+      '<span class="token keyword">set</span> vlans 200\n' +
+      '<span class="token keyword">set</span> interfaces ge-0/0/1</code></pre>'
+
+    await editor.paste(
+      "set vlans 100\nset vlans 200\nset interfaces ge-0/0/1",
+      { html },
+    )
+    await editor.flush()
+
+    const plainText = await editor.plainTextValue()
+    expect(plainText).toContain("set vlans 100\nset vlans 200\nset interfaces ge-0/0/1")
+  })
+})

--- a/test/javascript/unit/helpers/code_highlighting_helper.test.js
+++ b/test/javascript/unit/helpers/code_highlighting_helper.test.js
@@ -37,3 +37,19 @@ const expectedGrammars = [
 test.each(expectedGrammars)("Prism includes the %s grammar", (grammar) => {
   expect(Prism.languages[grammar]).toBeDefined()
 })
+
+test("highlightCode preserves the pre wrapper around the highlighted code element", () => {
+  const pre = document.createElement("pre")
+  pre.setAttribute("data-language", "javascript")
+  pre.innerHTML = "const a = 1<br>const b = 2"
+  document.body.appendChild(pre)
+
+  highlightCode()
+
+  const code = document.querySelector("code[data-language='javascript']")
+  expect(code).toBeTruthy()
+  expect(code.parentElement.tagName).toBe("PRE")
+  expect(code.textContent).toContain("const a = 1\nconst b = 2")
+
+  code.parentElement.remove()
+})


### PR DESCRIPTION
## Summary

- Copying a multi-line code block and pasting elsewhere collapsed all newlines into a single line
- Root cause: `highlightCode()` replaced the `<pre>` element with a bare `<code>` element — since `<code>` is inline, browsers collapse whitespace on copy
- Fix: changed `preElement.replaceWith(codeElement)` to `preElement.replaceChildren(codeElement)` to keep the `<pre>` wrapper

Additionally:
- Pasting into a code block now always uses plain text (`selection.insertRawText`), preventing HTML clipboard data from breaking code block structure
- Previously, paste-into-code-block was unhandled (deferred to Lexical's native handler which could interpret HTML and split the block)

Fixes [Basecamp card #9808822823](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9808822823): copy code block new lines are lost