### PR TITLE
Revert editor.flush() helper simplification

### DIFF
--- a/test/browser/helpers/editor_handle.js
+++ b/test/browser/helpers/editor_handle.js
@@ -168,7 +168,12 @@ export class EditorHandle {
 
   async flush() {
     await this.locator.evaluate((el) => {
-      return el.editor.getEditorState().read(() => {})
+      return new Promise((resolve) => {
+        el.editor.update(
+          () => {},
+          { onUpdate: () => requestAnimationFrame(resolve) },
+        )
+      })
     })
   }
 


### PR DESCRIPTION
## Summary

Reverts commit `f01a49a8` (\"Simplify editor flush to just force a read cycle\"), which had reduced `editor.flush()` to a single `getEditorState().read(() => {})` call.

That simplified form turned out to be unreliable as a \"settle the editor\" signal because it returns before async editor side-effects (transforms, RAF-scheduled dispatches) have settled.

This restores the previous implementation, which performs an empty `editor.update(...)` and waits one animation frame via `onUpdate: () => requestAnimationFrame(resolve)` — i.e., commits any pending updates and lets the DOM/reconciler settle before the next interaction.

## Test plan

- [x] `yarn lint` clean
- [x] `npm test` (vitest) green (83 passed)
- [x] `yarn test:browser --project=chromium` green (348 passed, 3 pre-existing flaky retry-passes — same set seen on `main`)