### PR TITLE
Group images pasted in succession into a gallery

### DIFF
--- a/src/editor/contents/uploader.js
+++ b/src/editor/contents/uploader.js
@@ -2,7 +2,6 @@ import { $getSelection } from "lexical"
 import { isPreviewableImage } from "../../helpers/html_helper"
 import { $createActionTextAttachmentUploadNode } from "../../nodes/action_text_attachment_upload_node"
 import { $createImageGalleryNode, $findOrCreateGalleryForImage, ImageGalleryNode } from "../../nodes/image_gallery_node"
-import { $getNearestNodeOfType } from "@lexical/utils"
 
 export default class Uploader {
   #files
@@ -12,8 +11,9 @@ export default class Uploader {
     return new UploaderKlass(editorElement, files)
   }
 
-  constructor(editorElement, files) {
+  constructor(editorElement, files, options = {}) {
     this.#files = files
+    this.options = options
 
     this.editorElement = editorElement
     this.contents = editorElement.contents
@@ -55,10 +55,10 @@ class GalleryUploader extends Uploader {
   #gallery
 
   static handle(editorElement, files) {
-    return this.#isMultipleImageUpload(files) || this.#gallerySelection(editorElement.selection)
+    return this.isMultipleImageUpload(files) || this.gallerySelection(editorElement.selection)
   }
 
-  static #isMultipleImageUpload(files) {
+  static isMultipleImageUpload(files) {
     let imageFileCount = 0
     for (const file of files) {
       if (isPreviewableImage(file.type)) imageFileCount++
@@ -67,11 +67,12 @@ class GalleryUploader extends Uploader {
     return false
   }
 
-  static #gallerySelection(selection) {
-    if (selection.isOnPreviewableImage) return true
+  static gallerySelection(selection) {
+    return selection.isOnPreviewableImage || this.selectionIsAfterGalleryEdge(selection)
+  }
 
-    const { node: selectedNode } = selection.selectedNodeWithOffset()
-    return $getNearestNodeOfType(selectedNode, ImageGalleryNode) !== null
+  static selectionIsAfterGalleryEdge(selection) {
+    return selection.isAtNodeStart && ImageGalleryNode.canCollapseWith(selection.nodeBeforeCursor)
   }
 
   $insertUploadNodes() {
@@ -83,10 +84,16 @@ class GalleryUploader extends Uploader {
   #findOrCreateGallery() {
     if (this.selection.isOnPreviewableImage) {
       this.#gallery = $findOrCreateGalleryForImage(this.#selectedNode)
+    } else if (this.#selectionIsAfterGalleryEdge) {
+      this.#gallery = $findOrCreateGalleryForImage(this.selection.nodeBeforeCursor)
     } else {
       this.#gallery = $createImageGalleryNode()
       this.contents.insertAtCursor(this.#gallery)
     }
+  }
+
+  get #selectionIsAfterGalleryEdge() {
+    return this.constructor.selectionIsAfterGalleryEdge(this.selection)
   }
 
   get #selectedNode() {
@@ -95,6 +102,8 @@ class GalleryUploader extends Uploader {
   }
 
   get #galleryInsertPosition() {
+    if (this.#selectionIsAfterGalleryEdge) return this.#gallery.getChildrenSize()
+
     const anchor = $getSelection()?.anchor
     const galleryHasElementSelection = anchor?.getNode().is(this.#gallery)
     if (galleryHasElementSelection) return anchor.offset

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -208,6 +208,11 @@ export default class Selection {
     return $isActionTextAttachmentNode(firstNode) && firstNode.isPreviewableImage
   }
 
+  get isAtNodeStart() {
+    const { anchorNode, offset } = this.#getCollapsedSelectionData()
+    return anchorNode && offset === 0
+  }
+
   get nodeAfterCursor() {
     const { anchorNode, offset } = this.#getCollapsedSelectionData()
     if (!anchorNode) return null

--- a/test/browser/helpers/gallery_test_helpers.js
+++ b/test/browser/helpers/gallery_test_helpers.js
@@ -1,0 +1,49 @@
+import { expect } from "@playwright/test"
+
+export async function uploadStandaloneAfter(editor, anchorType, filePath) {
+  await positionCursorAfterNode(editor, anchorType)
+  await editor.send("x", "Enter")
+  await editor.uploadFile(filePath)
+  await expect(editor.content.locator("figure.attachment--preview > progress")).toHaveCount(0)
+  await editor.flush()
+  await removeBufferParagraphsBetweenImages(editor)
+}
+
+export async function positionCursorAfterNode(editor, anchorType) {
+  await editor.locator.evaluate((el, type) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        for (const child of root.getChildren()) {
+          if (child.getType() === type) {
+            const next = child.getNextSibling()
+            if (next?.getType() === "provisonal_paragraph") {
+              next.selectStart()
+            } else {
+              child.selectNext(0, 0)
+            }
+            return
+          }
+        }
+      }, { onUpdate: resolve })
+    })
+  }, anchorType)
+}
+
+export async function removeBufferParagraphsBetweenImages(editor) {
+  await editor.locator.evaluate((el) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        const isImageNode = (n) =>
+          n?.getType() === "action_text_attachment" || n?.getType() === "image_gallery"
+        for (const node of root.getChildren()) {
+          const type = node.getType()
+          if (type !== "paragraph" && type !== "provisonal_paragraph") continue
+          if (!isImageNode(node.getPreviousSibling()) || !isImageNode(node.getNextSibling())) continue
+          if (node.getTextContent().replace(/x/g, "") === "") node.remove()
+        }
+      }, { onUpdate: resolve })
+    })
+  })
+}

