### PR TITLE
Preserve link when pasting a Lexxy single-link clipboard payload

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -3,14 +3,28 @@ import { isUrl } from "../helpers/string_helper"
 import { nextFrame } from "../helpers/timing_helpers"
 import { addBlockSpacing, dispatch, parseHtml } from "../helpers/html_helper"
 import { $isCodeNode } from "@lexical/code"
-import { $getSelection, $isRangeSelection, PASTE_TAG } from "lexical"
+import { $createTextNode, $getSelection, $isParagraphNode, $isRangeSelection, COMMAND_PRIORITY_NORMAL, PASTE_COMMAND, PASTE_TAG, SELECTION_INSERT_CLIPBOARD_NODES_COMMAND } from "lexical"
 import { $insertDataTransferForRichText } from "@lexical/clipboard"
+import { $createLinkNode, $isLinkNode, $toggleLink } from "@lexical/link"
+import { ListenerBin } from "../helpers/listener_helper"
 
 export default class Clipboard {
+  #listeners = new ListenerBin()
+
   constructor(editorElement) {
     this.editorElement = editorElement
     this.editor = editorElement.editor
     this.contents = editorElement.contents
+
+    this.#registerPasteCommands()
+  }
+
+  dispose() {
+    this.editorElement = null
+    this.editor = null
+    this.contents = null
+
+    this.#listeners.dispose()
   }
 
   paste(event) {
@@ -33,6 +47,25 @@ export default class Clipboard {
     const handled = this.#handlePastedFiles(clipboardData)
     if (handled) event.preventDefault()
     return handled
+  }
+
+  #registerPasteCommands() {
+    this.#listeners.track(
+      this.editor.registerCommand(PASTE_COMMAND, this.paste.bind(this), COMMAND_PRIORITY_NORMAL),
+      this.editor.registerCommand(
+        SELECTION_INSERT_CLIPBOARD_NODES_COMMAND,
+        (payload) => this.#handleParsedClipboardNodes(payload),
+        COMMAND_PRIORITY_NORMAL
+      )
+    )
+  }
+
+  #handleParsedClipboardNodes({ nodes, selection }) {
+    const url = $bareUrlFromSingleLink(nodes)
+    if (!url) return false
+
+    this.#insertSingleLinkAt(selection, url)
+    return true
   }
 
   #isPlainTextOrURLPasted(clipboardData) {
@@ -95,6 +128,24 @@ export default class Clipboard {
         this.#pasteRichText(clipboardData)
       }
     })
+  }
+
+  #insertSingleLinkAt(selection, url) {
+    if (!$isRangeSelection(selection)) return
+
+    if (!selection.isCollapsed()) {
+      $toggleLink(null)
+      $toggleLink(url)
+      return
+    }
+
+    const linkNode = $createLinkNode(url).append($createTextNode(url))
+    selection.insertNodes([ linkNode ])
+
+    // Defer the lexxy:insert-link event until after the active update commits;
+    // listeners may run editor mutations of their own.
+    const nodeKey = linkNode.getKey()
+    Promise.resolve().then(() => this.#dispatchLinkInsertEvent(nodeKey, { url }))
   }
 
   #dispatchLinkInsertEvent(nodeKey, payload) {
@@ -186,4 +237,26 @@ export default class Clipboard {
     window.scrollTo(scrollX, scrollY)
     this.editor.focus()
   }
+}
+
+function $bareUrlFromSingleLink(nodes) {
+  if (nodes.length !== 1) return null
+
+  const node = nodes[0]
+  if ($isLinkNode(node)) return $bareUrlFromLink(node)
+
+  if ($isParagraphNode(node)) {
+    const children = node.getChildren()
+    if (children.length === 1 && $isLinkNode(children[0])) {
+      return $bareUrlFromLink(children[0])
+    }
+  }
+
+  return null
+}
+
+function $bareUrlFromLink(linkNode) {
+  const url = linkNode.getURL()
+  if (!url) return null
+  return linkNode.getTextContent() === url ? url : null
 }

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -4,14 +4,12 @@ import {
   $isRangeSelection,
   $isTextNode,
   $setSelection,
-  COMMAND_PRIORITY_LOW,
   COMMAND_PRIORITY_NORMAL,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND,
-  PASTE_COMMAND,
   REDO_COMMAND,
   UNDO_COMMAND
 } from "lexical"
@@ -68,15 +66,10 @@ export class CommandDispatcher {
     this.editor = editorElement.editor
     this.selection = editorElement.selection
     this.contents = editorElement.contents
-    this.clipboard = editorElement.clipboard
 
     this.#registerCommands()
     this.#registerKeyboardCommands()
     this.#registerDragAndDropHandlers()
-  }
-
-  dispatchPaste(event) {
-    return this.clipboard.paste(event)
   }
 
   dispatchBold() {
@@ -305,8 +298,6 @@ export class CommandDispatcher {
       const methodName = `dispatch${capitalize(command)}`
       this.#registerCommandHandler(command, 0, this[methodName].bind(this))
     }
-
-    this.#registerCommandHandler(PASTE_COMMAND, COMMAND_PRIORITY_LOW, this.dispatchPaste.bind(this))
   }
 
   #registerCommandHandler(command, priority, handler) {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -77,6 +77,8 @@ export class LexicalEditorElement extends HTMLElement {
     this.#disposables.push(this.selection)
 
     this.clipboard = new Clipboard(this)
+    this.#disposables.push(this.clipboard)
+
     this.adapter = new BrowserAdapter()
 
     const commandDispatcher = CommandDispatcher.configureFor(this)

