### PR TITLE
Fix paste into quote started with `>` markdown shortcut

### DIFF
--- a/src/extensions/format_escape_extension.js
+++ b/src/extensions/format_escape_extension.js
@@ -1,11 +1,11 @@
 import { $createParagraphNode, $getSelection, $isRangeSelection, $splitNode, COMMAND_PRIORITY_HIGH, COMMAND_PRIORITY_NORMAL, INSERT_PARAGRAPH_COMMAND, KEY_ARROW_DOWN_COMMAND, ParagraphNode, defineExtension } from "lexical"
 import { CodeNode } from "@lexical/code"
 import { ListItemNode } from "@lexical/list"
-import { $isQuoteNode } from "@lexical/rich-text"
+import { $isQuoteNode, QuoteNode } from "@lexical/rich-text"
 import { $getNearestNodeOfType, mergeRegister } from "@lexical/utils"
 import { EarlyEscapeCodeNode } from "../nodes/early_escape_code_node"
 import { EarlyEscapeListItemNode } from "../nodes/early_escape_list_item_node"
-import { $isBlankNode, $isCursorOnLastLine, $trimTrailingBlankNodes } from "../helpers/lexical_helper"
+import { $containsRangeSelection, $isBlankNode, $isCursorOnLastLine, $trimTrailingBlankNodes } from "../helpers/lexical_helper"
 import LexxyExtension from "./lexxy_extension"
 
 export class FormatEscapeExtension extends LexxyExtension {
@@ -38,7 +38,8 @@ export class FormatEscapeExtension extends LexxyExtension {
             KEY_ARROW_DOWN_COMMAND,
             (event) => $handleArrowDownInCodeBlock(event),
             COMMAND_PRIORITY_NORMAL
-          )
+          ),
+          editor.registerNodeTransform(QuoteNode, $ensureQuoteHasParagraphChild)
         )
       }
     })
@@ -89,4 +90,11 @@ function $handleArrowDownInCodeBlock(event) {
   }
 
   return false
+}
+
+function $ensureQuoteHasParagraphChild(quoteNode) {
+  if (!quoteNode.isEmpty()) return
+
+  quoteNode.append($createParagraphNode())
+  if ($containsRangeSelection(quoteNode)) quoteNode.getFirstChild().select()
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,10 +1,19 @@
-import { $createNodeSelection, $createParagraphNode, $getSiblingCaret, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isParagraphNode, $isRootNode, $isRootOrShadowRoot, $isTextNode, $splitNode, LineBreakNode, TextNode } from "lexical"
+import { $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCommonAncestor, $getSelection, $getSiblingCaret, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isTextNode, $splitNode, LineBreakNode, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
 import { $ensureForwardRangeSelection, $isAtNodeEnd } from "@lexical/selection"
 
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
+
+export function $containsRangeSelection(node, selection = $getSelection()) {
+  if ($isRangeSelection(selection)) {
+    const { commonAncestor } = $getCommonAncestor(selection.focus.getNode(), selection.anchor.getNode())
+    return $findMatchingParent(commonAncestor, parent => parent.is(node))
+  } else {
+    return false
+  }
+}
 
 export function $createNodeSelectionWith(...nodes) {
   const selection = $createNodeSelection()

--- a/test/browser/tests/paste/paste_into_quote.test.js
+++ b/test/browser/tests/paste/paste_into_quote.test.js
@@ -84,4 +84,51 @@ test.describe("Paste into quote", () => {
     // not on a second line after a blank first line
     await assertEditorHtml(editor, "<blockquote><p>A copied sentence</p></blockquote>")
   })
+
+  test("pasting multi-line content into a quote started via the markdown shortcut keeps every line inside the quote", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    // Start the quote via the markdown shortcut (`>` + space).
+    // This path used to leave a QuoteNode with no ParagraphNode child,
+    // unlike the toolbar button which wraps an existing paragraph.
+    await editor.click()
+    await editor.send("> ")
+    await editor.flush()
+
+    await editor.paste("First paragraph\nSecond paragraph", {
+      html: "<p>First paragraph</p><p>Second paragraph</p>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote>",
+    )
+  })
+
+  test("the QuoteNode transform does not re-wrap toolbar-button quote children", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    await editor.click()
+    await page.getByRole("button", { name: "Quote" }).click()
+    await editor.flush()
+
+    await editor.paste("First paragraph\nSecond paragraph", {
+      html: "<p>First paragraph</p><p>Second paragraph</p>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote>",
+    )
+  })
 })

--- a/test/browser/tests/paste/paste_into_quote.test.js
+++ b/test/browser/tests/paste/paste_into_quote.test.js
@@ -97,7 +97,14 @@ test.describe("Paste into quote", () => {
     // unlike the toolbar button which wraps an existing paragraph.
     await editor.click()
     await editor.send("> ")
-    await editor.flush()
+    // Wait for the QuoteNode transform to add the <p> child before pasting,
+    // otherwise the paste can race the transform and escape the quote.
+    await expect
+      .poll(async () => {
+        await editor.flush()
+        return await editor.value()
+      })
+      .toBe("<blockquote><p><br></p></blockquote>")
 
     await editor.paste("First paragraph\nSecond paragraph", {
       html: "<p>First paragraph</p><p>Second paragraph</p>",


### PR DESCRIPTION
## Summary

- The `>` + space markdown shortcut leaves a `QuoteNode` whose only child is a `LineBreakNode` (no `ParagraphNode` wrapper). Pasting multi-line HTML into that shape escapes every line after the first out of the quote.
- The toolbar Quote button wraps an existing paragraph, so its `QuoteNode` already has a block-level child and doesn't hit the bug.
- Register a `QuoteNode` node transform in the format-escape extension that wraps inline children in a `ParagraphNode` and moves the selection into it when the cursor was sitting at the quote root. When the quote already has any element child, the transform bails out, so the toolbar-button and empty-paragraph cases are untouched.

Basecamp card #9830219205.

## Test plan

- [x] New Playwright test in `test/browser/tests/paste/paste_into_quote.test.js` reproduces the bug: types `> ` to start the quote via the markdown shortcut, then pastes `<p>First paragraph</p><p>Second paragraph</p>`.
- [x] Test fails on `main` with output `<blockquote>First paragraph</blockquote><p>Second paragraph</p>` (second paragraph escaped, first lost its `<p>` wrapper).
- [x] Test passes with the fix; both paragraphs end up inside the blockquote with proper `<p>` wrappers.
- [x] Existing toolbar-button quote regressions in `paste_into_quote.test.js` still pass.
- [x] Full chromium + firefox suites run clean (only pre-existing flakes in `attachments/gallery.test.js` and `attachments/attachments.test.js`, unrelated).
- [x] `yarn lint` clean.