### PR TITLE
Defer initialization to the next rAF

### DIFF
--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -326,7 +326,7 @@ export class CommandDispatcher {
   #registerDragAndDropHandlers() {
     if (this.editorElement.supportsAttachments) {
       this.dragCounter = 0
-      const root = this.editor.getRootElement()
+      const root = this.editorElement.editorContentElement
       this.#listeners.track(
         registerEventListener(root, "dragover", this.#handleDragOver.bind(this)),
         registerEventListener(root, "drop", this.#handleDrop.bind(this)),

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -342,7 +342,7 @@ export class CommandDispatcher {
     this.dragCounter++
     if (this.dragCounter === 1) {
       this.#saveSelectionBeforeDrag()
-      this.editor.getRootElement().classList.add("lexxy-editor--drag-over")
+      this.editorElement.editorContentElement.classList.add("lexxy-editor--drag-over")
     }
   }
 
@@ -352,7 +352,7 @@ export class CommandDispatcher {
     this.dragCounter--
     if (this.dragCounter === 0) {
       this.#selectionBeforeDrag = null
-      this.editor.getRootElement().classList.remove("lexxy-editor--drag-over")
+      this.editorElement.editorContentElement.classList.remove("lexxy-editor--drag-over")
     }
   }
 
@@ -368,7 +368,7 @@ export class CommandDispatcher {
     event.preventDefault()
 
     this.dragCounter = 0
-    this.editor.getRootElement().classList.remove("lexxy-editor--drag-over")
+    this.editorElement.editorContentElement.classList.remove("lexxy-editor--drag-over")
 
     const dataTransfer = event.dataTransfer
     if (!dataTransfer) return

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -326,12 +326,18 @@ export class CommandDispatcher {
   #registerDragAndDropHandlers() {
     if (this.editorElement.supportsAttachments) {
       this.dragCounter = 0
-      const root = this.editorElement.editorContentElement
       this.#listeners.track(
-        registerEventListener(root, "dragover", this.#handleDragOver.bind(this)),
-        registerEventListener(root, "drop", this.#handleDrop.bind(this)),
-        registerEventListener(root, "dragenter", this.#handleDragEnter.bind(this)),
-        registerEventListener(root, "dragleave", this.#handleDragLeave.bind(this))
+        this.editor.registerRootListener((rootElement) => {
+          if (rootElement) {
+            const teardowns = [
+              registerEventListener(rootElement, "dragover", this.#handleDragOver.bind(this)),
+              registerEventListener(rootElement, "drop", this.#handleDrop.bind(this)),
+              registerEventListener(rootElement, "dragenter", this.#handleDragEnter.bind(this)),
+              registerEventListener(rootElement, "dragleave", this.#handleDragLeave.bind(this))
+            ]
+            return () => teardowns.forEach((teardown) => teardown())
+          }
+        })
       )
     }
   }
@@ -342,7 +348,7 @@ export class CommandDispatcher {
     this.dragCounter++
     if (this.dragCounter === 1) {
       this.#saveSelectionBeforeDrag()
-      this.editorElement.editorContentElement.classList.add("lexxy-editor--drag-over")
+      this.editor.getRootElement().classList.add("lexxy-editor--drag-over")
     }
   }
 
@@ -352,7 +358,7 @@ export class CommandDispatcher {
     this.dragCounter--
     if (this.dragCounter === 0) {
       this.#selectionBeforeDrag = null
-      this.editorElement.editorContentElement.classList.remove("lexxy-editor--drag-over")
+      this.editor.getRootElement().classList.remove("lexxy-editor--drag-over")
     }
   }
 
@@ -368,7 +374,7 @@ export class CommandDispatcher {
     event.preventDefault()
 
     this.dragCounter = 0
-    this.editorElement.editorContentElement.classList.remove("lexxy-editor--drag-over")
+    this.editor.getRootElement().classList.remove("lexxy-editor--drag-over")
 
     const dataTransfer = event.dataTransfer
     if (!dataTransfer) return

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -361,7 +361,7 @@ export default class Selection {
     // above when navigating UP/DOWN when Lexical shows its fake cursor on custom decorator nodes.
     this.editorContentElement.addEventListener("keydown", (event) => {
       if (event.key === "ArrowUp") {
-        const lexicalCursor = this.editor.getRootElement().querySelector("[data-lexical-cursor]")
+        const lexicalCursor = this.editorContentElement.querySelector("[data-lexical-cursor]")
 
         if (lexicalCursor) {
           let currentElement = lexicalCursor.previousElementSibling
@@ -376,7 +376,7 @@ export default class Selection {
       }
 
       if (event.key === "ArrowDown") {
-        const lexicalCursor = this.editor.getRootElement().querySelector("[data-lexical-cursor]")
+        const lexicalCursor = this.editorContentElement.querySelector("[data-lexical-cursor]")
 
         if (lexicalCursor) {
           let currentElement = lexicalCursor.nextElementSibling
@@ -694,7 +694,7 @@ export default class Selection {
   }
 
   #calculateCursorPosition(rect, range) {
-    const rootRect = this.editor.getRootElement().getBoundingClientRect()
+    const rootRect = this.editorContentElement.getBoundingClientRect()
     const x = rect.left - rootRect.left
     let y = rect.top - rootRect.top
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -351,9 +351,8 @@ export default class Selection {
       return $isDecoratorNode(targetNode) && this.#selectInLexical(targetNode)
     }, COMMAND_PRIORITY_LOW))
 
-    const rootElement = this.editor.getRootElement()
     this.#listeners.track(
-      registerEventListener(rootElement, "lexxy:internal:move-to-next-line", () => this.#selectOrAppendNextLine())
+      registerEventListener(this.editorContentElement, "lexxy:internal:move-to-next-line", () => this.#selectOrAppendNextLine())
     )
   }
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -352,44 +352,58 @@ export default class Selection {
     }, COMMAND_PRIORITY_LOW))
 
     this.#listeners.track(
-      registerEventListener(this.editorContentElement, "lexxy:internal:move-to-next-line", () => this.#selectOrAppendNextLine())
+      this.editor.registerRootListener((rootElement) => {
+        if (rootElement) {
+          return registerEventListener(rootElement, "lexxy:internal:move-to-next-line", () => this.#selectOrAppendNextLine())
+        }
+      })
     )
   }
 
   #containEditorFocus() {
     // Workaround for a bizarre Chrome bug where the cursor abandons the editor to focus on not-focusable elements
     // above when navigating UP/DOWN when Lexical shows its fake cursor on custom decorator nodes.
-    this.editorContentElement.addEventListener("keydown", (event) => {
-      if (event.key === "ArrowUp") {
-        const lexicalCursor = this.editorContentElement.querySelector("[data-lexical-cursor]")
+    this.#listeners.track(
+      this.editor.registerRootListener((rootElement) => {
+        if (rootElement) {
+          const handler = (event) => this.#handleArrowKeyOnLexicalCursor(event)
+          rootElement.addEventListener("keydown", handler, true)
+          return () => rootElement.removeEventListener("keydown", handler, true)
+        }
+      })
+    )
+  }
 
-        if (lexicalCursor) {
-          let currentElement = lexicalCursor.previousElementSibling
-          while (currentElement && currentElement.hasAttribute("data-lexical-cursor")) {
-            currentElement = currentElement.previousElementSibling
-          }
+  #handleArrowKeyOnLexicalCursor(event) {
+    if (event.key === "ArrowUp") {
+      const lexicalCursor = this.editor.getRootElement().querySelector("[data-lexical-cursor]")
 
-          if (!currentElement) {
-            event.preventDefault()
-          }
+      if (lexicalCursor) {
+        let currentElement = lexicalCursor.previousElementSibling
+        while (currentElement && currentElement.hasAttribute("data-lexical-cursor")) {
+          currentElement = currentElement.previousElementSibling
+        }
+
+        if (!currentElement) {
+          event.preventDefault()
         }
       }
+    }
 
-      if (event.key === "ArrowDown") {
-        const lexicalCursor = this.editorContentElement.querySelector("[data-lexical-cursor]")
+    if (event.key === "ArrowDown") {
+      const lexicalCursor = this.editor.getRootElement().querySelector("[data-lexical-cursor]")
 
-        if (lexicalCursor) {
-          let currentElement = lexicalCursor.nextElementSibling
-          while (currentElement && currentElement.hasAttribute("data-lexical-cursor")) {
-            currentElement = currentElement.nextElementSibling
-          }
+      if (lexicalCursor) {
+        let currentElement = lexicalCursor.nextElementSibling
+        while (currentElement && currentElement.hasAttribute("data-lexical-cursor")) {
+          currentElement = currentElement.nextElementSibling
+        }
 
-          if (!currentElement) {
-            event.preventDefault()
-          }
+        if (!currentElement) {
+          event.preventDefault()
         }
       }
-    }, true)
+    }
   }
 
   #syncSelectedClasses() {
@@ -694,7 +708,7 @@ export default class Selection {
   }
 
   #calculateCursorPosition(rect, range) {
-    const rootRect = this.editorContentElement.getBoundingClientRect()
+    const rootRect = this.editor.getRootElement().getBoundingClientRect()
     const x = rect.left - rootRect.left
     let y = rect.top - rootRect.top
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -52,7 +52,9 @@ export class LexicalEditorElement extends HTMLElement {
   static observedAttributes = [ "connected", "required" ]
 
   #initialValue = ""
-  #initializeDispatched = false
+  #initializeEventDispatched = false
+  #editorInitializedDispatched = false
+  #valueLoaded = false
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
@@ -95,17 +97,21 @@ export class LexicalEditorElement extends HTMLElement {
     this.toggleAttribute("connected", true)
 
     requestAnimationFrame(() => {
-      this.editor.setRootElement(this.editorContentElement)
+      this.#mountRoot()
       this.#handleAutofocus()
       this.#dispatchInitialize()
     })
-
-    this.valueBeforeDisconnect = null
   }
 
   disconnectedCallback() {
-    this.#initializeDispatched = false
-    this.valueBeforeDisconnect = this.value
+    this.#initializeEventDispatched = false
+    this.#editorInitializedDispatched = false
+    if (this.#valueLoaded) {
+      this.valueBeforeDisconnect = this.value
+    } else {
+      this.valueBeforeDisconnect = null
+    }
+    this.#valueLoaded = false
     this.#reset() // Prevent hangs with Safari when morphing
   }
 
@@ -263,7 +269,7 @@ export class LexicalEditorElement extends HTMLElement {
 
     if (!this.editor) return
 
-    this.#initializeDispatched = true
+    this.#editorInitializedDispatched = true
     this.#dispatchEditorInitialized()
     this.#dispatchAttributesChange()
   }
@@ -318,6 +324,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   set value(html) {
+    this.#valueLoaded = true
     const editorHasFocus = this.#isContentFocused
 
     this.editor.update(() => {
@@ -417,6 +424,14 @@ export class LexicalEditorElement extends HTMLElement {
     return editor
   }
 
+  // Toggling editable around setRootElement skips Lexical's DOM-selection sync,
+  // which would otherwise steal focus from elsewhere on the page.
+  #mountRoot() {
+    this.editor.setEditable(false)
+    this.editor.setRootElement(this.editorContentElement)
+    this.editor.setEditable(true)
+  }
+
   get #lexicalNodes() {
     const nodes = [ CustomActionTextAttachmentNode ]
 
@@ -484,10 +499,12 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #loadInitialValue() {
-    const initialHtml = this.valueBeforeDisconnect || this.getAttribute("value") || "<p><br></p>"
-    this.editor.update(() => {
-      this.value = this.#initialValue = initialHtml
-    }, { tag: HISTORY_MERGE_TAG })
+    if (!this.#valueLoaded) {
+      const initialHtml = this.valueBeforeDisconnect || this.getAttribute("value") || "<p><br></p>"
+      this.editor.update(() => {
+        this.value = this.#initialValue = initialHtml
+      }, { tag: HISTORY_MERGE_TAG })
+    }
   }
 
   #resetBeforeTurboCaches() {
@@ -777,10 +794,16 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #dispatchInitialize() {
-    if (!this.#initializeDispatched && this.isConnected && this.adapter) {
-      this.#initializeDispatched = true
-      dispatch(this, "lexxy:initialize")
-      this.#dispatchEditorInitialized()
+    if (this.isConnected && this.adapter) {
+      if (!this.#initializeEventDispatched) {
+        this.#initializeEventDispatched = true
+        dispatch(this, "lexxy:initialize")
+      }
+
+      if (!this.#editorInitializedDispatched) {
+        this.#editorInitializedDispatched = true
+        this.#dispatchEditorInitialized()
+      }
     }
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -52,7 +52,7 @@ export class LexicalEditorElement extends HTMLElement {
   static observedAttributes = [ "connected", "required" ]
 
   #initialValue = ""
-  #editorInitializedRafId = null
+  #initializeDispatched = false
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
@@ -97,14 +97,14 @@ export class LexicalEditorElement extends HTMLElement {
     requestAnimationFrame(() => {
       this.editor.setRootElement(this.editorContentElement)
       this.#handleAutofocus()
-      this.#scheduleEditorInitializedDispatch()
+      this.#dispatchInitialize()
     })
 
     this.valueBeforeDisconnect = null
   }
 
   disconnectedCallback() {
-    this.#cancelEditorInitializedDispatch()
+    this.#initializeDispatched = false
     this.valueBeforeDisconnect = this.value
     this.#reset() // Prevent hangs with Safari when morphing
   }
@@ -263,7 +263,7 @@ export class LexicalEditorElement extends HTMLElement {
 
     if (!this.editor) return
 
-    this.#cancelEditorInitializedDispatch()
+    this.#initializeDispatched = true
     this.#dispatchEditorInitialized()
     this.#dispatchAttributesChange()
   }
@@ -776,22 +776,12 @@ export class LexicalEditorElement extends HTMLElement {
     })
   }
 
-  #scheduleEditorInitializedDispatch() {
-    this.#cancelEditorInitializedDispatch()
-    this.#editorInitializedRafId = requestAnimationFrame(() => {
-      this.#editorInitializedRafId = null
-      if (!this.isConnected || !this.adapter) return
-
+  #dispatchInitialize() {
+    if (!this.#initializeDispatched && this.isConnected && this.adapter) {
+      this.#initializeDispatched = true
       dispatch(this, "lexxy:initialize")
       this.#dispatchEditorInitialized()
-    })
-  }
-
-  #cancelEditorInitializedDispatch() {
-    if (this.#editorInitializedRafId == null) return
-
-    cancelAnimationFrame(this.#editorInitializedRafId)
-    this.#editorInitializedRafId = null
+    }
   }
 
   get #resolvedHighlightColors() {
@@ -842,7 +832,6 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #reset() {
-    this.#cancelEditorInitializedDispatch()
     this.#dispose()
     this.#resetValidity()
     this.editorContentElement?.remove()

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -95,20 +95,14 @@ export class LexicalEditorElement extends HTMLElement {
 
     this.toggleAttribute("connected", true)
 
-    if (this.hasAttribute("defer")) {
-      this.#deferredInitRafId = requestAnimationFrame(() => {
-        this.#deferredInitRafId = null
-        this.editor.setRootElement(this.editorContentElement)
-        this.#loadInitialValue()
-        this.#handleAutofocus()
-        this.#scheduleEditorInitializedDispatch()
-        this.valueBeforeDisconnect = null
-      })
-    } else {
-      this.#scheduleEditorInitializedDispatch()
+    this.#deferredInitRafId = requestAnimationFrame(() => {
+      this.#deferredInitRafId = null
+      this.editor.setRootElement(this.editorContentElement)
+      this.#loadInitialValue()
       this.#handleAutofocus()
+      this.#scheduleEditorInitializedDispatch()
       this.valueBeforeDisconnect = null
-    }
+    })
   }
 
   disconnectedCallback() {
@@ -393,7 +387,6 @@ export class LexicalEditorElement extends HTMLElement {
     this.#attachDebugHooks()
     this.#attachToolbar()
     this.#configureSanitizer()
-    if (!this.hasAttribute("defer")) this.#loadInitialValue()
     this.#resetBeforeTurboCaches()
   }
 
@@ -422,8 +415,6 @@ export class LexicalEditorElement extends HTMLElement {
     },
       ...this.extensions.lexicalExtensions
     )
-
-    if (!this.hasAttribute("defer")) editor.setRootElement(this.editorContentElement)
 
     return editor
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -92,10 +92,20 @@ export class LexicalEditorElement extends HTMLElement {
 
     this.#initialize()
 
-    this.#scheduleEditorInitializedDispatch()
     this.toggleAttribute("connected", true)
 
-    this.#handleAutofocus()
+    if (this.hasAttribute("defer")) {
+      requestAnimationFrame(() => {
+        if (!this.isConnected) return
+        this.editor.setRootElement(this.editorContentElement)
+        this.#loadInitialValue()
+        this.#handleAutofocus()
+        this.#scheduleEditorInitializedDispatch()
+      })
+    } else {
+      this.#scheduleEditorInitializedDispatch()
+      this.#handleAutofocus()
+    }
 
     this.valueBeforeDisconnect = null
   }
@@ -381,7 +391,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.#attachDebugHooks()
     this.#attachToolbar()
     this.#configureSanitizer()
-    this.#loadInitialValue()
+    if (!this.hasAttribute("defer")) this.#loadInitialValue()
     this.#resetBeforeTurboCaches()
   }
 
@@ -411,7 +421,7 @@ export class LexicalEditorElement extends HTMLElement {
       ...this.extensions.lexicalExtensions
     )
 
-    editor.setRootElement(this.editorContentElement)
+    if (!this.hasAttribute("defer")) editor.setRootElement(this.editorContentElement)
 
     return editor
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -53,6 +53,7 @@ export class LexicalEditorElement extends HTMLElement {
 
   #initialValue = ""
   #editorInitializedRafId = null
+  #deferredInitRafId = null
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
@@ -95,22 +96,23 @@ export class LexicalEditorElement extends HTMLElement {
     this.toggleAttribute("connected", true)
 
     if (this.hasAttribute("defer")) {
-      requestAnimationFrame(() => {
-        if (!this.isConnected) return
+      this.#deferredInitRafId = requestAnimationFrame(() => {
+        this.#deferredInitRafId = null
         this.editor.setRootElement(this.editorContentElement)
         this.#loadInitialValue()
         this.#handleAutofocus()
         this.#scheduleEditorInitializedDispatch()
+        this.valueBeforeDisconnect = null
       })
     } else {
       this.#scheduleEditorInitializedDispatch()
       this.#handleAutofocus()
+      this.valueBeforeDisconnect = null
     }
-
-    this.valueBeforeDisconnect = null
   }
 
   disconnectedCallback() {
+    this.#cancelDeferredInit()
     this.#cancelEditorInitializedDispatch()
     this.valueBeforeDisconnect = this.value
     this.#reset() // Prevent hangs with Safari when morphing
@@ -801,6 +803,13 @@ export class LexicalEditorElement extends HTMLElement {
 
     cancelAnimationFrame(this.#editorInitializedRafId)
     this.#editorInitializedRafId = null
+  }
+
+  #cancelDeferredInit() {
+    if (this.#deferredInitRafId == null) return
+
+    cancelAnimationFrame(this.#deferredInitRafId)
+    this.#deferredInitRafId = null
   }
 
   get #resolvedHighlightColors() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -53,7 +53,6 @@ export class LexicalEditorElement extends HTMLElement {
 
   #initialValue = ""
   #editorInitializedRafId = null
-  #deferredInitRafId = null
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
@@ -95,18 +94,16 @@ export class LexicalEditorElement extends HTMLElement {
 
     this.toggleAttribute("connected", true)
 
-    this.#deferredInitRafId = requestAnimationFrame(() => {
-      this.#deferredInitRafId = null
+    requestAnimationFrame(() => {
       this.editor.setRootElement(this.editorContentElement)
-      this.#loadInitialValue()
       this.#handleAutofocus()
       this.#scheduleEditorInitializedDispatch()
-      this.valueBeforeDisconnect = null
     })
+
+    this.valueBeforeDisconnect = null
   }
 
   disconnectedCallback() {
-    this.#cancelDeferredInit()
     this.#cancelEditorInitializedDispatch()
     this.valueBeforeDisconnect = this.value
     this.#reset() // Prevent hangs with Safari when morphing
@@ -387,6 +384,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.#attachDebugHooks()
     this.#attachToolbar()
     this.#configureSanitizer()
+    this.#loadInitialValue()
     this.#resetBeforeTurboCaches()
   }
 
@@ -794,13 +792,6 @@ export class LexicalEditorElement extends HTMLElement {
 
     cancelAnimationFrame(this.#editorInitializedRafId)
     this.#editorInitializedRafId = null
-  }
-
-  #cancelDeferredInit() {
-    if (this.#deferredInitRafId == null) return
-
-    cancelAnimationFrame(this.#deferredInitRafId)
-    this.#deferredInitRafId = null
   }
 
   get #resolvedHighlightColors() {

--- a/test/javascript/native/adapter_registration.test.js
+++ b/test/javascript/native/adapter_registration.test.js
@@ -92,4 +92,27 @@ describe("adapter registration", () => {
 
     expect(initializedPayloads).toHaveLength(1)
   })
+
+  test("dispatches lexxy:initialize when adapter is registered before first frame", async () => {
+    editorElement = await createTestEditor({ skipTick: true })
+
+    const customAdapter = {
+      frozenLinkKey: null,
+      dispatchEditorInitialized() {},
+      dispatchAttributesChange() {},
+      freeze() {},
+      thaw() {},
+      unlinkFrozenNode() {
+        return false
+      }
+    }
+
+    let initializeFired = 0
+    editorElement.addEventListener("lexxy:initialize", () => initializeFired++)
+
+    editorElement.registerAdapter(customAdapter)
+    await tick()
+
+    expect(initializeFired).toBe(1)
+  })
 })

--- a/test/javascript/unit/editor/deferred_init.test.js
+++ b/test/javascript/unit/editor/deferred_init.test.js
@@ -31,4 +31,26 @@ describe("deferred initialization", () => {
 
     expect(editorElement.value).toContain("edited content")
   })
+
+  test("preserves external value set after connectedCallback returns but before rAF fires", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>", skipTick: true })
+
+    editorElement.value = "<p>external write</p>"
+
+    await tick()
+
+    expect(editorElement.value).toContain("external write")
+  })
+
+  test("preserves value attribute across synchronous disconnect/reconnect before rAF fires", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>", skipTick: true })
+
+    const parent = editorElement.parentNode
+    parent.removeChild(editorElement)
+    parent.appendChild(editorElement)
+
+    await tick()
+
+    expect(editorElement.value).toContain("initial")
+  })
 })

--- a/test/javascript/unit/editor/deferred_init.test.js
+++ b/test/javascript/unit/editor/deferred_init.test.js
@@ -53,4 +53,48 @@ describe("deferred initialization", () => {
 
     expect(editorElement.value).toContain("initial")
   })
+
+  test("does not steal focus when value is set externally before rAF fires", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>", skipTick: true })
+
+    let focusEvents = 0
+    editorElement.addEventListener("lexxy:focus", () => focusEvents++)
+
+    editorElement.value = "<p>external write</p>"
+
+    await tick()
+
+    expect(focusEvents).toBe(0)
+  })
+
+  test("value is loaded synchronously so background-tab forms still submit content", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>", skipTick: true })
+
+    expect(editorElement.value).toContain("initial")
+  })
+
+  test("formResetCallback restores initial value before first frame", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>", skipTick: true })
+
+    editorElement.value = "<p>edited</p>"
+    editorElement.formResetCallback()
+
+    expect(editorElement.value).toContain("initial")
+  })
+
+  test("stale rAF firing while disconnected does not poison state on reconnect", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>", skipTick: true })
+
+    editorElement.value = "<p>external</p>"
+
+    const parent = editorElement.parentNode
+    parent.removeChild(editorElement)
+
+    await tick()
+
+    parent.appendChild(editorElement)
+    await tick()
+
+    expect(editorElement.value).toContain("external")
+  })
 })

--- a/test/javascript/unit/editor/deferred_init.test.js
+++ b/test/javascript/unit/editor/deferred_init.test.js
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { createTestEditor, destroyTestEditor, tick } from "../helpers/editor_helper"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+describe("deferred initialization", () => {
+  test("editor.getRootElement() is null until the next animation frame", async () => {
+    editorElement = await createTestEditor({ skipTick: true })
+
+    expect(editorElement.editor.getRootElement()).toBeNull()
+
+    await tick()
+
+    expect(editorElement.editor.getRootElement()).toBe(editorElement.editorContentElement)
+  })
+
+  test("restores valueBeforeDisconnect across disconnect/reconnect", async () => {
+    editorElement = await createTestEditor({ value: "<p>initial</p>" })
+
+    editorElement.value = "<p>edited content</p>"
+    await tick()
+
+    const parent = editorElement.parentNode
+    parent.removeChild(editorElement)
+    parent.appendChild(editorElement)
+    await tick()
+
+    expect(editorElement.value).toContain("edited content")
+  })
+})


### PR DESCRIPTION
Immediate initialization can sometimes cause lag spikes if the parent element is being morphed at the same time. This PR moves initialization to the next animation frame to give the DOM time to flush the pending layout before Lexical attempts to compute geometry.

The root cause of the lag is a forced layout flush caused by Lexical. It has a selection handler that calls `Selection.anchorNode` during `setRootElement`. This forces the browser to immediately flush the layout, persiste pending mutations, and perform style invalidation, all of which pushes the paint back causing causing a visual hang.

This often triggers on navigation with Turbo morph enabled. As morph updates the DOM, Lexxy initializes, and forces the browser to flush all the changes and perform style invalidation, causing the navigation to lag by 50-100ms.

By deferring initialization, navigation is able to complete as normal, the page is laid out and painted, and then Lexxy initializes, and does so much quicker as it doesn't have to perform additional layouts.