--- a/test/browser/tests/paste/copy_link.test.js
+++ b/test/browser/tests/paste/copy_link.test.js
@@ -1,0 +1,177 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent, assertEditorHtml } from "../../helpers/assertions.js"
+
+const URL = "https://37signals.com"
+
+function linkNode({ url = URL, text = URL } = {}) {
+  return {
+    children: [
+      {
+        detail: 0,
+        format: 0,
+        mode: "normal",
+        style: "",
+        text,
+        type: "text",
+        version: 1,
+      },
+    ],
+    direction: "ltr",
+    format: "",
+    indent: 0,
+    type: "link",
+    version: 1,
+    rel: null,
+    target: null,
+    title: null,
+    url,
+  }
+}
+
+function bareLinkNode() {
+  return linkNode()
+}
+
+function paragraphNode(children) {
+  return {
+    children,
+    direction: "ltr",
+    format: "",
+    indent: 0,
+    type: "paragraph",
+    version: 1,
+    textFormat: 0,
+    textStyle: "",
+  }
+}
+
+function lexicalPayload(nodes) {
+  return JSON.stringify({ namespace: "Lexxy", nodes })
+}
+
+async function pasteWithLexicalPayload(editor, lexical, { html, text } = {}) {
+  await editor.content.evaluate(
+    (el, { text, html, lexical }) => {
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: new DataTransfer(),
+      })
+      event.clipboardData.setData("text/plain", text)
+      event.clipboardData.setData("text/html", html)
+      event.clipboardData.setData("application/x-lexical-editor", lexical)
+      el.dispatchEvent(event)
+    },
+    { text: text ?? URL, html: html ?? `<a href="${URL}">${URL}</a>`, lexical },
+  )
+  await editor.flush()
+}
+
+test.describe("Paste — Lexxy → Lexxy link copy", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+  })
+
+  test("wraps the selected text when a Lexxy lexical payload contains only a link", async ({
+    editor,
+  }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+    await editor.select("everyone")
+
+    await pasteWithLexicalPayload(editor, lexicalPayload([ bareLinkNode() ]))
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator(`a[href="${URL}"]`)).toHaveText("everyone")
+    })
+  })
+
+  test("wraps the selected text when a Lexxy lexical payload wraps a single link in a paragraph", async ({
+    editor,
+  }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+    await editor.select("everyone")
+
+    await pasteWithLexicalPayload(
+      editor,
+      lexicalPayload([ paragraphNode([ bareLinkNode() ]) ]),
+    )
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator(`a[href="${URL}"]`)).toHaveText("everyone")
+    })
+  })
+
+  test("inserts the link when pasting a single-link Lexxy payload with no selection", async ({
+    editor,
+  }) => {
+    await editor.setValue("<p>Hello</p>")
+    await editor.focus()
+    await editor.send("End")
+
+    await pasteWithLexicalPayload(editor, lexicalPayload([ bareLinkNode() ]))
+
+    await assertEditorHtml(editor, `<p>Hello<a href="${URL}">${URL}</a></p>`)
+  })
+
+  test("preserves both href and label when pasting a labeled Lexxy link with no selection", async ({
+    editor,
+  }) => {
+    await editor.setValue("<p>Hello </p>")
+    await editor.focus()
+    await editor.send("End")
+
+    const labeled = linkNode({ url: URL, text: "Click here" })
+
+    await pasteWithLexicalPayload(editor, lexicalPayload([ labeled ]), {
+      html: `<a href="${URL}">Click here</a>`,
+      text: "Click here",
+    })
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator(`a[href="${URL}"]`)).toHaveText("Click here")
+    })
+  })
+
+  test("does not unwrap when the Lexxy payload contains a link plus surrounding text", async ({
+    editor,
+  }) => {
+    await editor.setValue("<p>Greetings </p>")
+    await editor.focus()
+    await editor.send("End")
+
+    const mixedParagraph = paragraphNode([
+      {
+        detail: 0,
+        format: 0,
+        mode: "normal",
+        style: "",
+        text: "see ",
+        type: "text",
+        version: 1,
+      },
+      bareLinkNode(),
+      {
+        detail: 0,
+        format: 0,
+        mode: "normal",
+        style: "",
+        text: " for details",
+        type: "text",
+        version: 1,
+      },
+    ])
+
+    await pasteWithLexicalPayload(editor, lexicalPayload([ mixedParagraph ]), {
+      html: `<p>see <a href="${URL}">${URL}</a> for details</p>`,
+      text: `see ${URL} for details`,
+    })
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator(`a[href="${URL}"]`)).toHaveText(URL)
+      await expect(content).toContainText("see")
+      await expect(content).toContainText("for details")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes Basecamp card #9745049753 ("HTML isn't always copied"). Copying a bare link inside Lexxy and pasting it back was dropping the link and inserting plain text.
- The clipboard's `application/x-lexical-editor` payload can serialize the copied link as a single `LinkNode` (optionally wrapped in a single paragraph). Lexical's default rich-text paste flattens that into the link's text content, losing the href.
- The paste path now detects "single link" Lexxy payloads and routes them through the same handler used for raw URL paste: wrap selected text in the link when a selection exists, otherwise insert the link at the cursor.

## Test plan

- [x] `test/browser/tests/paste/copy_link.test.js` — bare-link payload, paragraph-wrapped link payload, no-selection insert, and a regression case for a payload with a link plus surrounding text. The first two reproductions failed against `main` and pass with the fix.
- [x] Full chromium Playwright suite (`yarn test:browser:chromium`).
- [x] `yarn lint`.