### PR TITLE
Prevent prompt picker from scrolling the page when opened

### DIFF
--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -1,7 +1,7 @@
 import {
   $addUpdateTag, $createParagraphNode, $getNearestNodeFromDOMNode, $getRoot, $getSelection, $isDecoratorNode, $isElementNode,
   $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $setSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW, DELETE_CHARACTER_COMMAND,
-  HISTORY_MERGE_TAG, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND, SELECTION_CHANGE_COMMAND, isDOMNode
+  HISTORY_MERGE_TAG, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND, SELECTION_CHANGE_COMMAND, SKIP_SCROLL_INTO_VIEW_TAG, isDOMNode
 } from "lexical"
 import { $getNearestNodeOfType } from "@lexical/utils"
 import { $getListDepth, ListItemNode, ListNode } from "@lexical/list"
@@ -87,7 +87,7 @@ export default class Selection {
     return { node: null, offset: 0 }
   }
 
-  preservingSelection(fn) {
+  preservingSelection(fn, { preventScroll = false } = {}) {
     let selectionState = null
 
     this.editor.getEditorState().read(() => {
@@ -108,6 +108,7 @@ export default class Selection {
         if (selection && $isRangeSelection(selection)) {
           selection.anchor.set(selectionState.anchor.key, selectionState.anchor.offset, "text")
           selection.focus.set(selectionState.focus.key, selectionState.focus.offset, "text")
+          if (preventScroll) $addUpdateTag(SKIP_SCROLL_INTO_VIEW_TAG)
         }
       })
     }

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -238,20 +238,34 @@ export class LexicalPromptElement extends HTMLElement {
     return Array.from(this.popoverElement.querySelectorAll(".lexxy-prompt-menu__item"))
   }
 
-  #selectOption(listItem) {
+  #selectOption(listItem, { scrollIntoView = false } = {}) {
     this.#clearListItemSelection()
     listItem.toggleAttribute("aria-selected", true)
-    listItem.scrollIntoView({ block: "nearest", behavior: "smooth" })
-    listItem.focus()
+    if (scrollIntoView) this.#scrollItemIntoPopover(listItem)
 
-    // Preserve selection to prevent cursor jump
+    listItem.focus({ preventScroll: true })
+
+    // Focus the contenteditable directly — the editor wrapper's focus()
+    // drops options.
     this.#selection.preservingSelection(() => {
-      this.#editorElement.focus()
-    })
+      this.#editorContentElement.focus({ preventScroll: true })
+    }, { preventScroll: true })
 
     this.#setEditorAssociationAttribute("aria-controls", this.popoverElement.id)
     this.#setEditorAssociationAttribute("aria-activedescendant", listItem.id)
     this.#setEditorAssociationAttribute("aria-haspopup", "listbox")
+  }
+
+  #scrollItemIntoPopover(listItem) {
+    const popover = this.popoverElement
+    const itemRect = listItem.getBoundingClientRect()
+    const popoverRect = popover.getBoundingClientRect()
+
+    if (itemRect.bottom > popoverRect.bottom) {
+      popover.scrollTo({ top: popover.scrollTop + (itemRect.bottom - popoverRect.bottom), behavior: "smooth" })
+    } else if (itemRect.top < popoverRect.top) {
+      popover.scrollTo({ top: popover.scrollTop - (popoverRect.top - itemRect.top), behavior: "smooth" })
+    }
   }
 
   #clearListItemSelection() {
@@ -289,10 +303,25 @@ export class LexicalPromptElement extends HTMLElement {
       this.popoverElement.toggleAttribute("data-clipped-at-right", true)
     }
 
-    if (popoverRect.bottom > window.innerHeight) {
+    if (popoverRect.bottom > this.#viewportBottom) {
       this.#setPopoverOffsetY(contentRect.height - y + fontSize)
       this.popoverElement.toggleAttribute("data-clipped-at-bottom", true)
     }
+  }
+
+  // Embedded hosts that manage keyboard insets natively can leave both
+  // innerHeight and visualViewport at layout size; they can publish the
+  // visible-area height via --lexxy-host-viewport-height.
+  get #viewportBottom() {
+    const override = this.#hostViewportHeight
+    if (override != null) return override
+    const vv = window.visualViewport
+    return vv ? vv.offsetTop + vv.height : window.innerHeight
+  }
+
+  get #hostViewportHeight() {
+    const value = parseFloat(window.getComputedStyle(document.documentElement).getPropertyValue("--lexxy-host-viewport-height"))
+    return Number.isFinite(value) ? value : null
   }
 
   #setPopoverOffsetX(value) {
