### PR TITLE
Fix HTML injection via unsanitized empty-results attribute

### DIFF
--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -366,7 +366,7 @@ export class LexicalPromptElement extends HTMLElement {
 
   #showEmptyResults() {
     this.popoverElement.classList.add("lexxy-prompt-menu--empty")
-    const el = createElement("li", { innerHTML: this.#emptyResultsMessage })
+    const el = createElement("li", { textContent: this.#emptyResultsMessage })
     el.classList.add("lexxy-prompt-menu__item--empty")
     this.popoverElement.append(el)
   }

--- a/test/browser/fixtures/prompt-empty-results.html
+++ b/test/browser/fixtures/prompt-empty-results.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Prompt empty-results</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something...">
+        <lexxy-prompt trigger="@" name="mention" empty-results='<img src="x" data-payload="injected" onerror="window.__xss = true">No match for &lt;b&gt;literal&lt;/b&gt;'>
+          <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
+            <template type="menu"><span>Alice</span></template>
+            <template type="editor"><span>Alice</span></template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/prompts/empty_results.test.js
+++ b/test/browser/tests/prompts/empty_results.test.js
@@ -1,0 +1,35 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt empty-results", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/prompt-empty-results.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("renders empty-results attribute as text, not HTML", async ({ page, editor }) => {
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.content.pressSequentially("zzznomatch")
+    await editor.flush()
+
+    const emptyItem = popover.locator(".lexxy-prompt-menu__item--empty")
+    await expect(emptyItem).toBeVisible({ timeout: 5_000 })
+
+    // No HTML elements injected from the attribute value
+    await expect(emptyItem.locator("img")).toHaveCount(0)
+    await expect(emptyItem.locator("b")).toHaveCount(0)
+
+    // The whole attribute is rendered verbatim as text
+    await expect(emptyItem).toHaveText(
+      '<img src="x" data-payload="injected" onerror="window.__xss = true">No match for <b>literal</b>'
+    )
+
+    // The injected onerror handler did not execute
+    const xssFired = await page.evaluate(() => window.__xss === true)
+    expect(xssFired).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- `LexicalPromptElement#showEmptyResults` assigned the `empty-results` attribute directly to `innerHTML`, rendering any HTML in the attribute into the popover. A host app that reflected user input into `empty-results` (e.g. `<lexxy-prompt empty-results="No match for <%= params[:q] %>">`) would have reflected DOM injection. Even with strict CSP, an attacker controlling the attribute could inject `<meta http-equiv="refresh">` for open redirect.
- Switch the assignment to `textContent`. The default `NOTHING_FOUND_DEFAULT_MESSAGE` is already plain text, and treating the attribute as text matches what the attribute name suggests.
- Same shape as #903 (Jorge's fix for the equivalent issue on `<action-text-attachment>` `content`).

## Test plan
- [x] `yarn lint` clean
- [x] `yarn test:browser --project=chromium test/browser/tests/prompts/` — all 21 tests pass, including the new regression
- [x] New regression test asserts the popover renders an HTML payload verbatim as text (no `<img>` injection, no `onerror` execution)

Reported via HackerOne #3709373 by @blackm4c.