### PR TITLE
Don't auto-link plain text containing colons

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -1,5 +1,5 @@
 import { marked } from "marked"
-import { isUrl } from "../helpers/string_helper"
+import { isAutolinkableURL } from "../helpers/string_helper"
 import { nextFrame } from "../helpers/timing_helpers"
 import { addBlockSpacing, dispatch, parseHtml } from "../helpers/html_helper"
 import { $isCodeNode } from "@lexical/code"
@@ -117,9 +117,9 @@ export default class Clipboard {
   #pastePlainText(clipboardData) {
     const item = clipboardData.items[0]
     item.getAsString((text) => {
-      if (isUrl(text) && this.contents.hasSelectedText()) {
+      if (isAutolinkableURL(text) && this.contents.hasSelectedText()) {
         this.contents.createLinkWithSelectedText(text)
-      } else if (isUrl(text)) {
+      } else if (isAutolinkableURL(text)) {
         const nodeKey = this.contents.createLink(text)
         this.#dispatchLinkInsertEvent(nodeKey, { url: text })
       } else if (this.editorElement.supportsMarkdown) {

--- a/src/helpers/string_helper.js
+++ b/src/helpers/string_helper.js
@@ -2,13 +2,8 @@ export function dasherize(value) {
   return value.replace(/([A-Z])/g, (_, char) => `-${char.toLowerCase()}`)
 }
 
-export function isUrl(string) {
-  try {
-    new URL(string)
-    return true
-  } catch {
-    return false
-  }
+export function isAutolinkableURL(string) {
+  return /^(?:[a-z0-9]+:\/\/|www\.)[^\s]+$/i.test(string)
 }
 
 export function isPath(string) {

--- a/test/browser/tests/paste/links.test.js
+++ b/test/browser/tests/paste/links.test.js
@@ -48,6 +48,45 @@ test.describe("Paste — Links", () => {
     )
   })
 
+  const thingsThatMightBeURIs = [
+    [ "https://example.com/", true ],
+    [ "http://example.com/", true ],
+    [ "https://user:pass@example.com/", true ],
+    [ "www.example.com", true, "https://www.example.com" ],
+    [ "HTTPS://example.com/", true ],
+    [ "Http://example.com/", true ],
+    [ "WWW.example.com", true, "https://WWW.example.com" ],
+    [ "example.com", false ],
+
+    [ "http::parser", false ],
+    [ "https::client", false ],
+    [ "mailto::linker", false ],
+    [ "ftp::client", false ],
+
+    [ "Nokogiri::HTML", false ],
+    [ "Net::HTTP", false ],
+    [ "Foo::Bar::Baz", false ],
+
+    [ "port:8080", false ],
+    [ "key:value", false ],
+    [ "time:9:00", false ],
+  ]
+
+  for (const [ text, shouldLink, expectedHref = text ] of thingsThatMightBeURIs) {
+    test(`'${text}' ${shouldLink ? "is" : "is not"} auto-linked when pasted as plain text`, async ({ editor }) => {
+      await editor.paste(text)
+
+      await assertEditorContent(editor, async (content) => {
+        if (shouldLink) {
+          await expect(content.locator(`a[href="${expectedHref}"]`)).toHaveText(text)
+        } else {
+          await expect(content).toContainText(text)
+          await expect(content.locator("a")).toHaveCount(0)
+        }
+      })
+    })
+  }
+
   test("merge adjacent links when pasting URL over multiple words", async ({
     page,
     editor,


### PR DESCRIPTION
Pasting plain text like `Foo::Bar::Baz`, `port:8080`, or `time:9:00` was incorrectly converted into a link.

Replace `isUrl()` with a regex adapted from Basecamp's url_pastes.js (which has been in production for years) that only matches strings starting with `scheme://` or `www.` and containing no whitespace. The function is renamed `isAutolinkableURL` to make the (narrower-than-RFC-3986) intent explicit.

ref: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9844781664

🤖 Assisted by Claude