### PR TITLE
Fix flaky benchmark CI by improving time resolution

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,8 +17,8 @@ jobs:
       actions: read
       contents: read
     env:
-      BENCHMARK_ITERATIONS: 10
-      BENCHMARK_WARMUP_ITERATIONS: 2
+      BENCHMARK_ITERATIONS: 3
+      BENCHMARK_WARMUP_ITERATIONS: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,23 +111,30 @@ While in beta we are flagging the releases as pre-release.
 
 Lexxy also ships a browser benchmark harness for the JS side of the editor. These benchmarks run against the Vite fixture app in `test/browser/fixtures/`, just like the Playwright browser tests, so they measure editor bootstrap and content-loading cost without involving Rails, Action Text persistence, or Active Storage uploads.
 
+Each sample runs the scenario in a tight loop for a fixed time budget (default 5 seconds) and reports the per-operation median duration. Per-op timing amortizes frame-quantized waits across many operations, which is why this gives stable numbers for scenarios whose work is dominated by `requestAnimationFrame` / vsync alignment.
+
 To run the full browser benchmark suite locally:
 
 ```bash
 yarn benchmark:browser
 ```
 
-Results are written to `tmp/browser-benchmarks.json`.
+Results are written to `tmp/browser-benchmarks.json` by default. Use `--output <path>` to write elsewhere.
 
-For quicker iteration, you can narrow the run to a single scenario or reduce the sample counts:
+For quicker iteration, you can narrow the run to a single scenario, reduce the sample counts, or shorten the time budget:
 
 ```bash
 # List scenarios
 yarn benchmark:browser --list-scenarios
 
 # Run one scenario with smaller sample sizes
-yarn benchmark:browser --scenario load-very-large-table --warmup 1 --iterations 5
+yarn benchmark:browser --scenario load-very-large-table --warmup 1 --iterations 3
+
+# Use a shorter time budget per sample (default is 5000 ms)
+yarn benchmark:browser --time-budget 2000
 ```
+
+The same knobs are available as environment variables: `BENCHMARK_ITERATIONS`, `BENCHMARK_WARMUP_ITERATIONS`, and `BENCHMARK_TIME_BUDGET_MS`.
 
 The current benchmark scenarios are:
 
@@ -136,6 +143,8 @@ The current benchmark scenarios are:
 - `load-large-content`
 - `load-very-large-table`
 - `load-many-attachments`
+
+Each scenario's per-sample time budget defaults to 5 seconds (set in `test/browser/fixtures/benchmarks.js`). Slower scenarios fit fewer ops in that window, so their per-op variance is wider — `load-very-large-table` is the practical worst case at ~16 ops per sample. To tighten that scenario's spread at the cost of CI time, raise its `timeBudgetMs` in the scenario definition.
 
 To compare two result files locally:
 

--- a/scripts/benchmarks/run-browser-benchmarks.js
+++ b/scripts/benchmarks/run-browser-benchmarks.js
@@ -7,8 +7,9 @@ import process from "node:process"
 import { createServer } from "vite"
 
 const DEFAULT_OUTPUT_PATH = path.resolve("tmp/browser-benchmarks.json")
