### PR TITLE
Render `<em>` upright inside `<blockquote>`

### DIFF
--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -74,6 +74,10 @@
     p:last-child {
       margin-block-end: 0;
     }
+
+    .lexxy-content__italic {
+      font-style: normal;
+    }
   }
 
   p:empty {

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -395,4 +395,16 @@ test.describe("Block formatting", () => {
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("")
   })
+
+  test("italic inside blockquote renders upright so emphasis stands out", async ({ editor }) => {
+    await editor.setValue(
+      "<blockquote><p>Before <em>emphasised</em> after</p></blockquote>",
+    )
+
+    const paragraph = editor.content.locator("blockquote p")
+    const em = editor.content.locator("blockquote em")
+
+    await expect(paragraph).toHaveCSS("font-style", "italic")
+    await expect(em).toHaveCSS("font-style", "normal")
+  })
 })


### PR DESCRIPTION
Blockquotes are styled italic, and so is `<em>`. So emphasized text inside a blockquote blended in with the surrounding quote with no visible emphasis. This change renders `<em>` as upright text inside blockquotes, so emphasis stands out by contrast.

Added three lines of CSS inside the existing `blockquote { }` rule. No markup or serialization changes, so the fix applies to both the editor and the rendered Action Text view. Added a Playwright regression test asserting the paragraph stays italic while the nested `<em>` renders upright.

Closes #939.

### Before

https://github.com/user-attachments/assets/465e1933-def3-4871-9a2d-6e0e6cddb763

### After

https://github.com/user-attachments/assets/53968e74-38f6-46d7-96bc-5136bdca20a0



