### PR TITLE
Fix bin/setup and bin/rails

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -3,7 +3,7 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path("..", __dir__)
-ENGINE_PATH = File.expand_path("../lib/actiontext/lexical/engine", __dir__)
+ENGINE_PATH = File.expand_path("../lib/lexxy", __dir__)
 APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
 
 # Set up gems listed in the Gemfile.

--- a/bin/setup
+++ b/bin/setup
@@ -50,6 +50,6 @@ echo "== Installing Playwright browsers =="
 npx playwright install
 
 echo "== Preparing database =="
-bin/rails db:prepare
+bin/rails app:db:prepare
 
 echo "== Setup complete! =="


### PR DESCRIPTION
ENGINE_PATH in bin/rails still pointed at the pre-rename lib/actiontext/lexical/engine (gone since 5d1adc86). Repoint at lib/lexxy, the gem entry, so lexxy.rb loads before engine.rb. Unbreaks `bin/rails console`.

bin/setup ran `bin/rails db:prepare`, which doesn't exist at the engine root. Use `app:db:prepare` to dispatch against the dummy app.

🤖 Assisted by Claude