### PR TITLE
Fix quote formatting: preserve BRs and quote only selected lines

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -17,7 +17,7 @@ import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_nod
 import { ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils"
 import NodeInserter from "./contents/node_inserter"
-import { $isShadowRoot } from "../helpers/lexical_helper"
+import { $isShadowRoot, $splitParagraphsAtLineBreakBoundaries } from "../helpers/lexical_helper"
 
 export default class Contents {
   constructor(editorElement) {
@@ -135,7 +135,7 @@ export default class Contents {
     } else {
       topLevelElements.filter($isQuoteNode).forEach(node => this.#unwrap(node))
 
-      this.#splitParagraphsAtLineBreaks(selection)
+      $splitParagraphsAtLineBreakBoundaries(selection)
 
       const elements = this.#topLevelElementsInSelection(selection)
       if (elements.length === 0) return

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,8 +1,8 @@
-import { $createNodeSelection, $createParagraphNode, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isRootNode, $isRootOrShadowRoot, $isTextNode, TextNode } from "lexical"
+import { $createNodeSelection, $createParagraphNode, $getSiblingCaret, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isParagraphNode, $isRootNode, $isRootOrShadowRoot, $isTextNode, $splitNode, LineBreakNode, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
-import { $isAtNodeEnd } from "@lexical/selection"
+import { $ensureForwardRangeSelection, $isAtNodeEnd } from "@lexical/selection"
 
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 
@@ -143,4 +143,38 @@ export function isAttachmentSpacerTextNode(node, previousNode, index, childCount
     && node.getTextContent() === " "
     && index === childCount - 1
     && previousNode instanceof CustomActionTextAttachmentNode
+}
+
+export function $splitParagraphsAtLineBreakBoundaries(selection) {
+  $ensureForwardRangeSelection(selection)
+
+  // Split focus first so the anchor split position stays valid.
+  $splitAtNearestLineBreak(selection.focus, "next")
+  $splitAtNearestLineBreak(selection.anchor, "previous")
+}
+
+function $splitAtNearestLineBreak(point, direction) {
+  const paragraph = point.getNode().getTopLevelElement()
+  if (!paragraph || !$isParagraphNode(paragraph)) return
+
+  const pointNode = point.getNode()
+  const selectionChild = pointNode.getParent().is(paragraph) ? pointNode : pointNode.getParentOrThrow()
+  const lineBreakCaret = $caretAtNearestNodeOfType(selectionChild, LineBreakNode, direction)
+  if (!lineBreakCaret) return
+
+  const lineBreak = lineBreakCaret.origin
+  const isEdge = lineBreakCaret.getNodeAtCaret() === null
+
+  if (!isEdge) {
+    $splitNode(paragraph, lineBreak.getIndexWithinParent())
+  }
+
+  lineBreak.remove()
+}
+
+function $caretAtNearestNodeOfType(node, klass, direction) {
+  for (const caret of $getSiblingCaret(node, direction)) {
+    if (caret.origin instanceof klass) return caret
+  }
+  return null
 }

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -154,12 +154,12 @@ test.describe("Block formatting", () => {
     )
   })
 
-  test("quote soft-break lines splits them into separate paragraphs in the blockquote", async ({
+  test("quote preserves line breaks when entire paragraph with BRs is selected", async ({
     page,
     editor,
   }) => {
-    // Selecting two soft-break lines and quoting should split them into
-    // separate paragraphs inside the blockquote, not merge them into one.
+    // When the whole paragraph with BRs is selected, BRs should be preserved
+    // inside the blockquote — not split into separate paragraphs.
     await editor.setValue(
       "<p>Before</p><p>First line<br>Second line</p><p>After</p>",
     )
@@ -184,7 +184,7 @@ test.describe("Block formatting", () => {
 
     await assertEditorHtml(
       editor,
-      "<p>Before</p><blockquote><p>First line</p><p>Second line</p></blockquote><p>After</p>",
+      "<p>Before</p><blockquote><p>First line<br>Second line</p></blockquote><p>After</p>",
     )
   })
 
@@ -193,13 +193,12 @@ test.describe("Block formatting", () => {
     editor,
   }) => {
     // Line one (Shift+Enter) Line two (Enter) Line three (Shift+Enter) Line four
-    // Selecting "Line two" through "Line three" and applying quote should only
-    // quote those two lines, not all four.
+    // Selecting "Line two" through "Line three" should quote only those lines,
+    // not the entire paragraphs.
     await editor.setValue(
       "<p>Line one<br>Line two</p><p>Line three<br>Line four</p>",
     )
 
-    // Select from "Line two" in the first <p> through "Line three" in the second <p>
     await editor.content.evaluate((el) => {
       const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
       let startNode, endNode
@@ -221,6 +220,23 @@ test.describe("Block formatting", () => {
     await assertEditorHtml(
       editor,
       "<p>Line one</p><blockquote><p>Line two</p><p>Line three</p></blockquote><p>Line four</p>",
+    )
+  })
+
+  test("quote preserves BRs when all text with line breaks is selected", async ({
+    page,
+    editor,
+  }) => {
+    // Selecting all content of a paragraph with BRs and quoting should
+    // preserve the BRs inside the blockquote.
+    await editor.setValue("<p>Line one<br>Line two<br>Line three</p>")
+    await editor.selectAll()
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>Line one<br>Line two<br>Line three</p></blockquote>",
     )
   })
 


### PR DESCRIPTION
## Summary

Fixes two quote formatting bugs (replaces the wrong approach in #1013):

- **BRs preserved in blockquotes**: Applying quote formatting to text with `<br>` line breaks no longer discards them. The previous fix split all BRs into separate `<p>` elements — this fix only splits at selection boundaries, preserving BRs within the quoted content.
- **Only selected content is quoted**: When selecting a subset of lines in a paragraph with soft line breaks, only the selected lines are wrapped in the blockquote.

### Basecamp cards
- [Applying quote formatting to selected text discards line breaks](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9742922406)
- [Selecting text to quote puts all text in quote](https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9769568343)

### Approach

Replaced `#splitParagraphsAtLineBreaks` (which split ALL BRs into paragraphs) with `$splitParagraphsAtLineBreakBoundaries` — a new method that only splits at the BR nearest to each selection endpoint. BRs fully within the selected range are left intact inside the blockquote.


## Test plan

- [x] `yarn test:browser --project=chromium` — 320 passed, 0 failed
- [x] `npx eslint` — no errors
- [x] New/updated Playwright tests cover:
  - Selecting a single soft-break line → only that line is quoted
  - Selecting entire paragraph with BRs → BRs preserved in blockquote
  - Selecting across paragraphs with mixed breaks → only selected lines quoted
  - Selecting all text with BRs → BRs preserved in blockquote

🤖 Generated with [Claude Code](https://claude.com/claude-code)