### PR TITLE
Don't skip DOM selection update when setting value on focussed editor

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,4 +1,4 @@
-import { $createParagraphNode, $getRoot, $getSelection, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
@@ -16,7 +16,7 @@ import { HorizontalDividerNode } from "../nodes/horizontal_divider_node"
 import { CommandDispatcher } from "../editor/command_dispatcher"
 import Selection from "../editor/selection"
 import { createElement, dispatch, generateDomId, parseHtml } from "../helpers/html_helper"
-import { isAttachmentSpacerTextNode } from "../helpers/lexical_helper"
+import { isAttachmentSpacerTextNode, isEditorFocused } from "../helpers/lexical_helper"
 import { sanitize, setSanitizerConfig } from "../helpers/sanitization_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 import LexicalToolbar from "./toolbar"
@@ -251,14 +251,18 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   set value(html) {
+    const editorHasFocus = isEditorFocused(this.editor)
+
     this.editor.update(() => {
+      if (!editorHasFocus) $addUpdateTag(SKIP_DOM_SELECTION_TAG)
+
       $getRoot()
         .clear()
         .selectEnd()
         .insertNodes(this.#parseHtmlIntoLexicalNodes(html))
 
       this.#toggleEmptyStatus()
-    }, { discrete: true, tag: SKIP_DOM_SELECTION_TAG })
+    }, { discrete: true })
   }
 
   get canUndo() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -237,7 +237,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   get #isContentFocused() {
-    return !!this.editorContentElement && this.editorContentElement.contains(document.activeElement)
+    return !!this.editor && isEditorFocused(this.editor)
   }
 
   get value() {
@@ -251,7 +251,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   set value(html) {
-    const editorHasFocus = isEditorFocused(this.editor)
+    const editorHasFocus = this.#isContentFocused
 
     this.editor.update(() => {
       if (!editorHasFocus) $addUpdateTag(SKIP_DOM_SELECTION_TAG)

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,4 +1,4 @@
-import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
@@ -254,7 +254,13 @@ export class LexicalEditorElement extends HTMLElement {
     const editorHasFocus = this.#isContentFocused
 
     this.editor.update(() => {
-      if (!editorHasFocus) $addUpdateTag(SKIP_DOM_SELECTION_TAG)
+      if (editorHasFocus) {
+        // Address Safari inconsistently placing the cursor in the contenteditable by forcing focus back onto the editor
+        // Use direct `editor.focus` to bypass the pre-existing focus optimization and skip the callback
+        $onUpdate(() => this.editor.focus())
+      } else {
+        $addUpdateTag(SKIP_DOM_SELECTION_TAG)
+      }
 
       $getRoot()
         .clear()


### PR DESCRIPTION
Address a bug where Safari will place the cursor in an inconsistent location in the contenteditable when the value is set

<img width="676" height="216" alt="image" src="https://github.com/user-attachments/assets/b02e0732-cc52-4e1c-a7b7-77730c51c37b" />


- Don't skip DOM selection update when setting value on focussed editor
- Refresh editor focus after setting value where focus is already present