### PR TITLE
Skip customElements.define for already-registered elements

### DIFF
--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -21,6 +21,8 @@ export function defineElements() {
   }
 
   Object.entries(elements).forEach(([ name, element ]) => {
-    customElements.define(name, element)
+    if (!customElements.get(name)) {
+      customElements.define(name, element)
+    }
   })
 }


### PR DESCRIPTION
## Summary

`defineElements()` calls `customElements.define()` unconditionally for each lexxy element. If the bundle that imports `@37signals/lexxy` is evaluated more than once in the same page (same `window`, so the same `customElements` registry), the second evaluation throws:

```
NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry':
the name "lexxy-toolbar" has already been used with this registry
```

Guarding each `define()` with `customElements.get(name)` makes the function idempotent — a repeated invocation becomes a no-op, leaving the original registrations intact.

## How a single bundle ends up evaluated twice

In Basecamp's `bc3` repo, only one bundle (`rich_text.js`) imports the main `@37signals/lexxy` entry. It is lazy-loaded via a `<bc-require script="rich_text">` element which injects a classic `<script src="…/rich_text-<digest>.js">` into `<head>`. On first load, the bundle runs `setTimeout(defineElements, 0)` at module top level and registers all eight `lexxy-*` elements.

The duplicate-define trigger we observed is a Turbo navigation that restores a cached snapshot whose `<head>` already contained the previously-injected `<script>`. Re-inserting that classic `<script>` element causes the browser to re-execute the file, so `defineElements()` runs a second time against the same `customElements` registry. The Sentry event we tracked has a giveaway breadcrumb:

```
"category": "navigation",
"data": { "from": "/.../cards/9645566301", "to": "/.../cards/9645566301" }
```

(same URL → same URL = Turbo restore, e.g. back/forward or in-place stream-driven reload).

Other plausible triggers for the same symptom: a host app that bundles `@37signals/lexxy` into more than one entrypoint loaded together on the same page, or any environment that evaluates the lexxy module twice in one `window`. The fix is the same — make `defineElements()` safe to call repeatedly.

## Context

Cause of [BC3-JS-N5QV](https://basecamp.sentry.io/issues/7383413376/) in the Basecamp `bc3-js` Sentry project — ~5,087 events / 56 users over the last 14 days on the `five` environment.