@@ -396,12 +425,12 @@ export class LexicalPromptElement extends HTMLElement {
 
   #moveSelectionDown() {
     const nextIndex = this.#selectedIndex + 1
-    if (nextIndex < this.#listItemElements.length) this.#selectOption(this.#listItemElements[nextIndex])
+    if (nextIndex < this.#listItemElements.length) this.#selectOption(this.#listItemElements[nextIndex], { scrollIntoView: true })
   }
 
   #moveSelectionUp() {
     const previousIndex = this.#selectedIndex - 1
-    if (previousIndex >= 0) this.#selectOption(this.#listItemElements[previousIndex])
+    if (previousIndex >= 0) this.#selectOption(this.#listItemElements[previousIndex], { scrollIntoView: true })
   }
 
   get #selectedIndex() {

--- a/test/browser/tests/prompts/picker_does_not_scroll_page.test.js
+++ b/test/browser/tests/prompts/picker_does_not_scroll_page.test.js
@@ -1,0 +1,88 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+// Regression: typing "@" near the bottom of the visible area must not
+// scroll the page. We stub innerHeight larger than the real viewport to
+// simulate the iOS layout-vs-visual gap on a desktop test runner.
+test.describe("Prompt popover scroll", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 600 })
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("opening the picker with cursor near the visual viewport bottom does not scroll the page", async ({ page, editor }) => {
+    // Make the page scrollable so any unwanted scroll has somewhere to go.
+    await page.evaluate(() => {
+      document.body.style.paddingBottom = "2000px"
+    })
+
+    // Push the cursor toward the bottom of the viewport.
+    await editor.focus()
+    for (let i = 0; i < 18; i++) {
+      await editor.send("Enter")
+    }
+    await editor.send("Hello ")
+
+    // Simulate the iOS layout-vs-visual viewport gap.
+    await page.evaluate(() => {
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        get() { return 5000 },
+      })
+    })
+
+    const scrollYBefore = await page.evaluate(() => window.scrollY)
+
+    await editor.send("@")
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const scrollYAfter = await page.evaluate(() => window.scrollY)
+    expect(Math.abs(scrollYAfter - scrollYBefore)).toBeLessThanOrEqual(2)
+
+    // preventScroll alone could mask a regression that places the popover
+    // in the hidden area; assert it landed within the visible viewport.
+    const popoverWithinVisualViewport = await page.evaluate(() => {
+      const el = document.querySelector(".lexxy-prompt-menu--visible")
+      const rect = el.getBoundingClientRect()
+      const vv = window.visualViewport
+      return rect.bottom <= vv.offsetTop + vv.height + 1
+    })
+    expect(popoverWithinVisualViewport).toBe(true)
+    await expect(popover).toHaveAttribute("data-clipped-at-bottom", "")
+  })
+
+  test("host-supplied --lexxy-host-viewport-height overrides innerHeight and visualViewport for clipping", async ({ page, editor }) => {
+    await page.evaluate(() => {
+      document.body.style.paddingBottom = "2000px"
+    })
+
+    await editor.focus()
+    for (let i = 0; i < 18; i++) {
+      await editor.send("Enter")
+    }
+    await editor.send("Hello ")
+
+    // Embedded hosts can leave both innerHeight and visualViewport at
+    // layout size and publish the real visible height via the CSS variable.
+    await page.evaluate(() => {
+      Object.defineProperty(window, "innerHeight", { configurable: true, get() { return 5000 } })
+      Object.defineProperty(window.visualViewport, "height", { configurable: true, get() { return 5000 } })
+      document.documentElement.style.setProperty("--lexxy-host-viewport-height", "400px")
+    })
+
+    const scrollYBefore = await page.evaluate(() => window.scrollY)
+
+    await editor.send("@")
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const scrollYAfter = await page.evaluate(() => window.scrollY)
+    expect(Math.abs(scrollYAfter - scrollYBefore)).toBeLessThanOrEqual(2)
+
+    // data-clipped-at-bottom proves the override drove the flip — without
+    // it lexxy would have read the inflated innerHeight/visualViewport.
+    await expect(popover).toHaveAttribute("data-clipped-at-bottom", "")
+  })
+})


### PR DESCRIPTION
On mobile apps with the soft keyboard up, typing @ in a Lexxy editor whose cursor sat near the bottom of the visible area caused the entire page to scroll up. In some cases the picker was placed in the keyboard-covered area and clipped.

1. lexxy — give it a way to know about the keyboard
#viewportBottom now reads, in order:
--lexxy-host-viewport-height (+ --lexxy-host-viewport-top) CSS variables on <html> — the host-supplied authoritative number,
window.visualViewport.height — works for normal mobile Safari and most other browsers,
window.innerHeight — last-resort fallback.
This makes the clipping check correct, so the popover gets flipped above the cursor when the visible area below is too small.

2. lexxy — stop the picker from scrolling the page on open
In #selectOption:
Removed the unconditional listItem.scrollIntoView from the initial-open path. It now runs only on arrow-key navigation, scoped to the popover's own scroll container via popover.scrollTo — physically can't scroll the page.
listItem.focus({ preventScroll: true }).
Focus the contenteditable directly with editorContentElement.focus({ preventScroll: true }) — going through LexicalEditorElement.focus() would have silently dropped the option (the wrapper takes no parameters; editor.focus(callback) is Lexical's signature, not DOM focus(options)).