-const DEFAULT_ITERATIONS = numberFromEnv("BENCHMARK_ITERATIONS", 10)
-const DEFAULT_WARMUP_ITERATIONS = numberFromEnv("BENCHMARK_WARMUP_ITERATIONS", 2)
+const DEFAULT_ITERATIONS = numberFromEnv("BENCHMARK_ITERATIONS", 3)
+const DEFAULT_WARMUP_ITERATIONS = numberFromEnv("BENCHMARK_WARMUP_ITERATIONS", 1)
+const DEFAULT_TIME_BUDGET_MS = numberFromEnv("BENCHMARK_TIME_BUDGET_MS", 5_000)
 const BENCHMARK_PAGE_PATH = "/benchmarks.html"
 const VIEWPORT = { width: 1440, height: 1200 }
 const SCENARIOS = [
@@ -130,15 +131,15 @@ async function runScenario({ baseUrl, context, options, scenario }) {
   console.log(`Running ${scenario.name} (${options.warmupIterations} warmup, ${options.iterations} measured)`)
 
   for (let iteration = 0; iteration < options.warmupIterations; iteration += 1) {
-    await runScenarioSample({ baseUrl, context, scenario })
+    await runScenarioSample({ baseUrl, context, options, scenario })
   }
 
   const samples = []
   let details = null
 
   for (let iteration = 0; iteration < options.iterations; iteration += 1) {
-    const sample = await runScenarioSample({ baseUrl, context, scenario })
-    samples.push(roundNumber(sample.durationMs))
+    const sample = await runScenarioSample({ baseUrl, context, options, scenario })
+    samples.push(roundNumber(sample.details.perOpDurationMs))
     details ||= sample.details
   }
 
@@ -153,13 +154,20 @@ async function runScenario({ baseUrl, context, options, scenario }) {
   }
 }
 
-async function runScenarioSample({ baseUrl, context, scenario }) {
+async function runScenarioSample({ baseUrl, context, options, scenario }) {
   const page = await openBenchmarkPage(context, baseUrl)
+  const scenarioWithBudget = {
+    ...scenario,
+    options: {
+      ...scenario.options,
+      timeBudgetMs: scenario.options?.timeBudgetMs ?? options.timeBudgetMs,
+    },
+  }
 
   try {
     return await page.evaluate(async (scenarioDefinition) => {
       return await window.lexxyBenchmarks.measureScenario(scenarioDefinition)
-    }, scenario)
+    }, scenarioWithBudget)
   } finally {
     await page.close()
   }
@@ -191,6 +199,7 @@ async function collectEnvironment({ baseUrl, browser, context, options, port }) 
       port,
       warmupIterations: options.warmupIterations,
       iterations: options.iterations,
+      timeBudgetMs: options.timeBudgetMs,
     }
   } finally {
     await page.close()
@@ -247,6 +256,7 @@ function parseArgs(args) {
     outputPath: DEFAULT_OUTPUT_PATH,
     port: null,
     scenarioNames: null,
+    timeBudgetMs: DEFAULT_TIME_BUDGET_MS,
     warmupIterations: DEFAULT_WARMUP_ITERATIONS,
   }
 
@@ -280,6 +290,11 @@ function parseArgs(args) {
 
     if (arg === "--scenario") {
       options.scenarioNames = args[++index].split(",").map((name) => name.trim()).filter(Boolean)
+      continue
+    }
+
+    if (arg === "--time-budget") {
+      options.timeBudgetMs = parsePositiveInteger(args[++index], "--time-budget")
       continue
     }
 

--- a/test/browser/fixtures/benchmarks.js
+++ b/test/browser/fixtures/benchmarks.js
@@ -28,7 +28,7 @@ window.lexxyBenchmarks = {
     }
 
     if (scenario.kind === "load") {
-      return measureLoad(scenario.payload, scenario.editorAttributes)
+      return measureLoad(scenario.payload, scenario.editorAttributes, scenario.options)
     }
 
     throw new Error(`Unknown benchmark kind: ${scenario.kind}`)
@@ -40,50 +40,72 @@ async function measureBootstrap(options = {}) {
 
   const editorCount = options.editorCount ?? 1
   const editorAttributes = options.editorAttributes ?? {}
-  const editors = []
-  const initializationPromises = []
+  const timeBudgetMs = options.timeBudgetMs ?? 5_000
 
-  for (let index = 0; index < editorCount; index += 1) {
-    const editorElement = buildEditor(editorAttributes)
-    editors.push(editorElement)
-    initializationPromises.push(waitForEvent(editorElement, "lexxy:initialize"))
-  }
-
+  let opCount = 0
+  let lastEditors = []
   const startTime = performance.now()
-  root.replaceChildren(...editors)
 
-  await Promise.all(initializationPromises)
-  await Promise.all(editors.map(waitForEditorReady))
+  do {
+    const editors = []
+    const initializationPromises = []
+
+    for (let index = 0; index < editorCount; index += 1) {
+      const editorElement = buildEditor(editorAttributes)
+      editors.push(editorElement)
+      initializationPromises.push(waitForEvent(editorElement, "lexxy:initialize"))
+    }
+
+    root.replaceChildren(...editors)
+    await Promise.all(initializationPromises)
+    await Promise.all(editors.map(waitForEditorReady))
+    lastEditors = editors
+    opCount += 1
+  } while (performance.now() - startTime < timeBudgetMs)
+
   const durationMs = performance.now() - startTime
 
   return {
     details: {
       editorCount,
-      renderedNodeCount: editors.reduce((count, editor) => count + editor.querySelectorAll("*").length, 0),
-      toolbarCount: editors.filter((editor) => editor.toolbarElement).length,
+      opCount,
+      perOpDurationMs: durationMs / opCount,
+      renderedNodeCount: lastEditors.reduce((count, editor) => count + editor.querySelectorAll("*").length, 0),
+      timeBudgetMs,
+      toolbarCount: lastEditors.filter((editor) => editor.toolbarElement).length,
     },
     durationMs,
   }
 }
 
-async function measureLoad(payload, editorAttributes = {}) {
+async function measureLoad(payload, editorAttributes = {}, options = {}) {
   await clearRoot()
 
   const editorElement = await createReadyEditor(editorAttributes)
   const { details, html } = buildPayload(payload)
+  const timeBudgetMs = options.timeBudgetMs ?? 5_000
+
+  let opCount = 0
   const startTime = performance.now()
 
-  editorElement.value = html
-  await settleEditor(editorElement)
+  do {
+    editorElement.value = html
+    await settleEditor(editorElement)
+    opCount += 1
+  } while (performance.now() - startTime < timeBudgetMs)
+
   const durationMs = performance.now() - startTime
 
   return {
     details: {
       ...details,
       htmlLength: html.length,
+      opCount,
+      perOpDurationMs: durationMs / opCount,
       renderedNodeCount: editorElement.querySelectorAll("*").length,
       serializedHtmlLength: editorElement.value.length,
       textLength: editorElement.toString().length,
+      timeBudgetMs,
     },
     durationMs,
   }


### PR DESCRIPTION
The browser benchmarks have been flaky because the harness couldn't measure on a finer resolution than ~16.67 ms — one frame at 60 Hz — which is a problem for fast operations. Each sample was a single operation that went through one or more `requestAnimationFrame` callbacks, which fire on vsync edges, so samples were quantized to frame boundaries. Same code would land at different median values run-to-run, sometimes triggering false-positive regressions, and alignment differences flipped samples by a whole frame between runs.

Instead of measuring one operation, measure operation throughput over a five-second period (or configurable, via `BENCHMARK_TIME_BUDGET_MS` or `--time-budget`). Each sample loops the operation for the time budget and reports `durationMs / opCount` as the sample value. The per-op average has sub-frame resolution because the comparison unit is averaged across many ops rather than any single quantized one.

Drop `BENCHMARK_ITERATIONS` / `BENCHMARK_WARMUP_ITERATIONS` defaults from 10/2 to 3/1 since each sample is now amortized internally, and update the workflow env to match.

Schema-wise, `samples[]` is still an array of millisecond floats and `stats.median` still has the same meaning, so old baseline JSONs from `main` runs remain comparable to new outputs.