### PR TITLE
ci: Update benchmarks to run baseline and current

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -54,9 +54,11 @@ jobs:
       - name: Set up baseline worktree
         if: steps.baseline.outputs.sha != ''
         working-directory: current
+        env:
+          BASELINE_SHA: ${{ steps.baseline.outputs.sha }}
         run: |
-          git fetch --depth=1 origin ${{ steps.baseline.outputs.sha }}
-          git worktree add ../baseline ${{ steps.baseline.outputs.sha }}
+          git fetch --depth=1 origin "$BASELINE_SHA"
+          git worktree add ../baseline "$BASELINE_SHA"
 
       - name: Set up Node.js
         if: steps.baseline.outputs.sha != ''

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
   browser-benchmarks:
     name: Browser benchmarks
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -23,31 +23,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          path: current
           persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22"
-          cache: "yarn"
-
-      - name: Install JavaScript dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      - name: Run browser benchmarks
-        run: yarn benchmark:browser
-
-      - name: Upload browser benchmark results
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: browser-benchmarks
-          path: tmp/browser-benchmarks.json
-          if-no-files-found: ignore
-          retention-days: 30
 
       - name: Find latest successful main benchmark run
         id: baseline
@@ -55,35 +32,56 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          run_id=$(
+          sha=$(
             curl -fsSL \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${{ github.repository }}/actions/workflows/benchmarks.yml/runs?branch=main&status=success&event=push&per_page=1" \
-            | jq -r '.workflow_runs[0].id // empty'
+            | jq -r '.workflow_runs[0].head_sha // empty'
           )
-          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Note missing baseline
-        if: steps.baseline.outputs.run_id == ''
+        if: steps.baseline.outputs.sha == ''
         run: |
           {
             echo "## Browser Benchmark Comparison"
             echo ""
-            echo "No successful \`main\` benchmark run exists yet, so this run only published a fresh baseline artifact."
+            echo "No successful \`main\` benchmark run exists yet, so no comparison was performed."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Download baseline benchmark artifact
-        if: steps.baseline.outputs.run_id != ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          github-token: ${{ github.token }}
-          name: browser-benchmarks
-          path: baseline
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.baseline.outputs.run_id }}
+      - name: Set up baseline worktree
+        if: steps.baseline.outputs.sha != ''
+        working-directory: current
+        run: |
+          git fetch --depth=1 origin ${{ steps.baseline.outputs.sha }}
+          git worktree add ../baseline ${{ steps.baseline.outputs.sha }}
 
-      - name: Compare benchmark medians against main
-        if: steps.baseline.outputs.run_id != ''
-        run: yarn benchmark:browser:compare baseline/browser-benchmarks.json tmp/browser-benchmarks.json
+      - name: Set up Node.js
+        if: steps.baseline.outputs.sha != ''
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+
+      - name: Benchmark baseline
+        if: steps.baseline.outputs.sha != ''
+        working-directory: baseline
+        run: |
+          yarn install --frozen-lockfile
+          npx playwright install --with-deps chromium
+          yarn benchmark:browser --output ../tmp/browser-benchmarks-baseline.json
+
+      - name: Benchmark current
+        if: steps.baseline.outputs.sha != ''
+        working-directory: current
+        run: |
+          yarn install --frozen-lockfile
+          npx playwright install --with-deps chromium
+          yarn benchmark:browser --output ../tmp/browser-benchmarks-current.json
+
+      - name: Compare benchmarks
+        if: steps.baseline.outputs.sha != ''
+        working-directory: current
+        run: |
+          yarn benchmark:browser:compare ../tmp/browser-benchmarks-baseline.json ../tmp/browser-benchmarks-current.json

--- a/docs/development.md
+++ b/docs/development.md
@@ -158,7 +158,6 @@ The compare script checks per-scenario median regressions against coarse thresho
 
 GitHub Actions runs the browser benchmark workflow from `.github/workflows/benchmarks.yml` on pull requests, pushes to `main`, and manual dispatches.
 
-- Each run uploads `tmp/browser-benchmarks.json` as the `browser-benchmarks` artifact.
-- Pull requests compare their results against the latest successful benchmark run from `main`.
+- Pull requests run benchmarks against the latest commit on `main` for which there's a successful benchmark run, and use that as the baseline for comparison.
 - The workflow only fails when a scenario median regresses by more than both the configured absolute and relative threshold.
 - The comparison is written to the workflow summary, so you can inspect the deltas without downloading artifacts manually.


### PR DESCRIPTION
so we're comparing results run on the same hardware and VM. This should reduce the flakiness.

Previously, we have been using results generated on `main` from a previous CI run (which may have different performance characteristics that make direct comparison difficult).