### PR TITLE
Preserve multiple spaces on plain text paste

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -161,7 +161,7 @@ export default class Clipboard {
   }
 
   #pasteMarkdown(text) {
-    const html = marked(text, { breaks: true })
+    const html = marked(preserveConsecutiveSpaces(text), { breaks: true })
     const doc = parseHtml(html)
     const detail = Object.freeze({
       markdown: text,
@@ -237,6 +237,10 @@ export default class Clipboard {
     window.scrollTo(scrollX, scrollY)
     this.editor.focus()
   }
+}
+
+function preserveConsecutiveSpaces(text) {
+  return text.replace(/ {2,}/g, (run) => " " + "\u00A0".repeat(run.length - 1))
 }
 
 function $bareUrlFromSingleLink(nodes) {

--- a/test/browser/tests/paste/markdown.test.js
+++ b/test/browser/tests/paste/markdown.test.js
@@ -36,4 +36,36 @@ test.describe("Paste — Markdown", () => {
     await editor.paste("Hello **there**")
     await assertEditorHtml(editor, "<p>Hello **there**</p>")
   })
+
+  test("preserves runs of consecutive spaces when pasting plain text", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    const asciiTable = [
+      "+--------+--------+--------+",
+      "| Name   | Score  | Level  |",
+      "+--------+--------+--------+",
+      "| Alice  |   87   |   3    |",
+      "| Bob    |   42   |   7    |",
+      "| Clara  |   65   |   5    |",
+      "+--------+--------+--------+",
+    ].join("\n")
+
+    await editor.paste(asciiTable)
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      // textContent normalizes NBSPs to regular-space-equivalents for the
+      // visible text, so each row should round-trip with its column padding.
+      const text = await content.evaluate((el) =>
+        el.innerText.replace(/ /g, " "),
+      )
+      expect(text).toContain("| Alice  |   87   |   3    |")
+      expect(text).toContain("| Bob    |   42   |   7    |")
+      expect(text).toContain("| Clara  |   65   |   5    |")
+    })
+  })
 })


### PR DESCRIPTION
Plain-text paste collapsed runs of consecutive spaces, breaking ASCII tables and other space-aligned content. The collapse comes from HTML/Lexical whitespace normalization. This patch substitutes runs of 2+ spaces with a regular space + `&nbsp`s before Marked sees them, so the spacing survives the round trip while single spaces (and code-block paste) are untouched.

### Example table
```
+--------+--------+--------+
| Name   | Score  | Level  |
+--------+--------+--------+
| Alice  |   87   |   3    |
| Bob    |   42   |   7    |
| Clara  |   65   |   5    |
+--------+--------+--------+
```

### Expectation
<img width="223" height="132" alt="image" src="https://github.com/user-attachments/assets/01e701a4-8f56-491d-81dd-ecf6dfc47886" />

Turned into codeblock:
<img width="263" height="128" alt="image" src="https://github.com/user-attachments/assets/8d3edd2b-8c2f-4c3d-bc7d-a30ec85403eb" />


### Reality
<img width="225" height="136" alt="image" src="https://github.com/user-attachments/assets/2b4b60df-609b-41c7-92d2-6e08c58f2f93" />

Turned into codeblock:
<img width="262" height="127" alt="image" src="https://github.com/user-attachments/assets/1b612d80-79d6-4beb-8508-cc06cedeceff" />
