### PR TITLE
Add dispose() lifecycle hook to extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -18,6 +18,13 @@ Lexxy Extensions are a wrapper around [Lexical Extensions](https://lexical.dev/d
 
 An instance of the extension will be initialized per editor: `new MyLexxyExtension(lexxyElement)`. There is no need to supply a constructor as the base class provides `this.editorElement` to access Lexxy. If you specify a custom constructor you must pass the `lexxyElement` to `super`. If the return of `lexicalExtension` is truthy, it will be loaded at the time of Lexical editor creation. You can optionally provide an `enabled` getter which will be checked to see if your extension should be loaded by Lexxy.
 
+## Lifecycle
+
+- `initializeToolbar(lexxyToolbar)` is called when the editor toolbar is initialized. Use it to add toolbar buttons or attach listeners to existing toolbar DOM.
+- `dispose()` is called when the editor disconnects or reconnects. Use it to release anything that would otherwise leak across editor lifecycles: DOM listeners, global listeners, observers, timers, inserted DOM, or pending async state.
+
+A new extension instance is created on every editor `connectedCallback`, so any state that survives in the surrounding DOM (for example, listeners attached to the toolbar in `initializeToolbar`) must be cleaned up in `dispose()` to avoid duplication after reconnects.
+
 Should you need to extend any of Lexxy's nodes, they are exported at the top-level module:
 
 ```javascript

--- a/src/editor/extensions.js
+++ b/src/editor/extensions.js
@@ -20,6 +20,12 @@ export default class Extensions {
     this.#addExtensionToolbarButtons(toolbar)
   }
 
+  dispose() {
+    while (this.enabledExtensions.length) {
+      this.enabledExtensions.pop().dispose()
+    }
+  }
+
   #clearPreviousExtensionToolbarButtons(toolbar) {
     toolbar.querySelectorAll("[data-lexxy-extension]").forEach(el => el.remove())
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -65,6 +65,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.id ||= generateDomId("lexxy-editor")
     this.config = new Configuration(this)
     this.extensions = new Extensions(this)
+    this.#disposables.push(this.extensions)
 
     this.editor = this.#createEditor()
     this.#disposables.push(this.editor)

--- a/src/extensions/lexxy_extension.js
+++ b/src/extensions/lexxy_extension.js
@@ -29,4 +29,7 @@ export default class LexxyExtension {
   initializeToolbar(_lexxyToolbar) {
 
   }
+
+  dispose() {
+  }
 }

--- a/test/browser/fixtures/extension-dispose.html
+++ b/test/browser/fixtures/extension-dispose.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Extension Dispose</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..."></lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/extension-dispose.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/extension-dispose.js
+++ b/test/browser/fixtures/extension-dispose.js
@@ -1,0 +1,22 @@
+import { configure, Extension } from "lexxy"
+
+class DisposableListenerExtension extends Extension {
+  #abortController = new AbortController()
+
+  initializeToolbar(toolbar) {
+    toolbar.addEventListener(
+      "lexxy-test-ping",
+      () => {
+        window.__lexxyDisposeTest_pingCount = (window.__lexxyDisposeTest_pingCount || 0) + 1
+      },
+      { signal: this.#abortController.signal }
+    )
+  }
+
+  dispose() {
+    window.__lexxyDisposeTest_disposeCount = (window.__lexxyDisposeTest_disposeCount || 0) + 1
+    this.#abortController.abort()
+  }
+}
+
+configure({ global: { extensions: [DisposableListenerExtension] } })

--- a/test/browser/tests/editor/reconnect.test.js
+++ b/test/browser/tests/editor/reconnect.test.js
@@ -66,3 +66,35 @@ test.describe("Reconnect with extension toolbar buttons", () => {
     await expect(page.locator("lexxy-toolbar button[name='custom-extension-button']")).toHaveCount(1)
   })
 })
+
+test.describe("Reconnect with extension dispose lifecycle", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/extension-dispose.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("extension dispose() removes toolbar listeners across reconnect", async ({ page, editor }) => {
+    const ping = () => page.evaluate(() => {
+      document.querySelector("lexxy-toolbar").dispatchEvent(new CustomEvent("lexxy-test-ping"))
+    })
+    const pingCount = () => page.evaluate(() => window.__lexxyDisposeTest_pingCount || 0)
+    const disposeCount = () => page.evaluate(() => window.__lexxyDisposeTest_disposeCount || 0)
+
+    await ping()
+    expect(await pingCount()).toBe(1)
+
+    await page.evaluate(() => {
+      const el = document.querySelector("lexxy-editor")
+      const parent = el.parentElement
+      parent.removeChild(el)
+      parent.appendChild(el)
+    })
+
+    await editor.waitForConnected()
+
+    expect(await disposeCount()).toBe(1)
+
+    await ping()
+    expect(await pingCount()).toBe(2)
+  })
+})


### PR DESCRIPTION
A new Extensions instance is created on every editor connectedCallback, but the old extension instances had no way to clean up: any listeners, inserted DOM, timers, or pending async state they attached during initializeToolbar() simply leaked. On Turbo back/forward navigation — where the toolbar DOM survives the disconnect/reconnect cycle — this manifested as duplicated handlers firing N times after N reconnects.

Add an optional dispose() method to LexxyExtension as a no-op so extensions can override it. Extensions.dispose() pops each enabled extension and calls dispose() in reverse initialization order, and the editor element registers `this.extensions` as a disposable so the hook fires during teardown alongside the editor, listeners, and toolbar.

Document the new lifecycle in docs/extensions.md and cover the reconnect behavior with a browser test that asserts dispose() is called once and that toolbar listeners do not duplicate after the editor element is detached and re-attached.

🤖 Assisted by Claude