--- a/test/browser/tests/attachments/attachment_drag_and_drop.test.js
+++ b/test/browser/tests/attachments/attachment_drag_and_drop.test.js
@@ -1,6 +1,7 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+import { uploadStandaloneAfter } from "../../helpers/gallery_test_helpers.js"
 
 // Inject the shared drag simulation helper before each test
 test.beforeEach(async ({ page }) => {
@@ -444,54 +445,6 @@ async function assertGalleryWithImages(editor, count) {
 
 async function assertNoGallery(page) {
   await expect(page.locator(".attachment-gallery")).toHaveCount(0)
-}
-
-async function uploadStandaloneAfter(editor, anchorType, filePath) {
-  await positionCursorAfterNode(editor, anchorType)
-  await editor.send("x", "Enter")
-  await editor.uploadFile(filePath)
-  await expect(editor.content.locator("figure.attachment--preview > progress")).toHaveCount(0)
-  await editor.flush()
-  await removeBufferParagraphsBetweenImages(editor)
-}
-
-async function positionCursorAfterNode(editor, anchorType) {
-  await editor.locator.evaluate((el, type) => {
-    return new Promise((resolve) => {
-      el.editor.update(() => {
-        const root = el.editor.getEditorState()._nodeMap.get("root")
-        for (const child of root.getChildren()) {
-          if (child.getType() === type) {
-            const next = child.getNextSibling()
-            if (next?.getType() === "provisonal_paragraph") {
-              next.selectStart()
-            } else {
-              child.selectNext(0, 0)
-            }
-            return
-          }
-        }
-      }, { onUpdate: resolve })
-    })
-  }, anchorType)
-}
-
-async function removeBufferParagraphsBetweenImages(editor) {
-  await editor.locator.evaluate((el) => {
-    return new Promise((resolve) => {
-      el.editor.update(() => {
-        const root = el.editor.getEditorState()._nodeMap.get("root")
-        const isImageNode = (n) =>
-          n?.getType() === "action_text_attachment" || n?.getType() === "image_gallery"
-        for (const node of root.getChildren()) {
-          const type = node.getType()
-          if (type !== "paragraph" && type !== "provisonal_paragraph") continue
-          if (!isImageNode(node.getPreviousSibling()) || !isImageNode(node.getNextSibling())) continue
-          if (node.getTextContent().replace(/x/g, "") === "") node.remove()
-        }
-      }, { onUpdate: resolve })
-    })
-  })
 }
 
 async function simulateDrag(page, sourceSelector, targetSelector, position = "after") {

--- a/test/browser/tests/attachments/attachment_drag_and_drop.test.js
+++ b/test/browser/tests/attachments/attachment_drag_and_drop.test.js
@@ -112,8 +112,7 @@ test.describe("Attachment Drag and Drop", () => {
       await assertGalleryWithImages(editor, 2)
       await waitForUploadsComplete(page, editor)
 
-      await editor.send("Enter")
-      await editor.uploadFile("test/fixtures/files/example.png")
+      await uploadStandaloneAfter(editor, "image_gallery", "test/fixtures/files/example.png")
       await waitForUploadsComplete(page, editor)
 
       const standalone = page.locator(".lexxy-editor__content > figure.attachment")
@@ -132,8 +131,7 @@ test.describe("Attachment Drag and Drop", () => {
       await assertGalleryWithImages(editor, 2)
       await waitForUploadsComplete(page, editor)
 
-      await editor.send("Enter")
-      await editor.uploadFile("test/fixtures/files/example.png")
+      await uploadStandaloneAfter(editor, "image_gallery", "test/fixtures/files/example.png")
       await waitForUploadsComplete(page, editor)
       await editor.flush()
 
@@ -254,8 +252,9 @@ test.describe("Attachment Drag and Drop", () => {
 
     test("undo reverses gallery creation", async ({ page, editor }) => {
       await editor.uploadFile("test/fixtures/files/example.png")
-      await editor.send("Enter")
-      await editor.uploadFile("test/fixtures/files/example2.png")
+      await waitForUploadsComplete(page, editor)
+
+      await uploadStandaloneAfter(editor, "action_text_attachment", "test/fixtures/files/example2.png")
       await waitForUploadsComplete(page, editor)
 
       await simulateDragByIndex(page, 1, 0, "onto")
@@ -445,6 +444,54 @@ async function assertGalleryWithImages(editor, count) {
 
 async function assertNoGallery(page) {
   await expect(page.locator(".attachment-gallery")).toHaveCount(0)
+}
+
+async function uploadStandaloneAfter(editor, anchorType, filePath) {
+  await positionCursorAfterNode(editor, anchorType)
+  await editor.send("x", "Enter")
+  await editor.uploadFile(filePath)
+  await expect(editor.content.locator("figure.attachment--preview > progress")).toHaveCount(0)
+  await editor.flush()
+  await removeBufferParagraphsBetweenImages(editor)
+}
+
+async function positionCursorAfterNode(editor, anchorType) {
+  await editor.locator.evaluate((el, type) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        for (const child of root.getChildren()) {
+          if (child.getType() === type) {
+            const next = child.getNextSibling()
+            if (next?.getType() === "provisonal_paragraph") {
+              next.selectStart()
+            } else {
+              child.selectNext(0, 0)
+            }
+            return
+          }
+        }
+      }, { onUpdate: resolve })
+    })
+  }, anchorType)
+}
+
+async function removeBufferParagraphsBetweenImages(editor) {
+  await editor.locator.evaluate((el) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        const isImageNode = (n) =>
+          n?.getType() === "action_text_attachment" || n?.getType() === "image_gallery"
+        for (const node of root.getChildren()) {
+          const type = node.getType()
+          if (type !== "paragraph" && type !== "provisonal_paragraph") continue
+          if (!isImageNode(node.getPreviousSibling()) || !isImageNode(node.getNextSibling())) continue
+          if (node.getTextContent().replace(/x/g, "") === "") node.remove()
+        }
+      }, { onUpdate: resolve })
+    })
+  })
 }
 
 async function simulateDrag(page, sourceSelector, targetSelector, position = "after") {

--- a/test/browser/tests/attachments/gallery.test.js
+++ b/test/browser/tests/attachments/gallery.test.js
@@ -219,6 +219,31 @@ test.describe("Gallery", () => {
     await assertGalleryCount(page, 1)
   })
 
+  test("delete at gallery end absorbs next gallery", async ({
+    page,
+    editor,
+  }) => {
+    await editor.uploadFile([
+      "test/fixtures/files/example.png",
+      "test/fixtures/files/example2.png",
+      "test/fixtures/files/example.png",
+      "test/fixtures/files/example2.png",
+    ])
+
+    await assertGalleryWithImages(editor, 4)
+
+    await selectGalleryAtOffset(page, editor, 2)
+    await editor.send("Enter")
+
+    await assertGalleryCount(page, 2)
+
+    await selectGalleryAtOffset(page, editor, 2, 0)
+    await editor.send("Delete")
+
+    await assertGalleryCount(page, 1)
+    await assertGalleryWithImages(editor, 4)
+  })
+
   test("backspace at gallery start absorbs previous image", async ({
     page,
     editor,
@@ -251,42 +276,16 @@ test.describe("Gallery", () => {
       "test/fixtures/files/example2.png",
     ])
 
-    await editor.send("Enter")
+    await assertGalleryWithImages(editor, 2)
 
-    await editor.uploadFile("test/fixtures/files/example.png")
-
+    await uploadStandaloneAfter(editor, "image_gallery", "test/fixtures/files/example.png")
     await assertGalleryWithImages(editor, 2)
     await expect(page.locator("figure.attachment--preview")).toHaveCount(3)
 
-    await selectGalleryAtOffset(page, editor, 2)
+    await selectGalleryNode(editor)
     await editor.send("Delete")
 
     await assertGalleryWithImages(editor, 3)
-  })
-
-  test("delete at gallery end absorbs next gallery", async ({
-    page,
-    editor,
-  }) => {
-    await editor.uploadFile([
-      "test/fixtures/files/example.png",
-      "test/fixtures/files/example2.png",
-    ])
-
-    await editor.send("Enter")
-
-    await editor.uploadFile([
-      "test/fixtures/files/example.png",
-      "test/fixtures/files/example2.png",
-    ])
-
-    await assertGalleryCount(page, 2)
-
-    await selectGalleryAtOffset(page, editor, 2, 0)
-    await editor.send("Delete")
-
-    await assertGalleryCount(page, 1)
-    await assertGalleryWithImages(editor, 4)
   })
 
   test("backspace at gallery start with empty paragraph above removes paragraph", async ({
@@ -403,4 +402,64 @@ async function selectGalleryAtOffset(page, editor, offset, galleryIndex = 0) {
     await selectGalleryImage(page, offset - 1, galleryIndex)
     await editor.send("ArrowRight")
   }
+}
+
+async function uploadStandaloneAfter(editor, anchorType, filePath) {
+  await positionCursorAfterNode(editor, anchorType)
+  await editor.send("x", "Enter")
+  await editor.uploadFile(filePath)
+  await expect(editor.content.locator("figure.attachment--preview > progress")).toHaveCount(0)
+  await editor.flush()
+  await removeBufferParagraphsBetweenImages(editor)
+}
+
+async function positionCursorAfterNode(editor, anchorType) {
+  await editor.locator.evaluate((el, type) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        for (const child of root.getChildren()) {
+          if (child.getType() === type) {
+            const next = child.getNextSibling()
+            if (next?.getType() === "provisonal_paragraph") {
+              next.selectStart()
+            } else {
+              child.selectNext(0, 0)
+            }
+            return
+          }
+        }
+      }, { onUpdate: resolve })
+    })
+  }, anchorType)
+}
+
+async function removeBufferParagraphsBetweenImages(editor) {
+  await editor.locator.evaluate((el) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        const isImageNode = (n) =>
+          n?.getType() === "action_text_attachment" || n?.getType() === "image_gallery"
+        for (const node of root.getChildren()) {
+          const type = node.getType()
+          if (type !== "paragraph" && type !== "provisonal_paragraph") continue
+          if (!isImageNode(node.getPreviousSibling()) || !isImageNode(node.getNextSibling())) continue
+          if (node.getTextContent().replace(/x/g, "") === "") node.remove()
+        }
+      }, { onUpdate: resolve })
+    })
+  })
+}
+
+async function selectGalleryNode(editor, galleryIndex = 0) {
+  await editor.locator.evaluate((el, idx) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        const galleries = root.getChildren().filter((c) => c.getType() === "image_gallery")
+        if (galleries[idx]) galleries[idx].select()
+      }, { onUpdate: resolve })
+    })
+  }, galleryIndex)
 }

