### PR TITLE
Fix quote formatting discarding line breaks in middle paragraphs

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -399,8 +399,6 @@ export default class Contents {
   }
 
   #splitParagraphsAtLineBreaks(selection) {
-    const anchorTopLevel = selection.anchor.getNode().getTopLevelElement()
-    const focusTopLevel = selection.focus.getNode().getTopLevelElement()
     const topLevelElements = this.#topLevelElementsInSelection(selection)
 
     for (const element of topLevelElements) {
@@ -408,13 +406,6 @@ export default class Contents {
 
       const children = element.getChildren()
       if (!children.some($isLineBreakNode)) continue
-
-      // Check whether this paragraph needs splitting: skip only if neither
-      // selection endpoint is inside it (meaning it's a middle paragraph
-      // fully between anchor and focus with no partial lines to split off).
-      // Compare top-level elements so endpoints inside nested inline nodes
-      // (e.g. text inside a LinkNode) are still recognized.
-      if (element !== anchorTopLevel && element !== focusTopLevel) continue
 
       const groups = [ [] ]
       for (const child of children) {

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -188,6 +188,40 @@ test.describe("Block formatting", () => {
     )
   })
 
+  test("quoting across paragraphs splits soft breaks in middle paragraphs", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      "<p>First</p><p>Middle A<br>Middle B</p><p>Last</p>",
+    )
+    await editor.selectAll()
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>First</p><p>Middle A</p><p>Middle B</p><p>Last</p></blockquote>",
+    )
+  })
+
+  test("quoting across paragraphs splits soft breaks in multiple middle paragraphs", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      "<p>First</p><p>A<br>B</p><p>C<br>D</p><p>Last</p>",
+    )
+    await editor.selectAll()
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>First</p><p>A</p><p>B</p><p>C</p><p>D</p><p>Last</p></blockquote>",
+    )
+  })
+
   test("quote only selected lines across paragraphs with mixed break types", async ({
     page,
     editor,


### PR DESCRIPTION
## Summary

- Fixes [#9742922406 — Applying quote formatting to selected text discards line breaks](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9742922406): when selecting multi-line text and applying quote formatting, soft line breaks (`<br>`) in paragraphs between the selection anchor and focus were not split into separate paragraphs, causing them to appear merged inside the blockquote.
- Fixes [#9769568343 — Selecting text to quote puts all text in quote](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9769568343): this was a symptom of the same root cause — lost line breaks made it look like all text was collapsed into a single quoted block.

The root cause was a guard in `#splitParagraphsAtLineBreaks` that only split paragraphs containing a selection endpoint (anchor or focus), skipping "middle" paragraphs entirely. Removing this guard ensures all selected paragraphs with soft breaks are properly split before wrapping in a blockquote or converting to list items.

## Test plan

- [x] Added two regression tests to `test/browser/tests/formatting/block_formatting.test.js`:
  - "quoting across paragraphs splits soft breaks in middle paragraphs"
  - "quoting across paragraphs splits soft breaks in multiple middle paragraphs"
- [x] All 324 existing browser tests pass on Chromium (`yarn test:browser --project=chromium`)
- [x] All existing block formatting tests continue to pass (50 tests on Chromium + Firefox)
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)