### PR TITLE
Fix table cell selection with the mouse

### DIFF
--- a/src/extensions/tables_extension.js
+++ b/src/extensions/tables_extension.js
@@ -47,7 +47,13 @@ export class TablesExtension extends LexxyExtension {
         return mergeRegister(
           // Register Lexical table plugins
           registerTablePlugin(editor),
-          registerTableSelectionObserver(editor, true),
+          // Lexxy registers extensions before setRootElement(), but table
+          // drag-selection needs a root before wiring its pointer handlers.
+          editor.registerRootListener((rootElement) => {
+            if (rootElement) {
+              return registerTableSelectionObserver(editor, true)
+            }
+          }),
 
           // Bug fix: Prevent hardcoded background color (Lexical #8089)
           editor.registerNodeTransform(TableCellNode, (node) => {

--- a/src/extensions/tables_extension.js
+++ b/src/extensions/tables_extension.js
@@ -45,8 +45,8 @@ export class TablesExtension extends LexxyExtension {
         setScrollableTablesActive(editor, true)
 
         return mergeRegister(
-          // Register Lexical table plugins
           registerTablePlugin(editor),
+
           // Lexxy registers extensions before setRootElement(), but table
           // drag-selection needs a root before wiring its pointer handlers.
           editor.registerRootListener((rootElement) => {

--- a/test/browser/tests/tables/drag_selection.test.js
+++ b/test/browser/tests/tables/drag_selection.test.js
@@ -1,0 +1,39 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Tables — Drag selection", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("click+drag across multiple cells selects all cells the cursor moves over", async ({ page, editor }) => {
+    await editor.clickToolbarButton("insertTable")
+    await editor.flush()
+
+    const cells = editor.content.locator("table :is(th, td)")
+    await expect(cells).toHaveCount(9)
+
+    const [ a1, b1, c1 ] = await cells.evaluateAll((elements) => {
+      return elements.slice(0, 3).map((cell) => {
+        const { left, top, width, height } = cell.getBoundingClientRect()
+        return { x: left + width / 2, y: top + height / 2 }
+      })
+    })
+
+    await page.mouse.move(a1.x, a1.y)
+    await page.mouse.down()
+    await page.mouse.move(b1.x, b1.y, { steps: 8 })
+    await page.mouse.move(c1.x, c1.y, { steps: 8 })
+    await page.mouse.up()
+
+    await editor.flush()
+
+    const selectedCells = editor.content.locator(".lexxy-content__table-cell--selected")
+    await expect(selectedCells).toHaveCount(3)
+    await expect(cells.nth(0)).toHaveClass(/lexxy-content__table-cell--selected/)
+    await expect(cells.nth(1)).toHaveClass(/lexxy-content__table-cell--selected/)
+    await expect(cells.nth(2)).toHaveClass(/lexxy-content__table-cell--selected/)
+  })
+})


### PR DESCRIPTION
This PR fixes an issue with table cell selection.


### Original issue
Selecting cells with the mouse (click+drag) only selects two adjacent cells, no more. This is a regression.

#### Steps to reproduce
* Add a table
* Click into a cell, and click+hold to drag other cells

#### Expectation
* All cells should be selected where the cursor moves over

#### Reality
* Only 2 adjacent cells get selected