--- a/test/browser/tests/attachments/gallery.test.js
+++ b/test/browser/tests/attachments/gallery.test.js
@@ -1,6 +1,7 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+import { uploadStandaloneAfter } from "../../helpers/gallery_test_helpers.js"
 
 test.describe("Gallery", () => {
   test.beforeEach(async ({ page }) => {
@@ -402,54 +403,6 @@ async function selectGalleryAtOffset(page, editor, offset, galleryIndex = 0) {
     await selectGalleryImage(page, offset - 1, galleryIndex)
     await editor.send("ArrowRight")
   }
-}
-
-async function uploadStandaloneAfter(editor, anchorType, filePath) {
-  await positionCursorAfterNode(editor, anchorType)
-  await editor.send("x", "Enter")
-  await editor.uploadFile(filePath)
-  await expect(editor.content.locator("figure.attachment--preview > progress")).toHaveCount(0)
-  await editor.flush()
-  await removeBufferParagraphsBetweenImages(editor)
-}
-
-async function positionCursorAfterNode(editor, anchorType) {
-  await editor.locator.evaluate((el, type) => {
-    return new Promise((resolve) => {
-      el.editor.update(() => {
-        const root = el.editor.getEditorState()._nodeMap.get("root")
-        for (const child of root.getChildren()) {
-          if (child.getType() === type) {
-            const next = child.getNextSibling()
-            if (next?.getType() === "provisonal_paragraph") {
-              next.selectStart()
-            } else {
-              child.selectNext(0, 0)
-            }
-            return
-          }
-        }
-      }, { onUpdate: resolve })
-    })
-  }, anchorType)
-}
-
-async function removeBufferParagraphsBetweenImages(editor) {
-  await editor.locator.evaluate((el) => {
-    return new Promise((resolve) => {
-      el.editor.update(() => {
-        const root = el.editor.getEditorState()._nodeMap.get("root")
-        const isImageNode = (n) =>
-          n?.getType() === "action_text_attachment" || n?.getType() === "image_gallery"
-        for (const node of root.getChildren()) {
-          const type = node.getType()
-          if (type !== "paragraph" && type !== "provisonal_paragraph") continue
-          if (!isImageNode(node.getPreviousSibling()) || !isImageNode(node.getNextSibling())) continue
-          if (node.getTextContent().replace(/x/g, "") === "") node.remove()
-        }
-      }, { onUpdate: resolve })
-    })
-  })
 }
 
 async function selectGalleryNode(editor, galleryIndex = 0) {

--- a/test/browser/tests/paste/paste_images_gallery.test.js
+++ b/test/browser/tests/paste/paste_images_gallery.test.js
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs"
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+const EXAMPLE_PNG = readFileSync("test/fixtures/files/example.png").toString(
+  "base64",
+)
+const EXAMPLE2_PNG = readFileSync("test/fixtures/files/example2.png").toString(
+  "base64",
+)
+
+test.describe("Paste — Adjacent images form a gallery", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+    await mockActiveStorageUploads(page)
+  })
+
+  test("pasting two images one after another groups them into a gallery", async ({ page, editor }) => {
+    await editor.paste("", {
+      files: [
+        { base64: EXAMPLE_PNG, name: "first.png", type: "image/png" },
+      ],
+    })
+
+    // Wait for the first image to appear in the editor
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/png']"),
+    ).toHaveCount(1, { timeout: 10_000 })
+
+    await editor.paste("", {
+      files: [
+        { base64: EXAMPLE2_PNG, name: "second.png", type: "image/png" },
+      ],
+    })
+
+    // Both images should be visible
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/png']"),
+    ).toHaveCount(2, { timeout: 10_000 })
+
+    // And they should be grouped inside a single gallery (matching the
+    // behavior of uploading multiple images at once or pasting side-by-side
+    // images in Trix).
+    const gallery = editor.content.locator(".attachment-gallery")
+    await expect(gallery).toHaveCount(1)
+    await expect(gallery.locator("figure.attachment")).toHaveCount(2)
+  })
+
+  test("pasting three images in succession groups them into a single gallery", async ({ page, editor }) => {
+    for (const [ index, base64 ] of [ EXAMPLE_PNG, EXAMPLE2_PNG, EXAMPLE_PNG ].entries()) {
+      await editor.paste("", {
+        files: [ { base64, name: `image-${index}.png`, type: "image/png" } ],
+      })
+
+      await expect(
+        editor.content.locator("figure.attachment[data-content-type='image/png']"),
+      ).toHaveCount(index + 1, { timeout: 10_000 })
+    }
+
+    const gallery = editor.content.locator(".attachment-gallery")
+    await expect(gallery).toHaveCount(1)
+    await expect(gallery.locator("figure.attachment")).toHaveCount(3)
+  })
+
+  test("pasting a non-image after pasting an image does not extend the gallery", async ({ page, editor }) => {
+    await editor.paste("", {
+      files: [ { base64: EXAMPLE_PNG, name: "first.png", type: "image/png" } ],
+    })
+
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/png']"),
+    ).toHaveCount(1, { timeout: 10_000 })
+
+    // Pasting a non-image should not auto-create a gallery from a single image.
+    const PDF_BASE64 = Buffer.from("%PDF-1.4 dummy", "utf8").toString("base64")
+    await editor.paste("", {
+      files: [ { base64: PDF_BASE64, name: "doc.pdf", type: "application/pdf" } ],
+    })
+
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='application/pdf']"),
+    ).toHaveCount(1, { timeout: 10_000 })
+
+    // No gallery should have been formed because the second paste isn't an image.
+    await expect(editor.content.locator(".attachment-gallery")).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Pasting two or more images one after another in Lexxy used to produce
  separate stacked attachments and force the user to drag them into a
  gallery manually each time. This matches the behavior reported on
  Basecamp card #9811488004 and diverges from Trix, which groups
  consecutive pasted images into a gallery.
- `GalleryUploader` now also fires on the paste path when the cursor
  sits next to an existing previewable image attachment or gallery,
  appending the new image to that gallery (creating one in place if the
  neighbor is a standalone attachment).

Card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9811488004