### PR TITLE
Rework editor toolbar

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -525,7 +525,7 @@
 /* --------------------------------------------------------------------------
 /* Dropdowns */
 
-:where(lexxy-toolbar-dropdown) {
+:where(.lexxy-editor__toolbar-dropdown) {
   user-select: none;
   -webkit-user-select: none;
 
@@ -654,7 +654,7 @@
   /* --------------------------------------------------------------------------
   /* Link dropdown */
 
-  &[data-content="link"] {
+  &.lexxy-editor__toolbar-dropdown--link {
     [data-dropdown-panel] {
       font-size: var(--lexxy-text-small);
       gap: var(--lexxy-toolbar-spacing);
@@ -710,7 +710,7 @@
   /* --------------------------------------------------------------------------
   /* Color dropdown */
 
-  &[data-content="highlight"] {
+  &.lexxy-editor__toolbar-dropdown--highlight {
     position: relative;
 
     [overflowing] & {

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -548,7 +548,8 @@
     }
   }
 
-  [role="menu"] {
+  [role="menu"],
+  [role="dialog"] {
     background-color: var(--lexxy-color-canvas);
     border: 2px solid var(--lexxy-color-selected-hover);
     border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
@@ -661,7 +662,7 @@
     inset-inline-start: var(--lexxy-toolbar-spacing);
     inset-inline-end: var(--lexxy-toolbar-spacing);
 
-    [overflowing] &[role="menu"]:not([hidden]) {
+    [overflowing] &[role="dialog"]:not([hidden]) {
       display: block;
 
       .lexxy-editor__toolbar-dropdown-actions {

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -570,7 +570,7 @@
     border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
     box-sizing: border-box;
     box-shadow: var(--lexxy-shadow);
-    color: var(--lexxy-color-ink);
+    color: var(--lexxy-color-text);
     display: flex;
     gap: var(--lexxy-toolbar-gap);
     margin: 0;
@@ -591,6 +591,7 @@
 
     button {
       align-items: center;
+      color: var(--lexxy-color-text);
       display: flex;
       flex-direction: row;
       gap: 1ch;
@@ -611,6 +612,7 @@
 
       svg {
         block-size: 1lh;
+        fill: currentColor;
         inline-size: 1lh;
       }
     }

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -530,7 +530,7 @@
   -webkit-user-select: none;
 
   .lexxy-editor__toolbar-button {
-    color: var(--lexxy-color-text);
+    color: currentColor;
 
     &:hover {
       opacity: 0.8;
@@ -544,8 +544,8 @@
 
       &:after {
         block-size: 0.3ch;
-        border-block-end: 2px solid currentcolor;
-        border-inline-end: 2px solid currentcolor;
+        border-block-end: 2px solid currentColor;
+        border-inline-end: 2px solid currentColor;
         content: "";
         display: inline-block;
         inline-size: 0.3ch;

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -12,6 +12,7 @@
   border: 1px solid var(--lexxy-color-ink-lighter);
   border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
   background-color: var(--lexxy-color-canvas);
+  container-type: inline-size;
   display: block;
   overflow: visible;
   position: relative;
@@ -446,6 +447,10 @@
   max-inline-size: 100%;
   padding: 2px;
   position: relative;
+
+  @container (width < 300px) {
+    font-size: 0.8em;
+  }
 
   &[data-attachments="false"] button[name="image"],
   &[data-attachments="false"] button[name="file"] {

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -554,7 +554,7 @@
     }
   }
 
-  &[aria-expanded="true"] > .lexxy-editor__toolbar-button {
+  > .lexxy-editor__toolbar-button[aria-expanded="true"] {
     background-color: var(--lexxy-color-selected-hover);
     border-end-end-radius: 0;
     border-end-start-radius: 0;

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -525,7 +525,7 @@
   -webkit-user-select: none;
 
   &.lexxy-editor__toolbar-dropdown--chevron {
-    summary {
+    > .lexxy-editor__toolbar-button {
       aspect-ratio: unset;
       gap: 0.5ch;
       grid-template-columns: 2fr 1fr;
@@ -543,7 +543,7 @@
     }
   }
 
-  summary ~ * {
+  [role="menu"] {
     background-color: var(--lexxy-color-canvas);
     border: 2px solid var(--lexxy-color-selected-hover);
     border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
@@ -556,9 +556,13 @@
     padding: var(--lexxy-toolbar-spacing);
     position: absolute;
     z-index: 3;
+
+    &[hidden] {
+      display: none;
+    }
   }
 
-  &:is([open]) > .lexxy-editor__toolbar-button {
+  > .lexxy-editor__toolbar-button[aria-expanded="true"] {
     background-color: var(--lexxy-color-selected-hover);
     border-end-end-radius: 0;
     border-end-start-radius: 0;
@@ -568,7 +572,7 @@
     }
   }
 
-  button {
+  .lexxy-editor__toolbar-button {
     color: var(--lexxy-color-text);
 
     &:hover {
@@ -576,7 +580,7 @@
     }
   }
 
-  .lexxy-editor__toolbar-dropdown-list {
+  .lexxy-editor__toolbar-dropdown-list[role="menu"]:not([hidden]) {
     border-start-start-radius: 0;
     flex-direction: column;
     padding: 0.1ch;
@@ -634,7 +638,7 @@
     justify-self: flex-end;
     z-index: 1;
 
-    summary ~ * {
+    [role="menu"]:not([hidden]) {
       border-start-end-radius: 0;
       display: grid;
       grid-template-columns: repeat(4, 1fr);
@@ -652,7 +656,7 @@
     inset-inline-start: var(--lexxy-toolbar-spacing);
     inset-inline-end: var(--lexxy-toolbar-spacing);
 
-    [overflowing] [open] & {
+    [overflowing] &[role="menu"]:not([hidden]) {
       display: block;
 
       .lexxy-editor__toolbar-dropdown-actions {
@@ -710,7 +714,7 @@
     }
   }
 
-  lexxy-highlight-dropdown {
+  lexxy-highlight-dropdown[role="menu"]:not([hidden]) {
     --max-inline-size: calc(var(--max-colors) * (var(--lexxy-toolbar-button-size) + var(--lexxy-toolbar-spacing)));
     border-start-start-radius: 0;
     display: flex;
@@ -721,6 +725,7 @@
     max-inline-size: var(--max-inline-size);
 
     [overflowing] & {
+      border-start-start-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
       inset-inline-end: var(--lexxy-toolbar-spacing);
       inset-inline-start: var(--lexxy-toolbar-spacing);
     }

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -525,12 +525,18 @@
 /* --------------------------------------------------------------------------
 /* Dropdowns */
 
-:where(.lexxy-editor__toolbar-dropdown) {
+:where(lexxy-toolbar-dropdown) {
   user-select: none;
   -webkit-user-select: none;
 
-  &.lexxy-editor__toolbar-dropdown--chevron {
-    > .lexxy-editor__toolbar-button {
+  .lexxy-editor__toolbar-button {
+    color: var(--lexxy-color-text);
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    &.lexxy-editor__toolbar-button--chevron {
       aspect-ratio: unset;
       gap: 0.5ch;
       grid-template-columns: 2fr 1fr;
@@ -548,8 +554,17 @@
     }
   }
 
-  [role="menu"],
-  [role="dialog"] {
+  &[aria-expanded="true"] > .lexxy-editor__toolbar-button {
+    background-color: var(--lexxy-color-selected-hover);
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
+
+    &:hover {
+      background-color: var(--lexxy-color-selected-hover);
+    }
+  }
+
+  [data-dropdown-panel] {
     background-color: var(--lexxy-color-canvas);
     border: 2px solid var(--lexxy-color-selected-hover);
     border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
@@ -563,30 +578,13 @@
     position: absolute;
     z-index: 3;
 
-    &[hidden] {
+    &[hidden],
+    [overflowing] &[hidden] {
       display: none;
     }
   }
 
-  > .lexxy-editor__toolbar-button[aria-expanded="true"] {
-    background-color: var(--lexxy-color-selected-hover);
-    border-end-end-radius: 0;
-    border-end-start-radius: 0;
-
-    &:hover {
-      background-color: var(--lexxy-color-selected-hover);
-    }
-  }
-
-  .lexxy-editor__toolbar-button {
-    color: var(--lexxy-color-text);
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-
-  .lexxy-editor__toolbar-dropdown-list[role="menu"]:not([hidden]) {
+  .lexxy-editor__toolbar-dropdown-list {
     border-start-start-radius: 0;
     flex-direction: column;
     padding: 0.1ch;
@@ -644,7 +642,7 @@
     justify-self: flex-end;
     z-index: 1;
 
-    [role="menu"]:not([hidden]) {
+    [data-dropdown-panel] {
       border-start-end-radius: 0;
       display: grid;
       grid-template-columns: repeat(4, 1fr);
@@ -656,128 +654,127 @@
   /* --------------------------------------------------------------------------
   /* Link dropdown */
 
-  lexxy-link-dropdown {
-    font-size: var(--lexxy-text-small);
-    gap: var(--lexxy-toolbar-spacing);
-    inset-inline-start: var(--lexxy-toolbar-spacing);
-    inset-inline-end: var(--lexxy-toolbar-spacing);
+  &[data-content="link"] {
+    [data-dropdown-panel] {
+      font-size: var(--lexxy-text-small);
+      gap: var(--lexxy-toolbar-spacing);
+      inset-inline-start: var(--lexxy-toolbar-spacing);
+      inset-inline-end: var(--lexxy-toolbar-spacing);
 
-    [overflowing] &[role="dialog"]:not([hidden]) {
-      display: block;
+      [overflowing] & {
+        flex-wrap: wrap;
+      }
 
       .lexxy-editor__toolbar-dropdown-actions {
-        margin-block-start: var(--lexxy-toolbar-spacing);
+        display: flex;
+        flex: 1;
+        gap: var(--lexxy-toolbar-spacing);
       }
-    }
 
+      input[type="url"] {
+        background-color: var(--lexxy-color-canvas);
+        border: 1px solid var(--lexxy-color-ink-lighter);
+        border-radius: var(--lexxy-radius);
+        color: var(--lexxy-color-text);
+        block-size: var(--lexxy-toolbar-button-size);
+        box-sizing: border-box;
+        font-size: var(--lexxy-text-small);
+        flex: 2;
+        inline-size: 100%;
+        line-height: normal;
+        padding-block: 0;
+        padding-inline: 1ch;
 
-    .lexxy-editor__toolbar-dropdown-actions {
-      display: flex;
-      flex: 1;
-      gap: var(--lexxy-toolbar-spacing);
-    }
+        [overflowing] & {
+          min-inline-size: 100%;
+        }
+      }
 
-    input[type="url"] {
-      background-color: var(--lexxy-color-canvas);
-      border: 1px solid var(--lexxy-color-ink-lighter);
-      border-radius: var(--lexxy-radius);
-      color: var(--lexxy-color-text);
-      block-size: var(--lexxy-toolbar-button-size);
-      box-sizing: border-box;
-      font-size: var(--lexxy-text-small);
-      flex: 2;
-      inline-size: 100%;
-      line-height: normal;
-      padding-block: 0;
-      padding-inline: 1ch;
-    }
+      button {
+        background-color: var(--lexxy-color-ink-lightest);
+        inline-size: 100%;
+        padding-inline: 2ch;
+      }
 
-    button {
-      background-color: var(--lexxy-color-ink-lightest);
-      inline-size: 100%;
-      padding-inline: 2ch;
-    }
+      button[value="link"] {
+        background-color: var(--lexxy-color-accent-dark);
+        color: var(--lexxy-color-ink-inverted);
 
-    button[value="link"] {
-      background-color: var(--lexxy-color-accent-dark);
-      color: var(--lexxy-color-ink-inverted);
-
-      &:hover {
-        background-color: var(--lexxy-color-accent-medium);
+        &:hover {
+          background-color: var(--lexxy-color-accent-medium);
+        }
       }
     }
   }
 
-
   /* --------------------------------------------------------------------------
   /* Color dropdown */
 
-  &:has(lexxy-highlight-dropdown) {
+  &[data-content="highlight"] {
     position: relative;
 
     [overflowing] & {
       position: static;
     }
-  }
 
-  lexxy-highlight-dropdown[role="menu"]:not([hidden]) {
-    --max-inline-size: calc(var(--max-colors) * (var(--lexxy-toolbar-button-size) + var(--lexxy-toolbar-spacing)));
-    border-start-start-radius: 0;
-    display: flex;
-    gap: var(--lexxy-toolbar-spacing);
-    flex-direction: column;
-    font-size: var(--lexxy-text-small);
-    inset-inline-start: 0;
-    max-inline-size: var(--max-inline-size);
-
-    [overflowing] & {
-      border-start-start-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
-      inset-inline-end: var(--lexxy-toolbar-spacing);
-      inset-inline-start: var(--lexxy-toolbar-spacing);
-    }
-
-    button {
-      position: relative;
-    }
-
-    .lexxy-highlight-colors {
-      display: grid;
-      gap: var(--lexxy-toolbar-gap);
-      grid-template-columns: repeat(auto-fill, minmax(var(--lexxy-toolbar-button-size), 1fr));
+    [data-dropdown-panel] {
+      --max-inline-size: calc(var(--max-colors) * (var(--lexxy-toolbar-button-size) + var(--lexxy-toolbar-spacing)));
+      border-start-start-radius: 0;
+      gap: var(--lexxy-toolbar-spacing);
+      flex-direction: column;
+      font-size: var(--lexxy-text-small);
+      inset-inline-start: 0;
       max-inline-size: var(--max-inline-size);
 
+      [overflowing] & {
+        border-start-start-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
+        inset-inline-end: var(--lexxy-toolbar-spacing);
+        inset-inline-start: var(--lexxy-toolbar-spacing);
+      }
+
       button {
-        block-size: unset;
-        inline-size: 100%;
+        position: relative;
+      }
 
-        &:after {
-          align-self: center;
-          content: "Aa";
-          display: inline-block;
-          font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-          position: absolute;
-          inset-block-start: 0;
-          inset-block-end: 0;
-          inset-inline-end: 0;
-          inset-inline-start: 0;
-        }
+      .lexxy-highlight-colors {
+        display: grid;
+        gap: var(--lexxy-toolbar-gap);
+        grid-template-columns: repeat(auto-fill, minmax(var(--lexxy-toolbar-button-size), 1fr));
+        max-inline-size: var(--max-inline-size);
 
-        &[aria-pressed="true"] {
-          background-color: transparent;
-          box-shadow: 0 0 0 2px currentColor inset;
+        button {
+          block-size: unset;
+          inline-size: 100%;
 
           &:after {
-            content: "✓";
+            align-self: center;
+            content: "Aa";
+            display: inline-block;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            position: absolute;
+            inset-block-start: 0;
+            inset-block-end: 0;
+            inset-inline-end: 0;
+            inset-inline-start: 0;
+          }
+
+          &[aria-pressed="true"] {
+            background-color: transparent;
+            box-shadow: 0 0 0 2px currentColor inset;
+
+            &:after {
+              content: "✓";
+            }
           }
         }
       }
-    }
 
-    .lexxy-editor__toolbar-dropdown-reset {
-      background-color: var(--lexxy-color-ink-lightest);
+      .lexxy-editor__toolbar-dropdown-reset {
+        background-color: var(--lexxy-color-ink-lightest);
 
-      &:is([disabled]) {
-        display: none;
+        &:is([disabled]) {
+          display: none;
+        }
       }
     }
   }

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -1,5 +1,6 @@
 import { $getSelection, $isRangeSelection } from "lexical"
 import { $getSelectionStyleValueForProperty } from "@lexical/selection"
+import { ToolbarDropdown } from "../toolbar_dropdown"
 import { registerEventListener } from "../../helpers/listener_helper"
 
 const APPLY_HIGHLIGHT_SELECTOR = "button.lexxy-highlight-button"
@@ -10,12 +11,8 @@ const REMOVE_HIGHLIGHT_SELECTOR = "[data-command='removeHighlight']"
 // see https://github.com/facebook/lexical/issues/8013
 const NO_STYLE = Symbol("no_style")
 
-export class HighlightContent {
-  constructor(dropdown) {
-    this.dropdown = dropdown
-  }
-
-  connect() {
+export class HighlightDropdown extends ToolbarDropdown {
+  editorReady() {
     this.#setUpButtons()
     this.#registerButtonHandlers()
   }
@@ -26,23 +23,11 @@ export class HighlightContent {
     })
   }
 
-  get panel() {
-    return this.dropdown.panel
-  }
-
-  get editor() {
-    return this.dropdown.editor
-  }
-
-  get editorElement() {
-    return this.dropdown.editorElement
-  }
-
   #registerButtonHandlers() {
     this.#colorButtons.forEach(button => {
-      this.dropdown.track(registerEventListener(button, "click", this.#handleColorButtonClick))
+      this.track(registerEventListener(button, "click", this.#handleColorButtonClick))
     })
-    this.dropdown.track(registerEventListener(this.panel.querySelector(REMOVE_HIGHLIGHT_SELECTOR), "click", this.#handleRemoveHighlightClick))
+    this.track(registerEventListener(this.panel.querySelector(REMOVE_HIGHLIGHT_SELECTOR), "click", this.#handleRemoveHighlightClick))
   }
 
   #setUpButtons() {
@@ -84,14 +69,14 @@ export class HighlightContent {
     const value = button.dataset.value
 
     this.editor.dispatchCommand("toggleHighlight", { [attribute]: value })
-    this.dropdown.close()
+    this.close()
   }
 
   #handleRemoveHighlightClick = (event) => {
     event.preventDefault()
 
     this.editor.dispatchCommand("removeHighlight")
-    this.dropdown.close()
+    this.close()
   }
 
   #updateColorButtonStates(selection) {
@@ -122,4 +107,4 @@ export class HighlightContent {
   }
 }
 
-export default HighlightContent
+export default HighlightDropdown

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -54,6 +54,7 @@ export class HighlightDropdown extends ToolbarDropdown {
     button.dataset.value = value
     button.classList.add("lexxy-editor__toolbar-button", "lexxy-highlight-button")
     button.name = attribute + "-" + index
+    button.role = "menuitem"
     return button
   }
 

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -2,6 +2,7 @@ import { $getSelection, $isRangeSelection } from "lexical"
 import { $getSelectionStyleValueForProperty } from "@lexical/selection"
 import { ToolbarDropdown } from "../toolbar_dropdown"
 import { registerEventListener } from "../../helpers/listener_helper"
+import { createElement } from "../../helpers/html_helper"
 
 const APPLY_HIGHLIGHT_SELECTOR = "button.lexxy-highlight-button"
 const REMOVE_HIGHLIGHT_SELECTOR = "[data-command='removeHighlight']"
@@ -48,14 +49,14 @@ export class HighlightDropdown extends ToolbarDropdown {
   }
 
   #createButton(attribute, value, index) {
-    const button = document.createElement("button")
-    button.dataset.style = attribute
-    button.style.setProperty(attribute, value)
-    button.dataset.value = value
-    button.classList.add("lexxy-editor__toolbar-button", "lexxy-highlight-button")
-    button.name = attribute + "-" + index
-    button.role = "menuitem"
-    return button
+    return createElement("button", {
+      type: "button",
+      dataset: { value, style: attribute },
+      style: `${attribute}: ${value}`,
+      class: "lexxy-editor__toolbar-button lexxy-highlight-button",
+      name: `${attribute}-${index}`,
+      role: "menuitem"
+    })
   }
 
   #handleColorButtonClick = (event) => {

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -27,7 +27,6 @@ export class HighlightDropdown extends ToolbarDropdown {
     this.#colorButtons.forEach(button => {
       this.track(registerEventListener(button, "click", this.#handleColorButtonClick))
     })
-    this.track(registerEventListener(this.panel.querySelector(REMOVE_HIGHLIGHT_SELECTOR), "click", this.#handleRemoveHighlightClick))
   }
 
   #setUpButtons() {
@@ -65,17 +64,9 @@ export class HighlightDropdown extends ToolbarDropdown {
     const button = event.target.closest(APPLY_HIGHLIGHT_SELECTOR)
     if (!button) return
 
-    const attribute = button.dataset.style
-    const value = button.dataset.value
+    const { style, value } = button.dataset
 
-    this.editor.dispatchCommand("toggleHighlight", { [attribute]: value })
-    this.close()
-  }
-
-  #handleRemoveHighlightClick = (event) => {
-    event.preventDefault()
-
-    this.editor.dispatchCommand("removeHighlight")
+    this.editor.dispatchCommand("toggleHighlight", { [style]: value })
     this.close()
   }
 

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -19,7 +19,7 @@ export class HighlightDropdown extends ToolbarDropdown {
 
   connectedCallback() {
     super.connectedCallback()
-    this.track(registerEventListener(this.container, "toggle", this.#handleToggle))
+    this.track(registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle))
   }
 
   #registerButtonHandlers() {
@@ -57,7 +57,7 @@ export class HighlightDropdown extends ToolbarDropdown {
     return button
   }
 
-  #handleToggle = ({ newState }) => {
+  #handleToggle = ({ detail: { newState } }) => {
     if (newState === "open") {
       this.editor.getEditorState().read(() => {
         this.#updateColorButtonStates($getSelection())

--- a/src/elements/dropdown/highlight.js
+++ b/src/elements/dropdown/highlight.js
@@ -1,6 +1,5 @@
 import { $getSelection, $isRangeSelection } from "lexical"
 import { $getSelectionStyleValueForProperty } from "@lexical/selection"
-import { ToolbarDropdown } from "../toolbar_dropdown"
 import { registerEventListener } from "../../helpers/listener_helper"
 
 const APPLY_HIGHLIGHT_SELECTOR = "button.lexxy-highlight-button"
@@ -11,22 +10,39 @@ const REMOVE_HIGHLIGHT_SELECTOR = "[data-command='removeHighlight']"
 // see https://github.com/facebook/lexical/issues/8013
 const NO_STYLE = Symbol("no_style")
 
-export class HighlightDropdown extends ToolbarDropdown {
-  initialize() {
+export class HighlightContent {
+  constructor(dropdown) {
+    this.dropdown = dropdown
+  }
+
+  connect() {
     this.#setUpButtons()
     this.#registerButtonHandlers()
   }
 
-  connectedCallback() {
-    super.connectedCallback()
-    this.track(registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle))
+  onOpen() {
+    this.editor.getEditorState().read(() => {
+      this.#updateColorButtonStates($getSelection())
+    })
+  }
+
+  get panel() {
+    return this.dropdown.panel
+  }
+
+  get editor() {
+    return this.dropdown.editor
+  }
+
+  get editorElement() {
+    return this.dropdown.editorElement
   }
 
   #registerButtonHandlers() {
     this.#colorButtons.forEach(button => {
-      this.track(registerEventListener(button, "click", this.#handleColorButtonClick))
+      this.dropdown.track(registerEventListener(button, "click", this.#handleColorButtonClick))
     })
-    this.track(registerEventListener(this.querySelector(REMOVE_HIGHLIGHT_SELECTOR), "click", this.#handleRemoveHighlightClick))
+    this.dropdown.track(registerEventListener(this.panel.querySelector(REMOVE_HIGHLIGHT_SELECTOR), "click", this.#handleRemoveHighlightClick))
   }
 
   #setUpButtons() {
@@ -38,7 +54,7 @@ export class HighlightDropdown extends ToolbarDropdown {
     this.#populateButtonGroup("background-color", colorGroups["background-color"])
 
     const maxNumberOfColors = Math.max(colorGroups.color.length, colorGroups["background-color"].length)
-    this.style.setProperty("--max-colors", maxNumberOfColors)
+    this.panel.style.setProperty("--max-colors", maxNumberOfColors)
   }
 
   #populateButtonGroup(attribute, values) {
@@ -58,14 +74,6 @@ export class HighlightDropdown extends ToolbarDropdown {
     return button
   }
 
-  #handleToggle = ({ detail: { newState } }) => {
-    if (newState === "open") {
-      this.editor.getEditorState().read(() => {
-        this.#updateColorButtonStates($getSelection())
-      })
-    }
-  }
-
   #handleColorButtonClick = (event) => {
     event.preventDefault()
 
@@ -76,14 +84,14 @@ export class HighlightDropdown extends ToolbarDropdown {
     const value = button.dataset.value
 
     this.editor.dispatchCommand("toggleHighlight", { [attribute]: value })
-    this.close()
+    this.dropdown.close()
   }
 
   #handleRemoveHighlightClick = (event) => {
     event.preventDefault()
 
     this.editor.dispatchCommand("removeHighlight")
-    this.close()
+    this.dropdown.close()
   }
 
   #updateColorButtonStates(selection) {
@@ -102,16 +110,16 @@ export class HighlightDropdown extends ToolbarDropdown {
     })
 
     const hasHighlight = textColor !== NO_STYLE || backgroundColor !== NO_STYLE
-    this.querySelector(REMOVE_HIGHLIGHT_SELECTOR).disabled = !hasHighlight
+    this.panel.querySelector(REMOVE_HIGHLIGHT_SELECTOR).disabled = !hasHighlight
   }
 
   get #buttonContainer() {
-    return this.querySelector(".lexxy-highlight-colors")
+    return this.panel.querySelector(".lexxy-highlight-colors")
   }
 
   get #colorButtons() {
-    return Array.from(this.querySelectorAll(APPLY_HIGHLIGHT_SELECTOR))
+    return Array.from(this.panel.querySelectorAll(APPLY_HIGHLIGHT_SELECTOR))
   }
 }
 
-export default HighlightDropdown
+export default HighlightContent

--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -1,15 +1,12 @@
 import { LinkNode } from "@lexical/link"
+import { ToolbarDropdown } from "../toolbar_dropdown"
 import { registerEventListener } from "../../helpers/listener_helper"
 
-export class LinkContent {
-  constructor(dropdown) {
-    this.dropdown = dropdown
-  }
-
-  connect() {
+export class LinkDropdown extends ToolbarDropdown {
+  editorReady() {
     this.input = this.panel.querySelector("input")
 
-    this.dropdown.track(
+    this.track(
       registerEventListener(this.input, "keydown", this.#handleEnter),
       registerEventListener(this.linkButton, "click", this.#handleLink),
       registerEventListener(this.unlinkButton, "click", this.#handleUnlink)
@@ -23,18 +20,6 @@ export class LinkContent {
 
   onClose() {
     this.input.required = false
-  }
-
-  get panel() {
-    return this.dropdown.panel
-  }
-
-  get editor() {
-    return this.dropdown.editor
-  }
-
-  get editorElement() {
-    return this.dropdown.editorElement
   }
 
   get linkButton() {
@@ -60,12 +45,12 @@ export class LinkContent {
     }
 
     this.editor.dispatchCommand("link", this.input.value)
-    this.dropdown.close()
+    this.close()
   }
 
   #handleUnlink = () => {
     this.editor.dispatchCommand("unlink")
-    this.dropdown.close()
+    this.close()
   }
 
   get #selectedLinkUrl() {
@@ -76,4 +61,4 @@ export class LinkContent {
   }
 }
 
-export default LinkContent
+export default LinkDropdown

--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -1,32 +1,48 @@
 import { LinkNode } from "@lexical/link"
-import { ToolbarDropdown } from "../toolbar_dropdown"
 import { registerEventListener } from "../../helpers/listener_helper"
 
-export class LinkDropdown extends ToolbarDropdown {
-  connectedCallback() {
-    super.connectedCallback()
+export class LinkContent {
+  constructor(dropdown) {
+    this.dropdown = dropdown
+  }
 
-    this.input = this.querySelector("input")
+  connect() {
+    this.input = this.panel.querySelector("input")
 
-    this.track(
-      registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle),
+    this.dropdown.track(
       registerEventListener(this.input, "keydown", this.#handleEnter),
       registerEventListener(this.linkButton, "click", this.#handleLink),
       registerEventListener(this.unlinkButton, "click", this.#handleUnlink)
     )
   }
 
+  onOpen() {
+    this.input.value = this.#selectedLinkUrl
+    this.input.required = true
+  }
+
+  onClose() {
+    this.input.required = false
+  }
+
+  get panel() {
+    return this.dropdown.panel
+  }
+
+  get editor() {
+    return this.dropdown.editor
+  }
+
+  get editorElement() {
+    return this.dropdown.editorElement
+  }
+
   get linkButton() {
-    return this.querySelector("[value='link']")
+    return this.panel.querySelector("[value='link']")
   }
 
   get unlinkButton() {
-    return this.querySelector("[value='unlink']")
-  }
-
-  #handleToggle = ({ detail: { newState } }) => {
-    this.input.value = this.#selectedLinkUrl
-    this.input.required = newState === "open"
+    return this.panel.querySelector("[value='unlink']")
   }
 
   #handleEnter = (event) => {
@@ -44,12 +60,12 @@ export class LinkDropdown extends ToolbarDropdown {
     }
 
     this.editor.dispatchCommand("link", this.input.value)
-    this.close()
+    this.dropdown.close()
   }
 
   #handleUnlink = () => {
     this.editor.dispatchCommand("unlink")
-    this.close()
+    this.dropdown.close()
   }
 
   get #selectedLinkUrl() {
@@ -60,4 +76,4 @@ export class LinkDropdown extends ToolbarDropdown {
   }
 }
 
-export default LinkDropdown
+export default LinkContent

--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -9,7 +9,7 @@ export class LinkDropdown extends ToolbarDropdown {
     this.input = this.querySelector("input")
 
     this.track(
-      registerEventListener(this.container, "toggle", this.#handleToggle),
+      registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle),
       registerEventListener(this.input, "keydown", this.#handleEnter),
       registerEventListener(this.linkButton, "click", this.#handleLink),
       registerEventListener(this.unlinkButton, "click", this.#handleUnlink)
@@ -24,7 +24,7 @@ export class LinkDropdown extends ToolbarDropdown {
     return this.querySelector("[value='unlink']")
   }
 
-  #handleToggle = ({ newState }) => {
+  #handleToggle = ({ detail: { newState } }) => {
     this.input.value = this.#selectedLinkUrl
     this.input.required = newState === "open"
   }

--- a/src/elements/dropdown/registry.js
+++ b/src/elements/dropdown/registry.js
@@ -1,0 +1,7 @@
+import { HighlightContent } from "./highlight"
+import { LinkContent } from "./link"
+
+export const dropdownContents = {
+  highlight: HighlightContent,
+  link: LinkContent,
+}

--- a/src/elements/dropdown/registry.js
+++ b/src/elements/dropdown/registry.js
@@ -1,7 +1,0 @@
-import { HighlightContent } from "./highlight"
-import { LinkContent } from "./link"
-
-export const dropdownContents = {
-  highlight: HighlightContent,
-  link: LinkContent,
-}

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -1,4 +1,5 @@
 import Toolbar from "./toolbar"
+import ToolbarDropdown from "./toolbar_dropdown"
 
 import Editor from "./editor"
 import DropdownLink from "./dropdown/link"
@@ -11,9 +12,10 @@ import TableTools from "./table/table_tools"
 export function defineElements() {
   const elements = {
     "lexxy-toolbar": Toolbar,
-    "lexxy-editor": Editor,
+    "lexxy-toolbar-dropdown": ToolbarDropdown,
     "lexxy-link-dropdown": DropdownLink,
     "lexxy-highlight-dropdown": DropdownHighlight,
+    "lexxy-editor": Editor,
     "lexxy-prompt": Prompt,
     "lexxy-code-language-picker": CodeLanguagePicker,
     "lexxy-node-delete-button": NodeDeleteButton,

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -10,11 +10,15 @@ import TableTools from "./table/table_tools"
 
 export function defineElements() {
   const elements = {
+    // Toolbar must be registered BEFORE Editor
     "lexxy-toolbar": Toolbar,
     "lexxy-toolbar-dropdown": ToolbarDropdown,
     "lexxy-highlight-dropdown": HighlightDropdown,
     "lexxy-link-dropdown": LinkDropdown,
+
     "lexxy-editor": Editor,
+
+    // Prompt must be registered AFTER Editor
     "lexxy-prompt": Prompt,
     "lexxy-code-language-picker": CodeLanguagePicker,
     "lexxy-node-delete-button": NodeDeleteButton,

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -2,8 +2,6 @@ import Toolbar from "./toolbar"
 import ToolbarDropdown from "./toolbar_dropdown"
 
 import Editor from "./editor"
-import DropdownLink from "./dropdown/link"
-import DropdownHighlight from "./dropdown/highlight"
 import Prompt from "./prompt"
 import CodeLanguagePicker from "./code_language_picker"
 import NodeDeleteButton from "./node_delete_button"
@@ -13,8 +11,6 @@ export function defineElements() {
   const elements = {
     "lexxy-toolbar": Toolbar,
     "lexxy-toolbar-dropdown": ToolbarDropdown,
-    "lexxy-link-dropdown": DropdownLink,
-    "lexxy-highlight-dropdown": DropdownHighlight,
     "lexxy-editor": Editor,
     "lexxy-prompt": Prompt,
     "lexxy-code-language-picker": CodeLanguagePicker,

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -1,6 +1,7 @@
 import Toolbar from "./toolbar"
 import ToolbarDropdown from "./toolbar_dropdown"
-
+import HighlightDropdown from "./dropdown/highlight"
+import LinkDropdown from "./dropdown/link"
 import Editor from "./editor"
 import Prompt from "./prompt"
 import CodeLanguagePicker from "./code_language_picker"
@@ -11,11 +12,13 @@ export function defineElements() {
   const elements = {
     "lexxy-toolbar": Toolbar,
     "lexxy-toolbar-dropdown": ToolbarDropdown,
+    "lexxy-highlight-dropdown": HighlightDropdown,
+    "lexxy-link-dropdown": LinkDropdown,
     "lexxy-editor": Editor,
     "lexxy-prompt": Prompt,
     "lexxy-code-language-picker": CodeLanguagePicker,
     "lexxy-node-delete-button": NodeDeleteButton,
-    "lexxy-table-tools": TableTools,
+    "lexxy-table-tools": TableTools
   }
 
   Object.entries(elements).forEach(([ name, element ]) => {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -412,7 +412,7 @@ export class LexicalToolbarElement extends HTMLElement {
           ${ToolbarIcons.link}
         </summary>
         <lexxy-link-dropdown class="lexxy-editor__toolbar-dropdown-content">
-          <input type="url" placeholder="Enter a URL…" class="input">
+          <input type="url" placeholder="Enter a URL…" class="input" name="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
             <button type="button" class="lexxy-editor__toolbar-button" value="link">Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -320,7 +320,7 @@ export class LexicalToolbarElement extends HTMLElement {
 
   closeDropdowns({ except } = {}) {
     this.#dropdowns.forEach((dropdown) => {
-      if (dropdown !== except && typeof dropdown.close === "function") {
+      if (dropdown !== except) {
         dropdown.close({ focusEditor: false })
       }
     })

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -10,7 +10,7 @@ import { getNonce } from "../helpers/csp_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 import { handleRollingTabIndex } from "../helpers/accessibility_helper"
 import ToolbarIcons from "./toolbar_icons"
-import { isActiveAndVisible } from "../helpers/html_helper"
+import { generateDomId, isActiveAndVisible } from "../helpers/html_helper"
 
 export class LexicalToolbarElement extends HTMLElement {
   static observedAttributes = [ "connected" ]
@@ -352,6 +352,8 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   static get defaultTemplate() {
+    const linkInputId = generateDomId("lexxy-link-url")
+
     return `
       <button class="lexxy-editor__toolbar-button" type="button" name="image" data-command="uploadImage" data-prevent-overflow="true" title="Add images and video">
         ${ToolbarIcons.image}
@@ -415,7 +417,7 @@ export class LexicalToolbarElement extends HTMLElement {
           ${ToolbarIcons.link}
         </button>
         <div data-dropdown-panel role="dialog" aria-label="Link" hidden>
-          <input type="url" placeholder="Enter a URL…" class="input" id="lexxy-link-url">
+          <input type="url" placeholder="Enter a URL…" class="input" id="${linkInputId}">
           <div class="lexxy-editor__toolbar-dropdown-actions">
             <button type="button" class="lexxy-editor__toolbar-button" value="link">Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -327,15 +327,15 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   get #dropdowns() {
-    return this.querySelectorAll(":scope [role='menu'], :scope [role='dialog']")
+    return this.querySelectorAll(":scope lexxy-toolbar-dropdown")
   }
 
   get #overflow() {
-    return this.querySelector(".lexxy-editor__toolbar-overflow")
+    return this.querySelector("lexxy-toolbar-dropdown.lexxy-editor__toolbar-overflow")
   }
 
   get #overflowMenu() {
-    return this.querySelector(".lexxy-editor__toolbar-overflow-menu")
+    return this.#overflow?.querySelector(":scope > [data-dropdown-panel]")
   }
 
   get #overflowButtons() {
@@ -368,12 +368,11 @@ export class LexicalToolbarElement extends HTMLElement {
       ${ToolbarIcons.italic}
       </button>
 
-      <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron">
-        <button class="lexxy-editor__toolbar-button" type="button" name="format"
-                aria-haspopup="menu" aria-expanded="false" title="Text formatting">
+      <lexxy-toolbar-dropdown aria-expanded="false">
+        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="format" data-dropdown-trigger aria-haspopup="menu" title="Text formatting">
           ${ToolbarIcons.heading}
         </button>
-        <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-dropdown-list" hidden>
+        <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-dropdown-list" hidden>
           <button type="button" name="paragraph" data-command="setFormatParagraph" title="Paragraph" role="menuitem">
             ${ToolbarIcons.paragraph} <span>Normal</span>
           </button>
@@ -397,33 +396,31 @@ export class LexicalToolbarElement extends HTMLElement {
           <button type="button" name="clear-formatting" data-command="clearFormatting" title="Clear formatting" role="menuitem">
             ${ToolbarIcons.clearFormatting} <span>Clear formatting</span>
           </button>
-        </lexxy-toolbar-dropdown>
-      </div>
+        </div>
+      </lexxy-toolbar-dropdown>
 
-      <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron">
-        <button class="lexxy-editor__toolbar-button" type="button" name="highlight"
-                aria-haspopup="menu" aria-expanded="false" title="Color highlight">
+      <lexxy-toolbar-dropdown data-content="highlight" aria-expanded="false">
+        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="highlight" data-dropdown-trigger aria-haspopup="menu" title="Color highlight">
           ${ToolbarIcons.highlight}
         </button>
-        <lexxy-highlight-dropdown role="menu" hidden>
+        <div data-dropdown-panel role="menu" hidden>
           <div class="lexxy-highlight-colors"></div>
           <button data-command="removeHighlight" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset" role="menuitem">Remove all coloring</button>
-        </lexxy-highlight-dropdown>
-      </div>
+        </div>
+      </lexxy-toolbar-dropdown>
 
-      <div class="lexxy-editor__toolbar-dropdown">
-        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link"
-                aria-haspopup="dialog" aria-expanded="false" title="Link" data-hotkey="cmd+k ctrl+k">
+      <lexxy-toolbar-dropdown data-content="link" aria-expanded="false">
+        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link" data-dropdown-trigger aria-haspopup="dialog" title="Link" data-hotkey="cmd+k ctrl+k">
           ${ToolbarIcons.link}
         </button>
-        <lexxy-link-dropdown role="dialog" hidden>
+        <div data-dropdown-panel role="dialog" hidden>
           <input type="url" placeholder="Enter a URL…" class="input" name="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
             <button type="button" class="lexxy-editor__toolbar-button" value="link" >Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>
           </div>
-        </lexxy-link-dropdown>
-      </div>
+        </div>
+      </lexxy-toolbar-dropdown>
 
       <button class="lexxy-editor__toolbar-button" type="button" name="quote" data-command="insertQuoteBlock" title="Quote">
         ${ToolbarIcons.quote}
@@ -458,11 +455,12 @@ export class LexicalToolbarElement extends HTMLElement {
         ${ToolbarIcons.redo}
       </button>
 
-      <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
-        <button class="lexxy-editor__toolbar-button" type="button"
-                aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">${ToolbarIcons.overflow}</button>
-        <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></lexxy-toolbar-dropdown>
-      </div>
+      <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-overflow">
+        <button class="lexxy-editor__toolbar-button" type="button" data-dropdown-trigger aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">
+          ${ToolbarIcons.overflow}
+        </button>
+        <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></div>
+      </lexxy-toolbar-dropdown>
     `
   }
 }

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -374,27 +374,27 @@ export class LexicalToolbarElement extends HTMLElement {
           ${ToolbarIcons.heading}
         </button>
         <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-dropdown-list" hidden>
-          <button type="button" name="paragraph" data-command="setFormatParagraph" title="Paragraph">
+          <button type="button" name="paragraph" data-command="setFormatParagraph" title="Paragraph" role="menuitem">
             ${ToolbarIcons.paragraph} <span>Normal</span>
           </button>
-          <button type="button" name="heading-large" data-command="setFormatHeadingLarge" title="Large heading">
+          <button type="button" name="heading-large" data-command="setFormatHeadingLarge" title="Large heading" role="menuitem">
             ${ToolbarIcons.h2} <span>Large Heading</span>
           </button>
-          <button type="button" name="heading-medium" data-command="setFormatHeadingMedium" title="Medium heading">
+          <button type="button" name="heading-medium" data-command="setFormatHeadingMedium" title="Medium heading" role="menuitem">
             ${ToolbarIcons.h3} <span>Medium Heading</span>
           </button>
-          <button class="lexxy-editor__toolbar-group-end" type="button" name="heading-small" data-command="setFormatHeadingSmall" title="Small heading">
+          <button class="lexxy-editor__toolbar-group-end" type="button" name="heading-small" data-command="setFormatHeadingSmall" title="Small heading" role="menuitem">
             ${ToolbarIcons.h4} <span>Small Heading</span>
           </button>
           <div class="lexxy-editor__toolbar-separator" role="separator"></div>
-          <button type="button" name="strikethrough" data-command="strikethrough" title="Strikethrough">
+          <button type="button" name="strikethrough" data-command="strikethrough" title="Strikethrough" role="menuitem">
             ${ToolbarIcons.strikethrough} <span>Strikethrough</span>
           </button>
-          <button type="button" name="underline" data-command="underline" title="Underline">
+          <button type="button" name="underline" data-command="underline" title="Underline" role="menuitem">
             ${ToolbarIcons.underline} <span>Underline</span>
           </button>
           <div class="lexxy-editor__toolbar-separator" role="separator"></div>
-          <button type="button" name="clear-formatting" data-command="clearFormatting" title="Clear formatting">
+          <button type="button" name="clear-formatting" data-command="clearFormatting" title="Clear formatting" role="menuitem">
             ${ToolbarIcons.clearFormatting} <span>Clear formatting</span>
           </button>
         </lexxy-toolbar-dropdown>
@@ -407,7 +407,7 @@ export class LexicalToolbarElement extends HTMLElement {
         </button>
         <lexxy-highlight-dropdown role="menu" hidden>
           <div class="lexxy-highlight-colors"></div>
-          <button data-command="removeHighlight" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset">Remove all coloring</button>
+          <button data-command="removeHighlight" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset" role="menuitem">Remove all coloring</button>
         </lexxy-highlight-dropdown>
       </div>
 

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -180,8 +180,8 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #monitorSelectionChanges() {
-    this.#listeners.track(this.editor.registerUpdateListener(() => {
-      this.editor.getEditorState().read(() => {
+    this.#listeners.track(this.editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
         this.#updateButtonStates()
         this.closeDropdowns()
       })

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -327,7 +327,7 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   get #dropdowns() {
-    return this.querySelectorAll(":scope .lexxy-editor__toolbar-dropdown > [role='menu']")
+    return this.querySelectorAll(":scope [role='menu'], :scope [role='dialog']")
   }
 
   get #overflow() {
@@ -413,13 +413,13 @@ export class LexicalToolbarElement extends HTMLElement {
 
       <div class="lexxy-editor__toolbar-dropdown">
         <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link"
-                aria-haspopup="menu" aria-expanded="false" title="Link" data-hotkey="cmd+k ctrl+k">
+                aria-haspopup="dialog" aria-expanded="false" title="Link" data-hotkey="cmd+k ctrl+k">
           ${ToolbarIcons.link}
         </button>
-        <lexxy-link-dropdown role="menu" hidden>
+        <lexxy-link-dropdown role="dialog" hidden>
           <input type="url" placeholder="Enter a URL…" class="input" name="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
-            <button type="button" class="lexxy-editor__toolbar-button" value="link">Link</button>
+            <button type="button" class="lexxy-editor__toolbar-button" value="link" >Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>
           </div>
         </lexxy-link-dropdown>

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -414,7 +414,7 @@ export class LexicalToolbarElement extends HTMLElement {
         <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link" title="Link" data-hotkey="cmd+k ctrl+k" aria-haspopup="dialog" aria-expanded="false">
           ${ToolbarIcons.link}
         </button>
-        <div data-dropdown-panel role="dialog" hidden>
+        <div data-dropdown-panel role="dialog" aria-label="Link" hidden>
           <input type="url" placeholder="Enter a URL…" class="input" id="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
             <button type="button" class="lexxy-editor__toolbar-button" value="link">Link</button>

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -406,7 +406,7 @@ export class LexicalToolbarElement extends HTMLElement {
         </button>
         <div data-dropdown-panel role="menu" hidden>
           <div class="lexxy-highlight-colors"></div>
-          <button data-command="removeHighlight" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset" role="menuitem">Remove all coloring</button>
+          <button data-command="removeHighlight" type="button" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset" role="menuitem">Remove all coloring</button>
         </div>
       </lexxy-highlight-dropdown>
 

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -329,11 +329,11 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   get #dropdowns() {
-    return this.querySelectorAll(":scope lexxy-toolbar-dropdown")
+    return this.querySelectorAll(":scope .lexxy-editor__toolbar-dropdown")
   }
 
   get #overflow() {
-    return this.querySelector("lexxy-toolbar-dropdown.lexxy-editor__toolbar-overflow")
+    return this.querySelector(".lexxy-editor__toolbar-overflow")
   }
 
   get #overflowMenu() {
@@ -370,7 +370,7 @@ export class LexicalToolbarElement extends HTMLElement {
       ${ToolbarIcons.italic}
       </button>
 
-      <lexxy-toolbar-dropdown>
+      <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-dropdown">
         <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="format" title="Text formatting" aria-haspopup="menu" aria-expanded="false">
           ${ToolbarIcons.heading}
         </button>
@@ -401,7 +401,7 @@ export class LexicalToolbarElement extends HTMLElement {
         </div>
       </lexxy-toolbar-dropdown>
 
-      <lexxy-toolbar-dropdown data-content="highlight">
+      <lexxy-highlight-dropdown class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--highlight">
         <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="highlight" title="Color highlight" aria-haspopup="menu" aria-expanded="false">
           ${ToolbarIcons.highlight}
         </button>
@@ -409,20 +409,20 @@ export class LexicalToolbarElement extends HTMLElement {
           <div class="lexxy-highlight-colors"></div>
           <button data-command="removeHighlight" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset" role="menuitem">Remove all coloring</button>
         </div>
-      </lexxy-toolbar-dropdown>
+      </lexxy-highlight-dropdown>
 
-      <lexxy-toolbar-dropdown data-content="link">
+      <lexxy-link-dropdown class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--link">
         <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link" title="Link" data-hotkey="cmd+k ctrl+k" aria-haspopup="dialog" aria-expanded="false">
           ${ToolbarIcons.link}
         </button>
         <div data-dropdown-panel role="dialog" hidden>
           <input type="url" placeholder="Enter a URL…" class="input" id="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
-            <button type="button" class="lexxy-editor__toolbar-button" value="link" >Link</button>
+            <button type="button" class="lexxy-editor__toolbar-button" value="link">Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>
           </div>
         </div>
-      </lexxy-toolbar-dropdown>
+      </lexxy-link-dropdown>
 
       <button class="lexxy-editor__toolbar-button" type="button" name="quote" data-command="insertQuoteBlock" title="Quote">
         ${ToolbarIcons.quote}
@@ -457,7 +457,7 @@ export class LexicalToolbarElement extends HTMLElement {
         ${ToolbarIcons.redo}
       </button>
 
-      <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-overflow">
+      <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
         <button data-dropdown-trigger class="lexxy-editor__toolbar-button" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">
           ${ToolbarIcons.overflow}
         </button>

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -161,21 +161,21 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #handleEditorFocus = () => {
-    const firstVisible = this.#focusableItems.find(isActiveAndVisible)
+    const firstVisible = this.#buttons.find(isActiveAndVisible)
     if (firstVisible) firstVisible.tabIndex = 0
   }
 
   #handleEditorBlur = () => {
     this.#resetTabIndexValues()
-    this.#closeDropdowns()
+    this.closeDropdowns()
   }
 
   #handleKeydown = (event) => {
-    handleRollingTabIndex(this.#focusableItems, event)
+    handleRollingTabIndex(this.#buttons, event)
   }
 
   #resetTabIndexValues() {
-    this.#focusableItems.forEach((button) => {
+    this.#buttons.forEach((button) => {
       button.tabIndex = -1
     })
   }
@@ -184,7 +184,7 @@ export class LexicalToolbarElement extends HTMLElement {
     this.#listeners.track(this.editor.registerUpdateListener(() => {
       this.editor.getEditorState().read(() => {
         this.#updateButtonStates()
-        this.#closeDropdowns()
+        this.closeDropdowns()
       })
     }))
   }
@@ -270,7 +270,7 @@ export class LexicalToolbarElement extends HTMLElement {
   // The previous implementation interleaved `scrollWidth`/`clientWidth` reads with
   // `prepend()` writes inside a loop, forcing one full browser reflow per button.
   #compactMenu() {
-    const buttons = this.#buttons
+    const buttons = this.#overflowButtons
     if (buttons.length === 0) return
 
     const availableWidth = this.clientWidth + 1 // +1 for Safari zoom rounding
@@ -318,14 +318,16 @@ export class LexicalToolbarElement extends HTMLElement {
     })
   }
 
-  #closeDropdowns() {
-   this.#dropdowns.forEach((details) => {
-     details.open = false
-   })
- }
+  closeDropdowns({ except } = {}) {
+    this.#dropdowns.forEach((dropdown) => {
+      if (dropdown !== except && typeof dropdown.close === "function") {
+        dropdown.close({ focusEditor: false })
+      }
+    })
+  }
 
   get #dropdowns() {
-    return this.querySelectorAll("details")
+    return this.querySelectorAll(":scope .lexxy-editor__toolbar-dropdown > [role='menu']")
   }
 
   get #overflow() {
@@ -336,12 +338,12 @@ export class LexicalToolbarElement extends HTMLElement {
     return this.querySelector(".lexxy-editor__toolbar-overflow-menu")
   }
 
-  get #buttons() {
+  get #overflowButtons() {
     return Array.from(this.querySelectorAll(":scope > button:not([data-prevent-overflow='true'])"))
   }
 
-  get #focusableItems() {
-    return Array.from(this.querySelectorAll(":scope button, :scope > details > summary"))
+  get #buttons() {
+    return Array.from(this.querySelectorAll(":scope button"))
   }
 
   get #toolbarItems() {
@@ -366,11 +368,12 @@ export class LexicalToolbarElement extends HTMLElement {
       ${ToolbarIcons.italic}
       </button>
 
-      <details class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron" name="lexxy-dropdown">
-        <summary class="lexxy-editor__toolbar-button" name="format" title="Text formatting">
+      <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron">
+        <button class="lexxy-editor__toolbar-button" type="button" name="format"
+                aria-haspopup="menu" aria-expanded="false" title="Text formatting">
           ${ToolbarIcons.heading}
-        </summary>
-        <div class="lexxy-editor__toolbar-dropdown-list">
+        </button>
+        <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-dropdown-list" hidden>
           <button type="button" name="paragraph" data-command="setFormatParagraph" title="Paragraph">
             ${ToolbarIcons.paragraph} <span>Normal</span>
           </button>
@@ -394,31 +397,33 @@ export class LexicalToolbarElement extends HTMLElement {
           <button type="button" name="clear-formatting" data-command="clearFormatting" title="Clear formatting">
             ${ToolbarIcons.clearFormatting} <span>Clear formatting</span>
           </button>
-        </div>
-      </details>
+        </lexxy-toolbar-dropdown>
+      </div>
 
-      <details class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron" name="lexxy-dropdown">
-        <summary class="lexxy-editor__toolbar-button" name="highlight" title="Color highlight">
+      <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-dropdown--chevron">
+        <button class="lexxy-editor__toolbar-button" type="button" name="highlight"
+                aria-haspopup="menu" aria-expanded="false" title="Color highlight">
           ${ToolbarIcons.highlight}
-        </summary>
-        <lexxy-highlight-dropdown class="lexxy-editor__toolbar-dropdown-content">
+        </button>
+        <lexxy-highlight-dropdown role="menu" hidden>
           <div class="lexxy-highlight-colors"></div>
           <button data-command="removeHighlight" class="lexxy-editor__toolbar-button lexxy-editor__toolbar-dropdown-reset">Remove all coloring</button>
         </lexxy-highlight-dropdown>
-      </details>
+      </div>
 
-      <details class="lexxy-editor__toolbar-dropdown" name="lexxy-dropdown">
-        <summary class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" name="link" title="Link" data-hotkey="cmd+k ctrl+k">
+      <div class="lexxy-editor__toolbar-dropdown">
+        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link"
+                aria-haspopup="menu" aria-expanded="false" title="Link" data-hotkey="cmd+k ctrl+k">
           ${ToolbarIcons.link}
-        </summary>
-        <lexxy-link-dropdown class="lexxy-editor__toolbar-dropdown-content">
+        </button>
+        <lexxy-link-dropdown role="menu" hidden>
           <input type="url" placeholder="Enter a URL…" class="input" name="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
             <button type="button" class="lexxy-editor__toolbar-button" value="link">Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>
           </div>
         </lexxy-link-dropdown>
-      </details>
+      </div>
 
       <button class="lexxy-editor__toolbar-button" type="button" name="quote" data-command="insertQuoteBlock" title="Quote">
         ${ToolbarIcons.quote}
@@ -453,10 +458,11 @@ export class LexicalToolbarElement extends HTMLElement {
         ${ToolbarIcons.redo}
       </button>
 
-      <details class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow" name="lexxy-dropdown">
-        <summary class="lexxy-editor__toolbar-button" aria-label="Show more toolbar buttons">${ToolbarIcons.overflow}</summary>
-        <div class="lexxy-editor__toolbar-dropdown-content lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons"></div>
-      </details>
+      <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
+        <button class="lexxy-editor__toolbar-button" type="button"
+                aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">${ToolbarIcons.overflow}</button>
+        <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></lexxy-toolbar-dropdown>
+      </div>
     `
   }
 }

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -293,6 +293,7 @@ export class LexicalToolbarElement extends HTMLElement {
     const overflowButtons = buttons.slice(overflowIndex).reverse()
     for (const button of overflowButtons) {
       this.#overflowMenu.prepend(button)
+      button.role = "menuitem"
     }
   }
 
@@ -302,6 +303,7 @@ export class LexicalToolbarElement extends HTMLElement {
 
     for (const item of items) {
       const nextItem = this.querySelector(`[data-position="${this.#itemPosition(item) + 1}"]`) ?? this.#overflow
+      item.removeAttribute("role")
       this.insertBefore(item, nextItem)
     }
   }
@@ -368,8 +370,8 @@ export class LexicalToolbarElement extends HTMLElement {
       ${ToolbarIcons.italic}
       </button>
 
-      <lexxy-toolbar-dropdown aria-expanded="false">
-        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="format" data-dropdown-trigger aria-haspopup="menu" title="Text formatting">
+      <lexxy-toolbar-dropdown>
+        <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="format" title="Text formatting" aria-haspopup="menu" aria-expanded="false">
           ${ToolbarIcons.heading}
         </button>
         <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-dropdown-list" hidden>
@@ -399,8 +401,8 @@ export class LexicalToolbarElement extends HTMLElement {
         </div>
       </lexxy-toolbar-dropdown>
 
-      <lexxy-toolbar-dropdown data-content="highlight" aria-expanded="false">
-        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="highlight" data-dropdown-trigger aria-haspopup="menu" title="Color highlight">
+      <lexxy-toolbar-dropdown data-content="highlight">
+        <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="highlight" title="Color highlight" aria-haspopup="menu" aria-expanded="false">
           ${ToolbarIcons.highlight}
         </button>
         <div data-dropdown-panel role="menu" hidden>
@@ -409,12 +411,12 @@ export class LexicalToolbarElement extends HTMLElement {
         </div>
       </lexxy-toolbar-dropdown>
 
-      <lexxy-toolbar-dropdown data-content="link" aria-expanded="false">
-        <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link" data-dropdown-trigger aria-haspopup="dialog" title="Link" data-hotkey="cmd+k ctrl+k">
+      <lexxy-toolbar-dropdown data-content="link">
+        <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="link" title="Link" data-hotkey="cmd+k ctrl+k" aria-haspopup="dialog" aria-expanded="false">
           ${ToolbarIcons.link}
         </button>
         <div data-dropdown-panel role="dialog" hidden>
-          <input type="url" placeholder="Enter a URL…" class="input" name="lexxy-link-url">
+          <input type="url" placeholder="Enter a URL…" class="input" id="lexxy-link-url">
           <div class="lexxy-editor__toolbar-dropdown-actions">
             <button type="button" class="lexxy-editor__toolbar-button" value="link" >Link</button>
             <button type="button" class="lexxy-editor__toolbar-button" value="unlink">Unlink</button>
@@ -456,7 +458,7 @@ export class LexicalToolbarElement extends HTMLElement {
       </button>
 
       <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-overflow">
-        <button class="lexxy-editor__toolbar-button" type="button" data-dropdown-trigger aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">
+        <button data-dropdown-trigger class="lexxy-editor__toolbar-button" type="button" aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">
           ${ToolbarIcons.overflow}
         </button>
         <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></div>

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -167,7 +167,6 @@ export class LexicalToolbarElement extends HTMLElement {
 
   #handleEditorBlur = () => {
     this.#resetTabIndexValues()
-    this.closeDropdowns()
   }
 
   #handleKeydown = (event) => {

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -28,11 +28,11 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   get editorElement() {
-    return this.toolbar.editorElement
+    return this.toolbar?.editorElement
   }
 
   get editor() {
-    return this.toolbar.editor
+    return this.toolbar?.editor
   }
 
   get isOpen() {
@@ -72,8 +72,11 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   async #onToolbarEditor(callback) {
-    await this.toolbar.editorElement
-    callback()
+    const toolbar = this.toolbar
+    if (!toolbar) return
+
+    await toolbar.getEditorElement()
+    if (this.isConnected && this.toolbar === toolbar) callback()
   }
 
   #handleToggle = (event) => {

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -1,26 +1,33 @@
 import { nextFrame } from "../helpers/timing_helpers"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
+import { dropdownContents } from "./dropdown/registry"
 
 export class ToolbarDropdown extends HTMLElement {
   #listeners = new ListenerBin()
+  content = null
 
   connectedCallback() {
-    this.#onToolbarEditor(this.initialize.bind(this))
-
-    this.container = this.closest(".lexxy-editor__toolbar-dropdown")
-    this.trigger = this.container?.querySelector("button")
-
-    if (!this.container || !this.trigger) return
+    if (!this.trigger || !this.panel) return
 
     this.#listeners.track(
-      registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle),
-      registerEventListener(this.container, "keydown", this.#handleKeyDown),
+      registerEventListener(this, "keydown", this.#handleKeyDown),
       registerEventListener(this.trigger, "click", this.#handleTriggerClick)
     )
+
+    this.#onToolbarEditor(() => this.#connectContent())
   }
 
   disconnectedCallback() {
     this.#listeners.dispose()
+    this.content = null
+  }
+
+  get trigger() {
+    return this.querySelector(":scope > [data-dropdown-trigger]")
+  }
+
+  get panel() {
+    return this.querySelector(":scope > [data-dropdown-panel]")
   }
 
   get toolbar() {
@@ -36,30 +43,36 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   get isOpen() {
-    return this.trigger?.getAttribute("aria-expanded") === "true"
+    return this.getAttribute("aria-expanded") === "true"
   }
 
   track(...listeners) {
     this.#listeners.track(...listeners)
   }
 
-  initialize() {
-    // Any post-editor initialization
-  }
-
   open() {
     if (!this.trigger || this.isOpen) return
-    this.trigger.setAttribute("aria-expanded", "true")
-    this.hidden = false
-    this.#dispatchToggle("open")
+    this.setAttribute("aria-expanded", "true")
+    this.panel.hidden = false
+    this.content?.onOpen?.()
+    this.#focusFirstInteractive()
   }
 
   close({ focusEditor = true } = {}) {
     if (focusEditor) this.editor?.focus()
     if (!this.trigger || !this.isOpen) return
-    this.trigger.setAttribute("aria-expanded", "false")
-    this.hidden = true
-    this.#dispatchToggle("closed")
+    this.setAttribute("aria-expanded", "false")
+    this.panel.hidden = true
+    this.content?.onClose?.()
+  }
+
+  #connectContent() {
+    const name = this.dataset.content
+    const ContentClass = name ? dropdownContents[name] : null
+    if (!ContentClass) return
+
+    this.content = new ContentClass(this)
+    this.content.connect?.()
   }
 
   #handleTriggerClick = () => {
@@ -79,22 +92,16 @@ export class ToolbarDropdown extends HTMLElement {
     if (this.isConnected && this.toolbar === toolbar) callback()
   }
 
-  #handleToggle = (event) => {
-    if (event.detail?.newState === "open") {
-      this.#handleOpen()
-    }
-  }
-
-  async #handleOpen() {
-    this.#interactiveElements[0].focus()
-    this.#resetTabIndexValues()
-  }
-
   #handleKeyDown = (event) => {
     if (event.key === "Escape") {
       event.stopPropagation()
       this.close()
     }
+  }
+
+  async #focusFirstInteractive() {
+    this.#interactiveElements[0]?.focus()
+    await this.#resetTabIndexValues()
   }
 
   async #resetTabIndexValues() {
@@ -104,19 +111,12 @@ export class ToolbarDropdown extends HTMLElement {
     })
   }
 
-  #dispatchToggle(newState) {
-    this.container.dispatchEvent(new CustomEvent("lexxy:toolbar-dropdown-toggle", {
-      bubbles: true,
-      detail: { newState }
-    }))
-  }
-
   get #interactiveElements() {
-    return Array.from(this.querySelectorAll("button, input"))
+    return Array.from(this.panel.querySelectorAll("button, input"))
   }
 
   get #buttons() {
-    return Array.from(this.querySelectorAll("button"))
+    return Array.from(this.panel.querySelectorAll("button"))
   }
 }
 

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -43,7 +43,7 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   get isOpen() {
-    return this.getAttribute("aria-expanded") === "true"
+    return this.trigger?.getAttribute("aria-expanded") === "true"
   }
 
   track(...listeners) {
@@ -52,7 +52,7 @@ export class ToolbarDropdown extends HTMLElement {
 
   open() {
     if (!this.trigger || this.isOpen) return
-    this.setAttribute("aria-expanded", "true")
+    this.trigger.setAttribute("aria-expanded", "true")
     this.panel.hidden = false
     this.content?.onOpen?.()
     this.#focusFirstInteractive()
@@ -61,7 +61,7 @@ export class ToolbarDropdown extends HTMLElement {
   close({ focusEditor = true } = {}) {
     if (focusEditor) this.editor?.focus()
     if (!this.trigger || !this.isOpen) return
-    this.setAttribute("aria-expanded", "false")
+    this.trigger.setAttribute("aria-expanded", "false")
     this.panel.hidden = true
     this.content?.onClose?.()
   }

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -5,14 +5,10 @@ export class ToolbarDropdown extends HTMLElement {
   #listeners = new ListenerBin()
 
   connectedCallback() {
-    if (!this.trigger || !this.panel) return
-
-    this.#listeners.track(
-      registerEventListener(this, "keydown", this.#handleKeyDown),
-      registerEventListener(this.trigger, "click", this.#handleTriggerClick)
-    )
-
-    this.#onToolbarEditor(() => this.editorReady())
+    this.#onToolbarEditor(() => {
+      this.#registerListeners()
+      this.editorReady()
+    })
   }
 
   disconnectedCallback() {
@@ -72,6 +68,13 @@ export class ToolbarDropdown extends HTMLElement {
     this.onClose()
   }
 
+  #registerListeners() {
+    this.#listeners.track(
+      registerEventListener(this, "keydown", this.#handleKeyDown),
+      registerEventListener(this.trigger, "click", this.#handleTriggerClick)
+    )
+  }
+
   #handleTriggerClick = () => {
     if (this.isOpen) {
       this.close({ focusEditor: false })
@@ -82,11 +85,10 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   async #onToolbarEditor(callback) {
-    const toolbar = this.toolbar
-    if (!toolbar) return
+    if (!this.toolbar) return
 
-    await toolbar.getEditorElement()
-    if (this.isConnected && this.toolbar === toolbar) callback()
+    await this.toolbar.getEditorElement()
+    if (this.isConnected && this.toolbar) callback()
   }
 
   #handleKeyDown = (event) => {

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -1,10 +1,8 @@
 import { nextFrame } from "../helpers/timing_helpers"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
-import { dropdownContents } from "./dropdown/registry"
 
 export class ToolbarDropdown extends HTMLElement {
   #listeners = new ListenerBin()
-  content = null
 
   connectedCallback() {
     if (!this.trigger || !this.panel) return
@@ -14,13 +12,16 @@ export class ToolbarDropdown extends HTMLElement {
       registerEventListener(this.trigger, "click", this.#handleTriggerClick)
     )
 
-    this.#onToolbarEditor(() => this.#connectContent())
+    this.#onToolbarEditor(() => this.editorReady())
   }
 
   disconnectedCallback() {
     this.#listeners.dispose()
-    this.content = null
   }
+
+  editorReady() {}
+  onOpen() {}
+  onClose() {}
 
   get trigger() {
     return this.querySelector(":scope > [data-dropdown-trigger]")
@@ -43,7 +44,11 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   get isOpen() {
-    return this.trigger?.getAttribute("aria-expanded") === "true"
+    return this.panel.hidden === false
+  }
+
+  get isClosed() {
+    return !this.isOpen
   }
 
   track(...listeners) {
@@ -51,28 +56,20 @@ export class ToolbarDropdown extends HTMLElement {
   }
 
   open() {
-    if (!this.trigger || this.isOpen) return
+    if (this.isOpen) return
     this.trigger.setAttribute("aria-expanded", "true")
     this.panel.hidden = false
-    this.content?.onOpen?.()
+    this.onOpen()
     this.#focusFirstInteractive()
   }
 
   close({ focusEditor = true } = {}) {
     if (focusEditor) this.editor?.focus()
-    if (!this.trigger || !this.isOpen) return
+
+    if (this.isClosed) return
     this.trigger.setAttribute("aria-expanded", "false")
     this.panel.hidden = true
-    this.content?.onClose?.()
-  }
-
-  #connectContent() {
-    const name = this.dataset.content
-    const ContentClass = name ? dropdownContents[name] : null
-    if (!ContentClass) return
-
-    this.content = new ContentClass(this)
-    this.content.connect?.()
+    this.onClose()
   }
 
   #handleTriggerClick = () => {

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -5,10 +5,12 @@ export class ToolbarDropdown extends HTMLElement {
   #listeners = new ListenerBin()
 
   connectedCallback() {
-    this.container = this.closest("details")
+    this.container = this.closest(".lexxy-editor__toolbar-dropdown")
+    this.trigger = this.container?.querySelector("[aria-haspopup='menu']")
 
     this.#listeners.track(
-      registerEventListener(this.container, "toggle", this.#handleToggle),
+      registerEventListener(this.trigger, "click", this.#handleTriggerClick),
+      registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle),
       registerEventListener(this.container, "keydown", this.#handleKeyDown)
     )
 
@@ -31,6 +33,10 @@ export class ToolbarDropdown extends HTMLElement {
     return this.toolbar.editor
   }
 
+  get isOpen() {
+    return this.trigger?.getAttribute("aria-expanded") === "true"
+  }
+
   track(...listeners) {
     this.#listeners.track(...listeners)
   }
@@ -39,9 +45,28 @@ export class ToolbarDropdown extends HTMLElement {
     // Any post-editor initialization
   }
 
-  close() {
-    this.editor.focus()
-    this.container.open = false
+  open() {
+    if (!this.trigger || this.isOpen) return
+    this.trigger.setAttribute("aria-expanded", "true")
+    this.hidden = false
+    this.#dispatchToggle("open")
+  }
+
+  close({ focusEditor = true } = {}) {
+    if (focusEditor) this.editor?.focus()
+    if (!this.trigger || !this.isOpen) return
+    this.trigger.setAttribute("aria-expanded", "false")
+    this.hidden = true
+    this.#dispatchToggle("closed")
+  }
+
+  #handleTriggerClick = () => {
+    if (this.isOpen) {
+      this.close({ focusEditor: false })
+    } else {
+      this.toolbar?.closeDropdowns({ except: this })
+      this.open()
+    }
   }
 
   async #onToolbarEditor(callback) {
@@ -49,8 +74,8 @@ export class ToolbarDropdown extends HTMLElement {
     callback()
   }
 
-  #handleToggle = () => {
-    if (this.container.open) {
+  #handleToggle = (event) => {
+    if (event.detail?.newState === "open") {
       this.#handleOpen()
     }
   }
@@ -72,6 +97,13 @@ export class ToolbarDropdown extends HTMLElement {
     this.#buttons.forEach((element, index) => {
       element.setAttribute("tabindex", index === 0 ? 0 : "-1")
     })
+  }
+
+  #dispatchToggle(newState) {
+    this.container.dispatchEvent(new CustomEvent("lexxy:toolbar-dropdown-toggle", {
+      bubbles: true,
+      detail: { newState }
+    }))
   }
 
   get #interactiveElements() {

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -5,16 +5,18 @@ export class ToolbarDropdown extends HTMLElement {
   #listeners = new ListenerBin()
 
   connectedCallback() {
+    this.#onToolbarEditor(this.initialize.bind(this))
+
     this.container = this.closest(".lexxy-editor__toolbar-dropdown")
     this.trigger = this.container?.querySelector("[aria-haspopup='menu']")
 
-    this.#listeners.track(
-      registerEventListener(this.trigger, "click", this.#handleTriggerClick),
-      registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle),
-      registerEventListener(this.container, "keydown", this.#handleKeyDown)
-    )
+    if (!this.container || !this.trigger) return
 
-    this.#onToolbarEditor(this.initialize.bind(this))
+    this.#listeners.track(
+      registerEventListener(this.container, "lexxy:toolbar-dropdown-toggle", this.#handleToggle),
+      registerEventListener(this.container, "keydown", this.#handleKeyDown),
+      registerEventListener(this.trigger, "click", this.#handleTriggerClick)
+    )
   }
 
   disconnectedCallback() {

--- a/src/elements/toolbar_dropdown.js
+++ b/src/elements/toolbar_dropdown.js
@@ -8,7 +8,7 @@ export class ToolbarDropdown extends HTMLElement {
     this.#onToolbarEditor(this.initialize.bind(this))
 
     this.container = this.closest(".lexxy-editor__toolbar-dropdown")
-    this.trigger = this.container?.querySelector("[aria-haspopup='menu']")
+    this.trigger = this.container?.querySelector("button")
 
     if (!this.container || !this.trigger) return
 

--- a/src/helpers/html_helper.js
+++ b/src/helpers/html_helper.js
@@ -1,7 +1,9 @@
 export function createElement(name, properties, content = "") {
   const element = document.createElement(name)
   for (const [ key, value ] of Object.entries(properties || {})) {
-    if (key in element) {
+    if (key === "dataset") {
+      Object.entries(value).forEach(([ key, value ]) => (element.dataset[key] = value))
+    } else if (key in element) {
       element[key] = value
     } else if (value !== null && value !== undefined) {
       element.setAttribute(key, value)

--- a/test/browser/fixtures/toolbar-external.html
+++ b/test/browser/fixtures/toolbar-external.html
@@ -15,10 +15,11 @@
     <div class="body">
       <lexxy-toolbar id="external_toolbar">
         <button class="lexxy-editor__toolbar-button" type="button" name="bold" data-command="bold" title="Bold">bold</button>
-        <details class="lexxy-editor__toolbar-overflow">
-          <summary class="lexxy-editor__toolbar-button" aria-label="Show more toolbar buttons">&bull;&bull;&bull;</summary>
-          <div class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons"></div>
-        </details>
+        <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
+          <button class="lexxy-editor__toolbar-button" type="button"
+                  aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">&bull;&bull;&bull;</button>
+          <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></lexxy-toolbar-dropdown>
+        </div>
       </lexxy-toolbar>
 
       <lexxy-editor class="lexxy-content" placeholder="Write something..." toolbar="external_toolbar" required></lexxy-editor>

--- a/test/browser/fixtures/toolbar-external.html
+++ b/test/browser/fixtures/toolbar-external.html
@@ -15,7 +15,7 @@
     <div class="body">
       <lexxy-toolbar id="external_toolbar">
         <button class="lexxy-editor__toolbar-button" type="button" name="bold" data-command="bold" title="Bold">bold</button>
-        <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
+        <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-overflow">
           <button class="lexxy-editor__toolbar-button" type="button" data-dropdown-trigger
                   aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">&bull;&bull;&bull;</button>
           <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></div>

--- a/test/browser/fixtures/toolbar-external.html
+++ b/test/browser/fixtures/toolbar-external.html
@@ -15,11 +15,11 @@
     <div class="body">
       <lexxy-toolbar id="external_toolbar">
         <button class="lexxy-editor__toolbar-button" type="button" name="bold" data-command="bold" title="Bold">bold</button>
-        <div class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
-          <button class="lexxy-editor__toolbar-button" type="button"
+        <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-dropdown lexxy-editor__toolbar-overflow">
+          <button class="lexxy-editor__toolbar-button" type="button" data-dropdown-trigger
                   aria-haspopup="menu" aria-expanded="false" aria-label="Show more toolbar buttons">&bull;&bull;&bull;</button>
-          <lexxy-toolbar-dropdown role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></lexxy-toolbar-dropdown>
-        </div>
+          <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-overflow-menu" aria-label="More toolbar buttons" hidden></div>
+        </lexxy-toolbar-dropdown>
       </lexxy-toolbar>
 
       <lexxy-editor class="lexxy-content" placeholder="Write something..." toolbar="external_toolbar" required></lexxy-editor>

--- a/test/browser/helpers/toolbar.js
+++ b/test/browser/helpers/toolbar.js
@@ -23,7 +23,7 @@ export async function clickToolbarButton(page, command) {
 export async function applyHighlightOption(page, attribute, buttonIndex) {
   await page.locator("[name='highlight']").click()
   const buttons = page.locator(
-    `lexxy-highlight-dropdown .lexxy-highlight-colors .lexxy-highlight-button[data-style='${attribute}']`,
+    `lexxy-toolbar-dropdown[data-content='highlight'] [data-dropdown-panel] .lexxy-highlight-colors .lexxy-highlight-button[data-style='${attribute}']`,
   )
   await buttons.nth(buttonIndex - 1).click()
 }

--- a/test/browser/helpers/toolbar.js
+++ b/test/browser/helpers/toolbar.js
@@ -23,7 +23,7 @@ export async function clickToolbarButton(page, command) {
 export async function applyHighlightOption(page, attribute, buttonIndex) {
   await page.locator("[name='highlight']").click()
   const buttons = page.locator(
-    `lexxy-toolbar-dropdown[data-content='highlight'] [data-dropdown-panel] .lexxy-highlight-colors .lexxy-highlight-button[data-style='${attribute}']`,
+    `lexxy-highlight-dropdown [data-dropdown-panel] .lexxy-highlight-colors .lexxy-highlight-button[data-style='${attribute}']`,
   )
   await buttons.nth(buttonIndex - 1).click()
 }

--- a/test/browser/helpers/toolbar.js
+++ b/test/browser/helpers/toolbar.js
@@ -1,11 +1,11 @@
 export const HELLO_EVERYONE = "<p>Hello everyone</p>"
 
 export async function openFormatDropdown(page) {
-  await page.evaluate(() => {
-    const details = document.querySelector("summary[name='format']").closest("details")
-    details.open = true
-    details.dispatchEvent(new Event("toggle"))
-  })
+  await openToolbarDropdown(page, "format")
+}
+
+export async function openToolbarDropdown(page, name) {
+  await page.locator(`button[name='${name}'][aria-haspopup='menu']`).click()
 }
 
 const FORMAT_DROPDOWN_COMMANDS = new Set([

--- a/test/browser/helpers/toolbar.js
+++ b/test/browser/helpers/toolbar.js
@@ -5,7 +5,7 @@ export async function openFormatDropdown(page) {
 }
 
 export async function openToolbarDropdown(page, name) {
-  await page.locator(`button[name='${name}'][aria-haspopup='menu']`).click()
+  await page.locator(`button[name='${name}']`).click()
 }
 
 const FORMAT_DROPDOWN_COMMANDS = new Set([

--- a/test/browser/tests/events.test.js
+++ b/test/browser/tests/events.test.js
@@ -64,7 +64,7 @@ test.describe("Events", () => {
     await page.locator("[name='highlight']").click()
     await page
       .locator(
-        "lexxy-highlight-dropdown .lexxy-highlight-colors .lexxy-highlight-button[data-style='background-color']",
+        "lexxy-toolbar-dropdown[data-content='highlight'] [data-dropdown-panel] .lexxy-highlight-colors .lexxy-highlight-button[data-style='background-color']",
       )
       .first()
       .click()

--- a/test/browser/tests/events.test.js
+++ b/test/browser/tests/events.test.js
@@ -64,7 +64,7 @@ test.describe("Events", () => {
     await page.locator("[name='highlight']").click()
     await page
       .locator(
-        "lexxy-toolbar-dropdown[data-content='highlight'] [data-dropdown-panel] .lexxy-highlight-colors .lexxy-highlight-button[data-style='background-color']",
+        "lexxy-highlight-dropdown [data-dropdown-panel] .lexxy-highlight-colors .lexxy-highlight-button[data-style='background-color']",
       )
       .first()
       .click()

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -1,7 +1,7 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 import { assertEditorHtml } from "../../helpers/assertions.js"
-import { HELLO_EVERYONE, clickToolbarButton } from "../../helpers/toolbar.js"
+import { HELLO_EVERYONE, clickToolbarButton, openToolbarDropdown } from "../../helpers/toolbar.js"
 
 test.describe("Block formatting", () => {
   test.beforeEach(async ({ page }) => {
@@ -290,15 +290,7 @@ test.describe("Block formatting", () => {
     await editor.select("everyone")
     await editor.flush()
 
-    // Open the link dropdown programmatically to avoid focus/selection loss
-    // that occurs with a real click on the summary element
-    await page.evaluate(() => {
-      const details = document.querySelector(
-        "details:has(summary[name='link'])",
-      )
-      details.open = true
-      details.dispatchEvent(new Event("toggle"))
-    })
+    await openToolbarDropdown(page, "link")
 
     const input = page.locator("lexxy-link-dropdown input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
@@ -330,13 +322,7 @@ test.describe("Block formatting", () => {
     await editor.select("everyone")
     await editor.flush()
 
-    await page.evaluate(() => {
-      const details = document.querySelector(
-        "details:has(summary[name='link'])",
-      )
-      details.open = true
-      details.dispatchEvent(new Event("toggle"))
-    })
+    await openToolbarDropdown(page, "link")
 
     const input = page.locator("lexxy-link-dropdown input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
@@ -362,13 +348,7 @@ test.describe("Block formatting", () => {
     await editor.select("everyone")
     await editor.flush()
 
-    await page.evaluate(() => {
-      const details = document.querySelector(
-        "details:has(summary[name='link'])",
-      )
-      details.open = true
-      details.dispatchEvent(new Event("toggle"))
-    })
+    await openToolbarDropdown(page, "link")
 
     const input = page.locator("lexxy-link-dropdown input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
@@ -383,13 +363,7 @@ test.describe("Block formatting", () => {
     await editor.select("everyone")
     await editor.flush()
 
-    await page.evaluate(() => {
-      const details = document.querySelector(
-        "details:has(summary[name='link'])",
-      )
-      details.open = true
-      details.dispatchEvent(new Event("toggle"))
-    })
+    await openToolbarDropdown(page, "link")
 
     const input = page.locator("lexxy-link-dropdown input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -292,11 +292,11 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await input.fill("https://37signals.com")
     await page
-      .locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] button[value='link']")
+      .locator("lexxy-link-dropdown [data-dropdown-panel] button[value='link']")
       .first()
       .click()
 
@@ -324,7 +324,7 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await input.fill("https://37signals.com")
     await input.press("Enter")
@@ -350,7 +350,7 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("https://37signals.com")
   })
@@ -365,7 +365,7 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("")
   })

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -292,11 +292,11 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-link-dropdown input[type='url']").first()
+    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await input.fill("https://37signals.com")
     await page
-      .locator("lexxy-link-dropdown button[value='link']")
+      .locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] button[value='link']")
       .first()
       .click()
 
@@ -324,7 +324,7 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-link-dropdown input[type='url']").first()
+    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await input.fill("https://37signals.com")
     await input.press("Enter")
@@ -350,7 +350,7 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-link-dropdown input[type='url']").first()
+    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("https://37signals.com")
   })
@@ -365,7 +365,7 @@ test.describe("Block formatting", () => {
 
     await openToolbarDropdown(page, "link")
 
-    const input = page.locator("lexxy-link-dropdown input[type='url']").first()
+    const input = page.locator("lexxy-toolbar-dropdown[data-content='link'] [data-dropdown-panel] input[type='url']").first()
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("")
   })

--- a/test/browser/tests/formatting/color_highlighter.test.js
+++ b/test/browser/tests/formatting/color_highlighter.test.js
@@ -91,6 +91,7 @@ test.describe("Color highlighter", () => {
     await editor.flush()
 
     await assertEditorContent(editor, async (content) => {
+      await expect(content).toContainText("some log output")
       await expect(content.locator("code mark")).toContainText("log output")
     })
 
@@ -99,6 +100,7 @@ test.describe("Color highlighter", () => {
     await editor.flush()
 
     await assertEditorContent(editor, async (content) => {
+      await expect(content).toContainText("some log output")
       await expect(content.locator("code mark")).toHaveCount(0)
     })
   })

--- a/test/test_helpers/toolbar_helper.rb
+++ b/test/test_helpers/toolbar_helper.rb
@@ -2,7 +2,7 @@ module ToolbarHelper
   def apply_highlight_option(attribute, button_index)
     find("[name='highlight']").click
 
-    within "lexxy-highlight-dropdown .lexxy-highlight-colors" do
+    within "lexxy-toolbar-dropdown[data-content='highlight'] [data-dropdown-panel] .lexxy-highlight-colors" do
       all(".lexxy-highlight-button[data-style='#{attribute}']")[button_index - 1].click
     end
   end

--- a/test/test_helpers/toolbar_helper.rb
+++ b/test/test_helpers/toolbar_helper.rb
@@ -2,7 +2,7 @@ module ToolbarHelper
   def apply_highlight_option(attribute, button_index)
     find("[name='highlight']").click
 
-    within "lexxy-toolbar-dropdown[data-content='highlight'] [data-dropdown-panel] .lexxy-highlight-colors" do
+    within "lexxy-highlight-dropdown [data-dropdown-panel] .lexxy-highlight-colors" do
       all(".lexxy-highlight-button[data-style='#{attribute}']")[button_index - 1].click
     end
   end


### PR DESCRIPTION
This PR is aimed at silencing browser warnings:
- Chrome reported "interactive element inside of a `<summary>` element". This was caused by the accessibility helper assigning a `tabindex` on interactive toolbar elements, including `<summary>` elements. Although the code was cleaner with `<details>` elements, we are moving back to JS controlled dropdowns to silence these warnings.
- Chrome also reported a missing id/name for the link URL input, this PR adds an `id` attribute.
- Also leaves toolbar dropdowns open on editor blur, as the behavior was too aggressive


### Code refactoring of dropdowns

This refactor consolidates toolbar dropdown logic into a single custom element.

Previously, each dropdown was split across three pieces — a wrapper `<div class="lexxy-editor__toolbar-dropdown">`, a sibling trigger button, and a `<lexxy-toolbar-dropdown>` (or subclass) representing only the panel — with open/close coordination divided between toolbar.js and toolbar_dropdown.js.

The `<lexxy-toolbar-dropdown>` element now owns the whole unit: it wraps the trigger button (`data-dropdown-trigger`) and the panel (`data-dropdown-panel`), and handles open/close, focus, escape, and tabindex on its own. The toolbar continues to coordinate "close all dropdowns" on editor blur and selection change, but everything else moves into the dropdown element.

`HighlightDropdown` and `LinkDropdown` are no longer custom-element subclasses; they are plain `HighlightContent` / `LinkContent` controller classes wired through a small dropdownContents registry keyed off a data-content attribute on the dropdown.

The dropdown instantiates the controller and calls `connect()`, `onOpen()`, and `onClose()` directly, replacing the old `lexxy:toolbar-dropdown-toggle` custom event. CSS selectors that hung off `lexxy-link-dropdown` / `lexxy-highlight-dropdown` element names move to explicit panel classes (`.lexxy-editor__toolbar-link-panel`, `.lexxy-editor__toolbar-highlight-panel`).

No user-facing behavior change is intended — this is a structural cleanup.