### PR TITLE
Dispence with unecessary <code> element in highlight

### DIFF
--- a/src/helpers/code_highlighting_helper.js
+++ b/src/helpers/code_highlighting_helper.js
@@ -1,4 +1,3 @@
-import { createElement } from "./html_helper"
 import Prism from "../config/prism"
 
 export function highlightCode() {
@@ -23,13 +22,11 @@ function highlightElement(preElement) {
   code = new DOMParser().parseFromString(code, "text/html").body.textContent || ""
 
   const highlightedHtml = Prism.highlight(code, grammar, language)
-  const codeElement = createElement("code", { "data-language": language, innerHTML: highlightedHtml })
+  preElement.innerHTML = highlightedHtml
 
   if (highlights.length > 0) {
-    applyHighlightRanges(codeElement, highlights)
+    applyHighlightRanges(preElement, highlights)
   }
-
-  preElement.replaceChildren(codeElement)
 }
 
 // Walk the DOM tree inside a <pre> element and build a list of

--- a/test/javascript/unit/helpers/code_highlighting_helper.test.js
+++ b/test/javascript/unit/helpers/code_highlighting_helper.test.js
@@ -46,10 +46,5 @@ test("highlightCode preserves the pre wrapper around the highlighted code elemen
 
   highlightCode()
 
-  const code = document.querySelector("code[data-language='javascript']")
-  expect(code).toBeTruthy()
-  expect(code.parentElement.tagName).toBe("PRE")
-  expect(code.textContent).toContain("const a = 1\nconst b = 2")
-
-  code.parentElement.remove()
+  expect(pre.textContent).toContain("const a = 1\nconst b = 2")
 })

--- a/test/system/code_highlighting_test.rb
+++ b/test/system/code_highlighting_test.rb
@@ -17,8 +17,8 @@ class CodeHighlightingTest < ApplicationSystemTestCase
     click_on "Update Post"
 
     # Verify the rendered output has syntax highlighting
-    assert_selector "code[data-language='ruby']"
-    assert_selector "code span.token.keyword", text: "def"
+    assert_selector "pre[data-language='ruby']"
+    assert_selector "pre span.token.keyword", text: "def"
   end
 
   test "color highlights inside code blocks are preserved in rendered view" do
@@ -34,7 +34,7 @@ class CodeHighlightingTest < ApplicationSystemTestCase
     click_on "Update Post"
 
     # Verify the rendered output preserves the highlight mark inside Prism tokens
-    assert_selector "code[data-language='ruby']"
-    assert_selector "code mark[style*='background-color']", text: "hello"
+    assert_selector "pre[data-language='ruby']"
+    assert_selector "pre mark[style*='background-color']", text: "hello"
   end
 end


### PR DESCRIPTION
As we're keeping the `<pre>`, just replace its innerHTML rather than include an intermediary `<code>`