### PR TITLE
Fix paste into quote: honor cursor position and avoid extra blank line

### DIFF
--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -1,6 +1,5 @@
 import { $createLineBreakNode, $createParagraphNode, $createTextNode, $getChildCaretAtIndex, $isElementNode, $isLineBreakNode, $isNodeSelection } from "lexical"
 import { CodeNode } from "@lexical/code"
-import { QuoteNode } from "@lexical/rich-text"
 import { $ensureForwardRangeSelection } from "@lexical/selection"
 import { $getNearestNodeOfType } from "@lexical/utils"
 import { $isShadowRoot } from "../../helpers/lexical_helper"
@@ -9,7 +8,6 @@ export default class NodeInserter {
   static for(selection) {
     const INSERTERS = [
       CodeNodeInserter,
-      QuoteNodeInserter,
       ShadowRootNodeInserter,
       NodeSelectionNodeInserter
     ]
@@ -56,25 +54,6 @@ class CodeNodeInserter extends NodeInserter {
     }
   }
 
-}
-
-// Lexical will split a QuoteNode when inserting other Elements - we want them simply inserted as-is
-class QuoteNodeInserter extends NodeInserter {
-  static handles(selection) {
-    return $getNearestNodeOfType(selection.anchor?.getNode(), QuoteNode)
-  }
-
-  insertNodes(nodes) {
-    if (!this.selection.isCollapsed()) { this.selection.removeText() }
-
-    $ensureForwardRangeSelection(this.selection)
-    let lastNode = this.selection.focus.getNode()
-    for (const node of nodes) {
-      lastNode = lastNode.insertAfter(node)
-    }
-
-    lastNode.selectEnd()
-  }
 }
 
 class ShadowRootNodeInserter extends NodeInserter {

--- a/test/browser/tests/paste/paste_into_quote.test.js
+++ b/test/browser/tests/paste/paste_into_quote.test.js
@@ -1,0 +1,87 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent, assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Paste into quote", () => {
+  test("pasting text at a specific cursor position within a quote inserts at that position", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    // Set up a blockquote with text and place cursor in the middle
+    await editor.setValue("<blockquote><p>Hello World</p></blockquote>")
+    await editor.focus()
+
+    // Place cursor after "Hello" using Home then 5x ArrowRight
+    await editor.send("Home")
+    for (let i = 0; i < 5; i++) await editor.send("ArrowRight")
+    await editor.flush()
+
+    await editor.paste("INSERTED", { html: "<span>INSERTED</span>" })
+    await editor.flush()
+
+    // The pasted text should appear at cursor position, not at the end
+    await assertEditorHtml(editor, "<blockquote><p>HelloINSERTED World</p></blockquote>")
+  })
+
+  test("pasting HTML into a quote does not make the editor unresponsive", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    // Create a quote block via the toolbar
+    await editor.click()
+    await page.getByRole("button", { name: "Quote" }).click()
+    await editor.flush()
+
+    // Track console errors
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    // Paste HTML content (this is what triggers the unresponsive state)
+    await editor.paste("First paragraph\nSecond paragraph", {
+      html: "<p>First paragraph</p><p>Second paragraph</p>",
+    })
+    await editor.flush()
+
+    // Editor should remain responsive - verify by typing after paste
+    await editor.send(" more text")
+    await editor.flush()
+
+    // No console errors should have occurred
+    expect(errors).toHaveLength(0)
+
+    // Content should be inside the blockquote
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toHaveCount(1)
+      await expect(content.locator("blockquote")).toContainText("Second paragraph more text")
+    })
+  })
+
+  test("pasting into a quote does not prepend an extra blank line", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    // Create a quote block
+    await editor.click()
+    await page.getByRole("button", { name: "Quote" }).click()
+    await editor.flush()
+
+    // Paste a sentence (simulates copying from Basecamp)
+    await editor.paste("A copied sentence", {
+      html: "<span>A copied sentence</span>",
+    })
+    await editor.flush()
+
+    // The pasted content should start on the first line of the quote,
+    // not on a second line after a blank first line
+    await assertEditorHtml(editor, "<blockquote><p>A copied sentence</p></blockquote>")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes three interrelated quote/paste bugs:

- [Pasting into a quote doesn't honor cursor location](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9796872939) — pasted text goes to the end of the quote instead of at the cursor position.
- [Editor becomes unresponsive when pasting into a quote-block](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9789579032) — HTML paste into an empty quote could produce broken structure.
- [Quote formatting then pasting almost always starts on a 2nd line](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9791145467) — an empty line was prepended before the pasted content.

**Root cause:** `QuoteNodeInserter` used `insertAfter` on the focus node, ignoring the cursor offset within text nodes.

~~Fixed it manually with a $splitAtPointCaret as that nicely splits only one level and returns a convenient caret to insert the nodes at.~~

Fixed passing all tests by removing special handling to default to Lexical behavior