### PR TITLE
Convert pasted data-URI images into uploads

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
       sourceType: "module",
       globals: {
         AbortController: "readonly",
+        atob: "readonly",
         console: "readonly",
         document: "readonly",
         window: "readonly",

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -11,7 +11,7 @@ import { $createHeadingNode, $createQuoteNode, $isQuoteNode } from "@lexical/ric
 import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { $createLinkNode, $toggleLink } from "@lexical/link"
-import { dispatch, parseHtml } from "../helpers/html_helper"
+import { parseHtml } from "../helpers/html_helper"
 import { $forEachSelectedTextNode, $setBlocksType } from "@lexical/selection"
 import Uploader from "./contents/uploader"
 import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
@@ -253,7 +253,7 @@ export default class Contents {
       console.warn("This editor does not supports attachments (it's configured with [attachments=false])")
       return
     }
-    const validFiles = Array.from(files).filter(this.#shouldUploadFile.bind(this))
+    const validFiles = Array.from(files).filter(file => this.editorElement.acceptsFile(file))
 
     this.editor.update(() => {
       const uploader = Uploader.for(this.editorElement, validFiles)
@@ -607,10 +607,6 @@ export default class Contents {
   #createHtmlNodeWith(html) {
     const htmlNodes = $generateFilteredNodesFromDOM(this.editorElement, parseHtml(html))
     return htmlNodes[0] || $createParagraphNode()
-  }
-
-  #shouldUploadFile(file) {
-    return dispatch(this.editorElement, "lexxy:file-accept", { file }, true)
   }
 
   // When the selection anchor is on a shadow root (e.g. a table cell), Lexical's

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -15,7 +15,7 @@ import { parseHtml } from "../helpers/html_helper"
 import { $forEachSelectedTextNode, $setBlocksType } from "@lexical/selection"
 import Uploader from "./contents/uploader"
 import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
-import { ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
+import { $createActionTextAttachmentUploadNode, ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils"
 import NodeInserter from "./contents/node_inserter"
 import { $isShadowRoot, $splitParagraphsAtLineBreakBoundaries } from "../helpers/lexical_helper"
@@ -264,6 +264,15 @@ export default class Contents {
         lastNode.selectEnd()
         this.#normalizeSelectionInShadowRoot()
       }
+    })
+  }
+
+  $createUploadNode(file) {
+    return $createActionTextAttachmentUploadNode({
+      file,
+      uploadUrl: this.editorElement.directUploadUrl,
+      blobUrlTemplate: this.editorElement.blobUrlTemplate,
+      contentType: file.type,
     })
   }
 

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -5,6 +5,7 @@ import {
 } from "lexical"
 
 import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
+import { $convertInlineImageDataURIs } from "../helpers/inline_image_uri_helper"
 import { $createCodeNode, $isCodeNode } from "@lexical/code"
 import { $createHeadingNode, $createQuoteNode, $isQuoteNode } from "@lexical/rich-text"
 import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
@@ -42,7 +43,8 @@ export default class Contents {
     this.editor.update(() => {
       if ($hasUpdateTag(PASTE_TAG)) this.#stripTableCellColorStyles(doc)
 
-      const nodes = $generateFilteredNodesFromDOM(this.editorElement, doc)
+      let nodes = $generateFilteredNodesFromDOM(this.editorElement, doc)
+      if ($hasUpdateTag(PASTE_TAG)) nodes = $convertInlineImageDataURIs(nodes, this.editorElement)
       if (!this.#insertUploadNodes(nodes)) {
         this.insertAtCursor(...nodes)
       }

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -4,8 +4,6 @@ import {
   HISTORY_MERGE_TAG, PASTE_TAG
 } from "lexical"
 
-import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
-import { $convertInlineImageDataURIs } from "../helpers/inline_image_uri_helper"
 import { $createCodeNode, $isCodeNode } from "@lexical/code"
 import { $createHeadingNode, $createQuoteNode, $isQuoteNode } from "@lexical/rich-text"
 import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
@@ -43,8 +41,7 @@ export default class Contents {
     this.editor.update(() => {
       if ($hasUpdateTag(PASTE_TAG)) this.#stripTableCellColorStyles(doc)
 
-      let nodes = $generateFilteredNodesFromDOM(this.editorElement, doc)
-      if ($hasUpdateTag(PASTE_TAG)) nodes = $convertInlineImageDataURIs(nodes, this.editorElement)
+      const nodes = this.editorElement.$generateNodesFromDOM(doc)
       if (!this.#insertUploadNodes(nodes)) {
         this.insertAtCursor(...nodes)
       }
@@ -614,7 +611,7 @@ export default class Contents {
   }
 
   #createHtmlNodeWith(html) {
-    const htmlNodes = $generateFilteredNodesFromDOM(this.editorElement, parseHtml(html))
+    const htmlNodes = this.editorElement.$generateNodesFromDOM(parseHtml(html))
     return htmlNodes[0] || $createParagraphNode()
   }
 

--- a/src/editor/contents/uploader.js
+++ b/src/editor/contents/uploader.js
@@ -1,6 +1,5 @@
 import { $getSelection } from "lexical"
 import { isPreviewableImage } from "../../helpers/html_helper"
-import { $createActionTextAttachmentUploadNode } from "../../nodes/action_text_attachment_upload_node"
 import { $createImageGalleryNode, $findOrCreateGalleryForImage, ImageGalleryNode } from "../../nodes/image_gallery_node"
 
 export default class Uploader {
@@ -30,24 +29,11 @@ export default class Uploader {
   }
 
   $createUploadNodes() {
-    this.nodes = this.files.map(file =>
-      $createActionTextAttachmentUploadNode({
-        ...this.#nodeUrlProperties,
-        file: file,
-        contentType: file.type
-      })
-    )
+    this.nodes = this.files.map(file => this.contents.$createUploadNode(file))
   }
 
   $insertUploadNodes() {
     this.contents.insertAtCursor(...this.nodes)
-  }
-
-  get #nodeUrlProperties() {
-    return {
-      uploadUrl: this.editorElement.directUploadUrl,
-      blobUrlTemplate: this.editorElement.blobUrlTemplate
-    }
   }
 }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -182,6 +182,10 @@ export class LexicalEditorElement extends HTMLElement {
     }
   }
 
+  acceptsFile(file) {
+    return dispatch(this, "lexxy:file-accept", { file }, true)
+  }
+
   get isEmpty() {
     return [ "<p><br></p>", "<p></p>", "" ].includes(this.value.trim())
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,12 +1,13 @@
-import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
 import { $getNearestNodeOfType } from "@lexical/utils"
 import { registerPlainText } from "@lexical/plain-text"
 import { HeadingNode, QuoteNode, registerRichText } from "@lexical/rich-text"
-import { $generateHtmlFromNodes } from "@lexical/html"
-import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
+import { $generateHtmlFromNodes, $generateNodesFromDOM as $generateLexicalNodesFromDOM } from "@lexical/html"
+import { filterDisallowedAttachmentNodes } from "../helpers/attachment_filter_helper"
+import { $convertInlineImageDataURIs } from "../helpers/inline_image_uri_helper"
 import { CodeHighlightNode, CodeNode, registerCodeHighlighting } from "@lexical/code"
 import { TRANSFORMERS, registerMarkdownShortcuts } from "@lexical/markdown"
 import { HORIZONTAL_DIVIDER } from "../editor/markdown/horizontal_divider_transformer"
@@ -186,6 +187,12 @@ export class LexicalEditorElement extends HTMLElement {
     return dispatch(this, "lexxy:file-accept", { file }, true)
   }
 
+  $generateNodesFromDOM(doc) {
+    let nodes = $generateLexicalNodesFromDOM(this.editor, doc)
+    if ($hasUpdateTag(PASTE_TAG)) nodes = $convertInlineImageDataURIs(nodes, this)
+    return filterDisallowedAttachmentNodes(nodes, this)
+  }
+
   get isEmpty() {
     return [ "<p><br></p>", "<p></p>", "" ].includes(this.value.trim())
   }
@@ -308,7 +315,7 @@ export class LexicalEditorElement extends HTMLElement {
 
   #parseHtmlIntoLexicalNodes(html) {
     if (!html) html = "<p></p>"
-    const nodes = $generateFilteredNodesFromDOM(this, parseHtml(`${html}`))
+    const nodes = this.$generateNodesFromDOM(parseHtml(`${html}`))
 
     return nodes
       .filter(this.#isNotWhitespaceOnlyNode)

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -6,7 +6,6 @@ import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_atta
 import InlinePromptSource from "../editor/prompt/inline_source"
 import DeferredPromptSource from "../editor/prompt/deferred_source"
 import RemoteFilterSource from "../editor/prompt/remote_filter_source"
-import { $generateFilteredNodesFromDOM } from "../helpers/attachment_filter_helper"
 import { debounce, nextFrame } from "../helpers/timing_helpers"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 
@@ -448,7 +447,7 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   #buildEditableTextNodes(template) {
-    return $generateFilteredNodesFromDOM(this.#editorElement, parseHtml(`${template.innerHTML}`))
+    return this.#editorElement.$generateNodesFromDOM(parseHtml(`${template.innerHTML}`))
   }
 
   #insertTemplatesAsAttachments(templates, stringToReplace, fallbackSgid = null) {

--- a/src/helpers/attachment_filter_helper.js
+++ b/src/helpers/attachment_filter_helper.js
@@ -1,12 +1,6 @@
-import { $generateNodesFromDOM } from "@lexical/html"
 import { $descendantsMatching } from "@lexical/utils"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
-
-export function $generateFilteredNodesFromDOM(editorElement, doc) {
-  const nodes = $generateNodesFromDOM(editorElement.editor, doc)
-  return filterDisallowedAttachmentNodes(nodes, editorElement)
-}
 
 export function filterDisallowedAttachmentNodes(nodes, editorElement) {
   return nodes

--- a/src/helpers/inline_image_uri_helper.js
+++ b/src/helpers/inline_image_uri_helper.js
@@ -1,7 +1,6 @@
 import { $descendantsMatching } from "@lexical/utils"
 import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 import { $createActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
-import { dispatch } from "./html_helper"
 import { mimeTypeToExtension } from "./storage_helper"
 
 // Replaces inline `data:image/...` attachments with upload nodes that flow through the normal
@@ -16,22 +15,22 @@ import { mimeTypeToExtension } from "./storage_helper"
 // pipeline; on refusal, the node is dropped silently — matching how `Contents#uploadFiles` handles
 // file-picker rejections.
 export function $convertInlineImageDataURIs(nodes, editorElement) {
-  return nodes.flatMap(node => {
-    if (isInlineImageDataURIAttachment(node)) {
-      const upload = $tryConvertToUpload(node, editorElement)
-      return upload ? [ upload ] : []
+  const topLevel = nodes
+    .map(node => isInlineImageDataURIAttachment(node) ? $tryCreateUploadFromDataURI(node, editorElement) : node)
+    .filter(node => node !== null)
+
+  for (const node of topLevel) {
+    for (const desc of $descendantsMatching([ node ], isInlineImageDataURIAttachment)) {
+      const upload = $tryCreateUploadFromDataURI(desc, editorElement)
+      if (upload) {
+        desc.replace(upload)
+      } else {
+        desc.remove()
+      }
     }
-    $descendantsMatching([ node ], isInlineImageDataURIAttachment)
-      .forEach(desc => {
-        const upload = $tryConvertToUpload(desc, editorElement)
-        if (upload) {
-          desc.replace(upload)
-        } else {
-          desc.remove()
-        }
-      })
-    return [ node ]
-  })
+  }
+
+  return topLevel
 }
 
 function isInlineImageDataURIAttachment(node) {
@@ -39,9 +38,9 @@ function isInlineImageDataURIAttachment(node) {
     /^data:image\//i.test(node.src ?? "")
 }
 
-function $tryConvertToUpload(node, editorElement) {
+function $tryCreateUploadFromDataURI(node, editorElement) {
   const file = dataURIToFile(node.src)
-  if (file && dispatch(editorElement, "lexxy:file-accept", { file }, true)) {
+  if (file && editorElement.acceptsFile(file)) {
     return $createActionTextAttachmentUploadNode({
       file,
       uploadUrl: editorElement.directUploadUrl,
@@ -49,6 +48,7 @@ function $tryConvertToUpload(node, editorElement) {
       contentType: file.type,
     })
   }
+  return null
 }
 
 function dataURIToFile(dataURI) {

--- a/src/helpers/inline_image_uri_helper.js
+++ b/src/helpers/inline_image_uri_helper.js
@@ -1,6 +1,5 @@
 import { $descendantsMatching } from "@lexical/utils"
 import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
-import { $createActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { mimeTypeToExtension } from "./storage_helper"
 
 // Replaces inline `data:image/...` attachments with upload nodes that flow through the normal
@@ -41,12 +40,7 @@ function isInlineImageDataURIAttachment(node) {
 function $tryCreateUploadFromDataURI(node, editorElement) {
   const file = dataURIToFile(node.src)
   if (file && editorElement.acceptsFile(file)) {
-    return $createActionTextAttachmentUploadNode({
-      file,
-      uploadUrl: editorElement.directUploadUrl,
-      blobUrlTemplate: editorElement.blobUrlTemplate,
-      contentType: file.type,
-    })
+    return editorElement.contents.$createUploadNode(file)
   }
   return null
 }

--- a/src/helpers/inline_image_uri_helper.js
+++ b/src/helpers/inline_image_uri_helper.js
@@ -1,0 +1,70 @@
+import { $descendantsMatching } from "@lexical/utils"
+import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
+import { $createActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
+import { dispatch } from "./html_helper"
+import { mimeTypeToExtension } from "./storage_helper"
+
+// Replaces inline `data:image/...` attachments with upload nodes that flow through the normal
+// file upload pipeline.
+//
+// Without this step, pasted-from-Google-Docs-style content lands in the editor with the entire
+// base64 image embedded in the attachment's `src`, which then persists into the saved HTML and
+// bloats the stored document.
+//
+// Each conversion dispatches the cancelable `lexxy:file-accept` event so the host's allowlist (and
+// any other listener) can refuse the synthesized File before it's accepted into the upload
+// pipeline; on refusal, the node is dropped silently — matching how `Contents#uploadFiles` handles
+// file-picker rejections.
+export function $convertInlineImageDataURIs(nodes, editorElement) {
+  return nodes.flatMap(node => {
+    if (isInlineImageDataURIAttachment(node)) {
+      const upload = $tryConvertToUpload(node, editorElement)
+      return upload ? [ upload ] : []
+    }
+    $descendantsMatching([ node ], isInlineImageDataURIAttachment)
+      .forEach(desc => {
+        const upload = $tryConvertToUpload(desc, editorElement)
+        if (upload) {
+          desc.replace(upload)
+        } else {
+          desc.remove()
+        }
+      })
+    return [ node ]
+  })
+}
+
+function isInlineImageDataURIAttachment(node) {
+  return node instanceof ActionTextAttachmentNode &&
+    /^data:image\//i.test(node.src ?? "")
+}
+
+function $tryConvertToUpload(node, editorElement) {
+  const file = dataURIToFile(node.src)
+  if (file && dispatch(editorElement, "lexxy:file-accept", { file }, true)) {
+    return $createActionTextAttachmentUploadNode({
+      file,
+      uploadUrl: editorElement.directUploadUrl,
+      blobUrlTemplate: editorElement.blobUrlTemplate,
+      contentType: file.type,
+    })
+  }
+}
+
+function dataURIToFile(dataURI) {
+  try {
+    const [ header, data ] = dataURI.split(",")
+
+    // https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
+    const mimeType = header.match(/^data:(image\/[A-Za-z0-9][A-Za-z0-9!#$&\-^_.+]*)/)?.[1]
+    if (mimeType) {
+      const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0))
+      const extension = mimeTypeToExtension(mimeType) ?? "png"
+      return new File([ bytes ], `pasted-image-${Date.now()}.${extension}`, { type: mimeType })
+    } else {
+      return null
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/helpers/inline_image_uri_helper.js
+++ b/src/helpers/inline_image_uri_helper.js
@@ -34,7 +34,7 @@ export function $convertInlineImageDataURIs(nodes, editorElement) {
 
 function isInlineImageDataURIAttachment(node) {
   return node instanceof ActionTextAttachmentNode &&
-    /^data:image\//i.test(node.src ?? "")
+    /^data:image\/[^,]*;base64,/i.test(node.src ?? "")
 }
 
 function $tryCreateUploadFromDataURI(node, editorElement) {

--- a/test/browser/fixtures/attachments-permitted-image-png.html
+++ b/test/browser/fixtures/attachments-permitted-image-png.html
@@ -13,7 +13,9 @@
         class="lexxy-content"
         placeholder="Write something..."
         attachments="true"
-        permitted-attachment-types="image/png"></lexxy-editor>
+        permitted-attachment-types="image/png"
+        data-direct-upload-url="/rails/active_storage/direct_uploads"
+        data-blob-url-template="/rails/active_storage/blobs/:signed_id/:filename"></lexxy-editor>
     </div>
   </form>
 

--- a/test/browser/tests/editor/load_html.test.js
+++ b/test/browser/tests/editor/load_html.test.js
@@ -35,4 +35,11 @@ test.describe("Load HTML", () => {
       await expect(paragraphs.last()).toHaveText("Second paragraph.")
     })
   })
+
+  test("preserves inline image data URIs untouched (no paste-time conversion)", async ({ editor }) => {
+    const dataURI = `data:image/png;base64,${Buffer.from("\x89PNG\r\n\x1a\n", "binary").toString("base64")}`
+    await editor.setValue(`<p>before</p><img src="${dataURI}"><p>after</p>`)
+
+    expect(await editor.value()).toContain(dataURI)
+  })
 })

--- a/test/browser/tests/paste/data_uri_safeguards.test.js
+++ b/test/browser/tests/paste/data_uri_safeguards.test.js
@@ -185,6 +185,21 @@ test.describe("Paste — Inline image data URIs", () => {
     expect(await editor.value()).toContain(pdfDataURI)
   })
 
+  test("leaves a non-base64 image data URI untouched in the saved HTML", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    const svgDataURI = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3C/svg%3E"
+    await editor.paste("", {
+      html: `<p>before</p><img src="${svgDataURI}"><p>after</p>`,
+    })
+    await editor.flush()
+
+    expect(calls.blobCreations).toHaveLength(0)
+    expect(await editor.value()).toContain(svgDataURI)
+  })
+
   test("silently drops a malformed data URI", async ({ page, editor }) => {
     await page.goto("/attachments.html")
     await editor.waitForConnected()

--- a/test/browser/tests/paste/data_uri_safeguards.test.js
+++ b/test/browser/tests/paste/data_uri_safeguards.test.js
@@ -135,6 +135,21 @@ test.describe("Paste — Inline image data URIs", () => {
     expect(value).not.toContain("data:image/png")
   })
 
+  test("converts a permitted image data URI even with a restrictive allowlist", async ({ page, editor }) => {
+    await page.goto("/attachments-permitted-image-png.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    await editor.paste("", { html: `<img src="${PNG_DATA_URI}">` })
+
+    await expect.poll(() => calls.blobCreations.length, { timeout: 10_000 }).toBe(1)
+    expect(calls.blobCreations[0].content_type).toBe("image/png")
+
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/png']"),
+    ).toHaveCount(1)
+  })
+
   test("silently drops a non-permitted image data URI", async ({ page, editor }) => {
     await page.goto("/attachments-permitted-image-png.html")
     await editor.waitForConnected()

--- a/test/browser/tests/paste/data_uri_safeguards.test.js
+++ b/test/browser/tests/paste/data_uri_safeguards.test.js
@@ -1,0 +1,193 @@
+import { readFileSync } from "node:fs"
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+const EXAMPLE_PNG = readFileSync("test/fixtures/files/example.png").toString("base64")
+const EXAMPLE_SVG = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>',
+).toString("base64")
+const PNG_DATA_URI = `data:image/png;base64,${EXAMPLE_PNG}`
+const SVG_DATA_URI = `data:image/svg+xml;base64,${EXAMPLE_SVG}`
+const modifier = process.platform === "darwin" ? "Meta" : "Control"
+
+test.describe("Paste — Inline image data URIs", () => {
+  test("converts a standalone data URI image into an upload", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    await editor.paste("", { html: `<img src="${PNG_DATA_URI}">` })
+
+    await expect.poll(() => calls.blobCreations.length, { timeout: 10_000 }).toBe(1)
+    expect(calls.blobCreations[0].content_type).toBe("image/png")
+
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/png']"),
+    ).toHaveCount(1)
+
+    expect(await editor.value()).not.toContain("data:image/png")
+  })
+
+  test("preserves the full subtype for spec-compliant mimetypes", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    const validBase64 = Buffer.from("hello").toString("base64")
+    const dataURI = `data:image/x-icon;base64,${validBase64}`
+    await editor.paste("", { html: `<img src="${dataURI}">` })
+
+    await expect.poll(() => calls.blobCreations.length, { timeout: 10_000 }).toBe(1)
+    expect(calls.blobCreations[0].content_type).toBe("image/x-icon")
+
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/x-icon']"),
+    ).toHaveCount(1)
+  })
+
+  test("preserves position when surrounded by other content", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    await editor.paste("", {
+      html: `<p>before</p><img src="${PNG_DATA_URI}"><p>after</p>`,
+    })
+
+    await expect.poll(() => calls.blobCreations.length, { timeout: 10_000 }).toBe(1)
+
+    const children = editor.content.locator(":scope > *")
+    await expect(children).toHaveCount(3)
+    await expect(children.nth(0)).toContainText("before")
+    await expect(children.nth(1)).toHaveClass(/attachment/)
+    await expect(children.nth(2)).toContainText("after")
+    expect(await editor.value()).not.toContain("data:image/png")
+  })
+
+  test("converts a data URI inline within paragraph content", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    await editor.paste("", {
+      html: `<p>see <img src="${PNG_DATA_URI}"> here</p>`,
+    })
+
+    await expect.poll(() => calls.blobCreations.length, { timeout: 10_000 }).toBe(1)
+
+    const children = editor.content.locator(":scope > *")
+    await expect(children).toHaveCount(3)
+    await expect(children.nth(0)).toContainText("see")
+    await expect(children.nth(1)).toHaveClass(/attachment/)
+    await expect(children.nth(2)).toContainText("here")
+    expect(await editor.value()).not.toContain("data:image/png")
+  })
+
+  test("converts each of multiple data URI images independently without forming a gallery", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    await editor.paste("", {
+      html: `<img src="${PNG_DATA_URI}"><img src="${PNG_DATA_URI}">`,
+    })
+
+    await expect.poll(() => calls.blobCreations.length, { timeout: 10_000 }).toBe(2)
+
+    await expect(
+      editor.content.locator("figure.attachment[data-content-type='image/png']"),
+    ).toHaveCount(2)
+    await expect(editor.content.locator(".attachment-gallery")).toHaveCount(0)
+  })
+
+  test("fires lexxy:file-accept with the synthesized file", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    await mockActiveStorageUploads(page)
+
+    await editor.locator.evaluate((el) => {
+      window.__fileAcceptCalls = []
+      el.addEventListener("lexxy:file-accept", (e) => {
+        window.__fileAcceptCalls.push({ type: e.detail.file.type })
+      })
+    })
+
+    await editor.paste("", { html: `<img src="${PNG_DATA_URI}">` })
+    await editor.flush()
+
+    const fileAcceptCalls = await page.evaluate(() => window.__fileAcceptCalls)
+    expect(fileAcceptCalls).toEqual([ { type: "image/png" } ])
+  })
+
+  test("undo lands on pre-paste state without the data URI", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    await mockActiveStorageUploads(page)
+
+    await editor.paste("", { html: `<img src="${PNG_DATA_URI}">` })
+    await editor.flush()
+
+    await editor.content.press(`${modifier}+z`)
+    await editor.flush()
+
+    const value = await editor.value()
+    expect(value).not.toContain("data:image/png")
+  })
+
+  test("silently drops a non-permitted image data URI", async ({ page, editor }) => {
+    await page.goto("/attachments-permitted-image-png.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    await editor.paste("", {
+      html: `<p>before</p><img src="${SVG_DATA_URI}"><p>after</p>`,
+    })
+    await editor.flush()
+
+    expect(calls.blobCreations).toHaveLength(0)
+
+    const children = editor.content.locator(":scope > *")
+    await expect(children).toHaveCount(2)
+    await expect(editor.content.locator(":scope > p")).toHaveCount(2)
+    await expect(children.nth(0)).toContainText("before")
+    await expect(children.nth(1)).toContainText("after")
+    expect(await editor.value()).not.toContain("data:image")
+  })
+
+  test("leaves a non-image data URI untouched in the saved HTML", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    const pdfDataURI = `data:application/pdf;base64,${Buffer.from("hello").toString("base64")}`
+    await editor.paste("", {
+      html: `<p>before</p><img src="${pdfDataURI}"><p>after</p>`,
+    })
+    await editor.flush()
+
+    expect(calls.blobCreations).toHaveLength(0)
+    expect(await editor.value()).toContain(pdfDataURI)
+  })
+
+  test("silently drops a malformed data URI", async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    const calls = await mockActiveStorageUploads(page)
+
+    const malformed = "data:image/png;base64,!!!!not-real-base64!!!!"
+    await editor.paste("", {
+      html: `<p>before</p><img src="${malformed}"><p>after</p>`,
+    })
+    await editor.flush()
+
+    expect(calls.blobCreations).toHaveLength(0)
+
+    const children = editor.content.locator(":scope > *")
+    await expect(children).toHaveCount(2)
+    await expect(editor.content.locator(":scope > p")).toHaveCount(2)
+    await expect(children.nth(0)).toContainText("before")
+    await expect(children.nth(1)).toContainText("after")
+    expect(await editor.value()).not.toContain("data:image/png")
+  })
+})


### PR DESCRIPTION
Convert data-URI images into uploads when content is pasted.

Pasted content from sources like Google Docs can include `<img src="data:image/png;base64,...">` with the full image inlined. Without intervention, the base64 payload persists into saved HTML and bloats the stored document.

Extracted an editor function `$generateNodesFromDOM` which calls `$convertInlineImageDataURIs` when content has been pasted. That helper method decodes each `data:image/...` URI into a File, dispatches the cancelable `lexxy:file-accept` event, and replaces the attachment with an `ActionTextAttachmentUploadNode` that flows through the normal Active Storage pipeline.

Also extracted `$createUploadNode` for the inline image uri helper, but this simplifies the uploader as well.

See also previous work in Basecamp to implement this feature for Trix at https://github.com/basecamp/bc3/pull/9882

ref: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9849287511