### PR TITLE
Improve soft-linebreak handling in toolbar tools

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -64,6 +64,7 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
+    $splitParagraphsAtLineBreakBoundaries(selection)
     $setBlocksType(selection, () => $createParagraphNode())
   }
 
@@ -71,6 +72,7 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
+    $splitParagraphsAtLineBreakBoundaries(selection)
     $setBlocksType(selection, () => $createHeadingNode(tag))
   }
 
@@ -112,10 +114,20 @@ export default class Contents {
     if (allCode) {
       blockElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
+      // We first split the enclosing paragraph at the <br>s on either side of
+      // the selection, so that a one-line selection out of a paragraph with
+      // soft line breaks becomes its own paragraph. We then re-collect block
+      // elements from the updated selection, because the split above is a
+      // no-op when the selection lives inside a container like a blockquote,
+      // where the elements to convert are the container's child paragraphs.
+      $splitParagraphsAtLineBreakBoundaries(selection)
+      const elements = this.#blockLevelElementsInSelection(selection)
+      if (elements.length === 0) return
+
       const codeNode = $createCodeNode("plain")
-      blockElements.at(-1).insertAfter(codeNode)
+      elements.at(-1).insertAfter(codeNode)
       codeNode.selectEnd()
-      this.insertAtCursor(...blockElements)
+      this.insertAtCursor(...elements)
     }
   }
 
@@ -401,6 +413,11 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
+    // Two-pass: first isolate the selected range as its own paragraph so that
+    // <br>s outside the selection stay grouped (boundary-aware); then explode
+    // every <br> within the isolated paragraph so each selected line becomes
+    // its own list item.
+    $splitParagraphsAtLineBreakBoundaries(selection)
     this.#splitParagraphsAtLineBreaks(selection)
   }
 

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -114,12 +114,6 @@ export default class Contents {
     if (allCode) {
       blockElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
-      // We first split the enclosing paragraph at the <br>s on either side of
-      // the selection, so that a one-line selection out of a paragraph with
-      // soft line breaks becomes its own paragraph. We then re-collect block
-      // elements from the updated selection, because the split above is a
-      // no-op when the selection lives inside a container like a blockquote,
-      // where the elements to convert are the container's child paragraphs.
       $splitParagraphsAtLineBreakBoundaries(selection)
       const elements = this.#blockLevelElementsInSelection(selection)
       if (elements.length === 0) return

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -134,9 +134,7 @@ export default class Contents {
     } else {
       topLevelElements.filter($isQuoteNode).forEach(node => this.#unwrap(node))
 
-      $splitParagraphsAtLineBreakBoundaries(selection)
-
-      const elements = this.#topLevelElementsInSelection(selection)
+      const elements = $splitParagraphsAtLineBreakBoundaries(selection)
       if (elements.length === 0) return
 
       const blockquote = $createQuoteNode()
@@ -407,8 +405,6 @@ export default class Contents {
   }
 
   #splitParagraphsAtLineBreaks(selection) {
-    const anchorTopLevel = selection.anchor.getNode().getTopLevelElement()
-    const focusTopLevel = selection.focus.getNode().getTopLevelElement()
     const topLevelElements = this.#topLevelElementsInSelection(selection)
 
     for (const element of topLevelElements) {
@@ -416,13 +412,6 @@ export default class Contents {
 
       const children = element.getChildren()
       if (!children.some($isLineBreakNode)) continue
-
-      // Check whether this paragraph needs splitting: skip only if neither
-      // selection endpoint is inside it (meaning it's a middle paragraph
-      // fully between anchor and focus with no partial lines to split off).
-      // Compare top-level elements so endpoints inside nested inline nodes
-      // (e.g. text inside a LinkNode) are still recognized.
-      if (element !== anchorTopLevel && element !== focusTopLevel) continue
 
       const groups = [ [] ]
       for (const child of children) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -16,7 +16,7 @@ import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_nod
 import { $createActionTextAttachmentUploadNode, ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils"
 import NodeInserter from "./contents/node_inserter"
-import { $isShadowRoot, $splitParagraphsAtLineBreakBoundaries } from "../helpers/lexical_helper"
+import { $expandSelectionToLineBreaksAndSplitAtEdges, $isShadowRoot, $splitSelectedParagraphsAtInnerLineBreaks } from "../helpers/lexical_helper"
 
 export default class Contents {
   constructor(editorElement) {
@@ -64,7 +64,7 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
-    $splitParagraphsAtLineBreakBoundaries(selection)
+    $expandSelectionToLineBreaksAndSplitAtEdges(selection)
     $setBlocksType(selection, () => $createParagraphNode())
   }
 
@@ -72,7 +72,7 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
-    $splitParagraphsAtLineBreakBoundaries(selection)
+    $expandSelectionToLineBreaksAndSplitAtEdges(selection)
     $setBlocksType(selection, () => $createHeadingNode(tag))
   }
 
@@ -114,7 +114,7 @@ export default class Contents {
     if (allCode) {
       blockElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
-      $splitParagraphsAtLineBreakBoundaries(selection)
+      $expandSelectionToLineBreaksAndSplitAtEdges(selection)
       const elements = this.#blockLevelElementsInSelection(selection)
       if (elements.length === 0) return
 
@@ -140,7 +140,7 @@ export default class Contents {
     } else {
       topLevelElements.filter($isQuoteNode).forEach(node => this.#unwrap(node))
 
-      const elements = $splitParagraphsAtLineBreakBoundaries(selection)
+      const elements = $expandSelectionToLineBreaksAndSplitAtEdges(selection)
       if (elements.length === 0) return
 
       const blockquote = $createQuoteNode()
@@ -407,41 +407,8 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
-    // Two-pass: first isolate the selected range as its own paragraph so that
-    // <br>s outside the selection stay grouped (boundary-aware); then explode
-    // every <br> within the isolated paragraph so each selected line becomes
-    // its own list item.
-    $splitParagraphsAtLineBreakBoundaries(selection)
-    this.#splitParagraphsAtLineBreaks(selection)
-  }
-
-  #splitParagraphsAtLineBreaks(selection) {
-    const topLevelElements = this.#topLevelElementsInSelection(selection)
-
-    for (const element of topLevelElements) {
-      if (!$isParagraphNode(element)) continue
-
-      const children = element.getChildren()
-      if (!children.some($isLineBreakNode)) continue
-
-      const groups = [ [] ]
-      for (const child of children) {
-        if ($isLineBreakNode(child)) {
-          groups.push([])
-          child.remove()
-        } else {
-          groups[groups.length - 1].push(child)
-        }
-      }
-
-      for (const group of groups) {
-        if (group.length === 0) continue
-        const paragraph = $createParagraphNode()
-        group.forEach(child => paragraph.append(child))
-        element.insertBefore(paragraph)
-      }
-      if (groups.some(group => group.length > 0)) element.remove()
-    }
+    $expandSelectionToLineBreaksAndSplitAtEdges(selection)
+    $splitSelectedParagraphsAtInnerLineBreaks(selection)
   }
 
   #blockLevelElementsInSelection(selection) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -140,7 +140,8 @@ export default class Contents {
     } else {
       topLevelElements.filter($isQuoteNode).forEach(node => this.#unwrap(node))
 
-      const elements = $expandSelectionToLineBreaksAndSplitAtEdges(selection)
+       $expandSelectionToLineBreaksAndSplitAtEdges(selection)
+      const elements = this.#topLevelElementsInSelection(selection)
       if (elements.length === 0) return
 
       const blockquote = $createQuoteNode()

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -163,19 +163,19 @@ export function $splitParagraphsAtLineBreakBoundaries(selection) {
   // A collapsed cursor adjacent to a <br> would claim it from both sides via
   // inward-edge; force outward-only walks so each side finds its own boundary.
   const skipInwardEdge = selection.isCollapsed()
-  const focusBr = $getCaretAtLineBreakBoundary(focusCaret, skipInwardEdge)
-  let anchorBr = $getCaretAtLineBreakBoundary(anchorCaret, skipInwardEdge)
+  const focusBrCaret = $getCaretAtLineBreakBoundary(focusCaret, skipInwardEdge)
+  let anchorBrCaret = $getCaretAtLineBreakBoundary(anchorCaret, skipInwardEdge)
 
-  if (focusBr?.is(anchorBr)) {
-    anchorBr = null
+  if (focusBrCaret?.origin.is(anchorBrCaret?.origin)) {
+    anchorBrCaret = null
   }
 
   // Splitting focus first keeps the anchor <br>'s position stable.
-  const focusOuter = focusBr ? $splitAroundLineBreak($getSiblingCaret(focusBr, "next")) : null
-  const anchorOuter = anchorBr ? $splitAroundLineBreak($getSiblingCaret(anchorBr, "previous")) : null
+  const focusOuter = focusBrCaret && $splitAroundLineBreak(focusBrCaret)
+  const anchorOuter = anchorBrCaret && $splitAroundLineBreak(anchorBrCaret)
 
-  const innerStart = anchorOuter ? anchorOuter.getNextSibling() : selection.anchor.getNode().getTopLevelElement()
-  const innerEnd = focusOuter ? focusOuter.getPreviousSibling() : selection.focus.getNode().getTopLevelElement()
+  const innerStart = anchorOuter?.getNextSibling() ?? selection.anchor.getNode().getTopLevelElement()
+  const innerEnd = focusOuter?.getPreviousSibling() ?? selection.focus.getNode().getTopLevelElement()
   if (!innerStart || !innerEnd) return []
 
   const paragraphs = []
@@ -191,11 +191,10 @@ function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {
   const paragraph = caret.origin.getTopLevelElement()
   if (!paragraph || !$isParagraphNode(paragraph)) return null
 
-  if (!skipInwardEdge) {
-    const br = $inwardEdgeLineBreak(caret, paragraph)
-    if (br) return br
-  }
-  return $outwardLineBreak(caret, paragraph)
+  const lineBreak = (skipInwardEdge ? null : $inwardEdgeLineBreak(caret, paragraph))
+    ?? $outwardLineBreak(caret, paragraph)
+
+  return lineBreak ? $getSiblingCaret(lineBreak, caret.direction) : null
 }
 
 // Prefer a <br> the cursor is sitting flush against, except when a further <br>

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -233,11 +233,11 @@ function $candidateUnlessShadowed(candidateCaret) {
 
 function $outwardLineBreak(caret, paragraph) {
   const startCaret = $outwardWalkStartCaret(caret, paragraph)
-  if (startCaret) {
-    for (const c of startCaret) {
-      if (!c.origin.getParent()?.is(paragraph)) break
-      if ($isLineBreakNode(c.origin)) return c.origin
-    }
+  if (!startCaret) return null
+
+  for (const { origin } of startCaret) {
+    if (!origin.getParent().is(paragraph)) break
+    if ($isLineBreakNode(origin)) return origin
   }
   return null
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -154,7 +154,40 @@ export function isAttachmentSpacerTextNode(node, previousNode, index, childCount
     && previousNode instanceof CustomActionTextAttachmentNode
 }
 
-export function $splitParagraphsAtLineBreakBoundaries(selection) {
+export function $splitSelectedParagraphsAtInnerLineBreaks(selection) {
+  const topLevelElements = new Set()
+  for (const node of selection.getNodes()) {
+    const topLevel = node.getTopLevelElement()
+    if (topLevel) topLevelElements.add(topLevel)
+  }
+
+  for (const element of topLevelElements) {
+    if (!$isParagraphNode(element)) continue
+
+    const children = element.getChildren()
+    if (!children.some($isLineBreakNode)) continue
+
+    const groups = [ [] ]
+    for (const child of children) {
+      if ($isLineBreakNode(child)) {
+        groups.push([])
+        child.remove()
+      } else {
+        groups[groups.length - 1].push(child)
+      }
+    }
+
+    for (const group of groups) {
+      if (group.length === 0) continue
+      const paragraph = $createParagraphNode()
+      group.forEach(child => paragraph.append(child))
+      element.insertBefore(paragraph)
+    }
+    if (groups.some(group => group.length > 0)) element.remove()
+  }
+}
+
+export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
   $ensureForwardRangeSelection(selection)
 
   const focusCaret = $caretFromPoint(selection.focus, "next")

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -271,7 +271,7 @@ function $outwardLineBreak(caret, paragraph) {
 }
 
 function $outwardWalkStartCaret(caret, paragraph) {
-  if (caret.getParentAtCaret()?.is(paragraph)) {
+  if (caret.getParentAtCaret().is(paragraph)) {
     return caret
   } else {
     return $paragraphChildCaretContaining(caret, paragraph)

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,4 +1,4 @@
-import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCommonAncestor, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $rewindSiblingCaret, $splitAtPointCaretNext, TextNode } from "lexical"
+import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
@@ -216,7 +216,15 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
     paragraphs.push(c.origin)
     if (c.origin.is(innerEnd)) break
   }
-  $selectParagraphs(selection, paragraphs)
+
+  $setSelectionFromCaretRange($getCaretRange(
+    $normalizeCaret($getChildCaret(innerStart, "next")),
+    $getCaretInDirection(
+      $normalizeCaret($getChildCaret(innerEnd, "previous")),
+      "next",
+    ),
+  ))
+
   return paragraphs
 }
 
@@ -314,23 +322,3 @@ function $splitAroundLineBreak(lineBreakCaret) {
   return outer
 }
 
-function $selectParagraphs(selection, paragraphs) {
-  if (paragraphs.length > 0) {
-    const first = paragraphs[0]
-    const last = paragraphs[paragraphs.length - 1]
-    const firstLeaf = first.getFirstDescendant() ?? first
-    const lastLeaf = last.getLastDescendant() ?? last
-
-    if ($isTextNode(firstLeaf)) {
-      selection.anchor.set(firstLeaf.getKey(), 0, "text")
-    } else {
-      selection.anchor.set(first.getKey(), 0, "element")
-    }
-
-    if ($isTextNode(lastLeaf)) {
-      selection.focus.set(lastLeaf.getKey(), lastLeaf.getTextContentSize(), "text")
-    } else {
-      selection.focus.set(last.getKey(), last.getChildrenSize(), "element")
-    }
-  }
-}

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -160,18 +160,14 @@ export function $splitParagraphsAtLineBreakBoundaries(selection) {
   const focusCaret = $caretFromPoint(selection.focus, "next")
   const anchorCaret = $caretFromPoint(selection.anchor, "previous")
 
-  let focusBr = $boundaryLineBreak(focusCaret)
-  let anchorBr = $boundaryLineBreak(anchorCaret)
+  // A collapsed cursor adjacent to a <br> would claim it from both sides via
+  // inward-edge; force outward-only walks so each side finds its own boundary.
+  const skipInwardEdge = selection.isCollapsed()
+  const focusBr = $getCaretAtLineBreakBoundary(focusCaret, skipInwardEdge)
+  let anchorBr = $getCaretAtLineBreakBoundary(anchorCaret, skipInwardEdge)
 
-  // A collapsed cursor adjacent to a <br> claims it via inward-edge on one
-  // side and outward walk on the other; force outward-only on both so each
-  // side finds its own boundary.
-  if (focusBr && anchorBr && focusBr.is(anchorBr)) {
-    focusBr = $boundaryLineBreak(focusCaret, true)
-    anchorBr = $boundaryLineBreak(anchorCaret, true)
-    if (focusBr && anchorBr && focusBr.is(anchorBr)) {
-      anchorBr = null
-    }
+  if (focusBr?.is(anchorBr)) {
+    anchorBr = null
   }
 
   // Splitting focus first keeps the anchor <br>'s position stable.
@@ -191,7 +187,7 @@ export function $splitParagraphsAtLineBreakBoundaries(selection) {
   return paragraphs
 }
 
-function $boundaryLineBreak(caret, skipInwardEdge = false) {
+function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {
   const paragraph = caret.origin.getTopLevelElement()
   if (!paragraph || !$isParagraphNode(paragraph)) return null
 

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,4 +1,4 @@
-import { $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCommonAncestor, $getSelection, $getSiblingCaret, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isTextNode, $splitNode, LineBreakNode, TextNode } from "lexical"
+import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCommonAncestor, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $rewindSiblingCaret, $splitAtPointCaretNext, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
@@ -157,33 +157,155 @@ export function isAttachmentSpacerTextNode(node, previousNode, index, childCount
 export function $splitParagraphsAtLineBreakBoundaries(selection) {
   $ensureForwardRangeSelection(selection)
 
-  // Split focus first so the anchor split position stays valid.
-  $splitAtNearestLineBreak(selection.focus, "next")
-  $splitAtNearestLineBreak(selection.anchor, "previous")
-}
+  const focusCaret = $caretFromPoint(selection.focus, "next")
+  const anchorCaret = $caretFromPoint(selection.anchor, "previous")
 
-function $splitAtNearestLineBreak(point, direction) {
-  const paragraph = point.getNode().getTopLevelElement()
-  if (!paragraph || !$isParagraphNode(paragraph)) return
+  let focusBr = $boundaryLineBreak(focusCaret)
+  let anchorBr = $boundaryLineBreak(anchorCaret)
 
-  const pointNode = point.getNode()
-  const selectionChild = pointNode.getParent().is(paragraph) ? pointNode : pointNode.getParentOrThrow()
-  const lineBreakCaret = $caretAtNearestNodeOfType(selectionChild, LineBreakNode, direction)
-  if (!lineBreakCaret) return
-
-  const lineBreak = lineBreakCaret.origin
-  const isEdge = lineBreakCaret.getNodeAtCaret() === null
-
-  if (!isEdge) {
-    $splitNode(paragraph, lineBreak.getIndexWithinParent())
+  // A collapsed cursor adjacent to a <br> claims it via inward-edge on one
+  // side and outward walk on the other; force outward-only on both so each
+  // side finds its own boundary.
+  if (focusBr && anchorBr && focusBr.is(anchorBr)) {
+    focusBr = $boundaryLineBreak(focusCaret, true)
+    anchorBr = $boundaryLineBreak(anchorCaret, true)
+    if (focusBr && anchorBr && focusBr.is(anchorBr)) {
+      anchorBr = null
+    }
   }
 
-  lineBreak.remove()
+  // Splitting focus first keeps the anchor <br>'s position stable.
+  const focusOuter = focusBr ? $splitAroundLineBreak($getSiblingCaret(focusBr, "next")) : null
+  const anchorOuter = anchorBr ? $splitAroundLineBreak($getSiblingCaret(anchorBr, "previous")) : null
+
+  const innerStart = anchorOuter ? anchorOuter.getNextSibling() : selection.anchor.getNode().getTopLevelElement()
+  const innerEnd = focusOuter ? focusOuter.getPreviousSibling() : selection.focus.getNode().getTopLevelElement()
+  if (!innerStart || !innerEnd) return []
+
+  const paragraphs = []
+  for (const c of $rewindSiblingCaret($getSiblingCaret(innerStart, "next"))) {
+    paragraphs.push(c.origin)
+    if (c.origin.is(innerEnd)) break
+  }
+  $selectParagraphs(selection, paragraphs)
+  return paragraphs
 }
 
-function $caretAtNearestNodeOfType(node, klass, direction) {
-  for (const caret of $getSiblingCaret(node, direction)) {
-    if (caret.origin instanceof klass) return caret
+function $boundaryLineBreak(caret, skipInwardEdge = false) {
+  const paragraph = caret.origin.getTopLevelElement()
+  if (!paragraph || !$isParagraphNode(paragraph)) return null
+
+  if (!skipInwardEdge) {
+    const br = $inwardEdgeLineBreak(caret, paragraph)
+    if (br) return br
+  }
+  return $outwardLineBreak(caret, paragraph)
+}
+
+// Prefer a <br> the cursor is sitting flush against, except when a further <br>
+// also exists outward — that one is the real paragraph break for this side.
+function $inwardEdgeLineBreak(caret, paragraph) {
+  let candidateCaret
+
+  if (
+    ($isChildCaret(caret) && caret.origin.is(paragraph)) ||
+    ($isTextPointCaret(caret) && $isExtendableTextPointCaret(caret.getFlipped()))
+  ) {
+    candidateCaret = null
+  } else if ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph)) {
+    candidateCaret = caret
+  } else {
+    const childCaret = $paragraphChildAtInwardEdge(caret, paragraph)
+    candidateCaret = childCaret ? $rewindSiblingCaret(childCaret) : null
+  }
+
+  if (candidateCaret && $isLineBreakNode(candidateCaret.origin)) {
+    return $candidateUnlessShadowed(candidateCaret)
+  } else {
+    return null
+  }
+}
+
+function $candidateUnlessShadowed(candidateCaret) {
+  const outward = candidateCaret.getNodeAtCaret()
+  return $isLineBreakNode(outward) ? null : candidateCaret.origin
+}
+
+function $outwardLineBreak(caret, paragraph) {
+  const startCaret = $outwardWalkStartCaret(caret, paragraph)
+  if (startCaret) {
+    for (const c of startCaret) {
+      if (!c.origin.getParent()?.is(paragraph)) break
+      if ($isLineBreakNode(c.origin)) return c.origin
+    }
   }
   return null
+}
+
+function $outwardWalkStartCaret(caret, paragraph) {
+  if (
+    ($isChildCaret(caret) && caret.origin.is(paragraph)) ||
+    ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph))
+  ) {
+    return caret
+  } else {
+    return $paragraphChildContaining(caret, paragraph)
+  }
+}
+
+function $paragraphChildContaining(caret, paragraph) {
+  let cursor = caret.getSiblingCaret()
+  while (cursor && !cursor.origin.getParent()?.is(paragraph)) {
+    cursor = cursor.getParentCaret()
+  }
+  return cursor?.origin.getParent()?.is(paragraph) ? cursor : null
+}
+
+// Only succeeds when the cursor is flush against the inward edge of every
+// ancestor between itself and the paragraph child.
+function $paragraphChildAtInwardEdge(caret, paragraph) {
+  let cursor = caret.getSiblingCaret()
+  while (cursor && !cursor.origin.getParent()?.is(paragraph)) {
+    if (cursor.getNodeAtCaret()) return null
+    cursor = cursor.getParentCaret()
+  }
+  return cursor?.origin.getParent()?.is(paragraph) ? cursor : null
+}
+
+function $splitAroundLineBreak(lineBreakCaret) {
+  let outer = null
+
+  if (lineBreakCaret.getNodeAtCaret() === null) {
+    lineBreakCaret.origin.remove()
+  } else {
+    const lineBreak = lineBreakCaret.origin
+    const splitCaret = $getCaretInDirection($rewindSiblingCaret(lineBreakCaret), "next")
+
+    $splitAtPointCaretNext(splitCaret)
+    outer = lineBreak.getTopLevelElement()
+    lineBreak.remove()
+  }
+
+  return outer
+}
+
+function $selectParagraphs(selection, paragraphs) {
+  if (paragraphs.length > 0) {
+    const first = paragraphs[0]
+    const last = paragraphs[paragraphs.length - 1]
+    const firstLeaf = first.getFirstDescendant() ?? first
+    const lastLeaf = last.getLastDescendant() ?? last
+
+    if ($isTextNode(firstLeaf)) {
+      selection.anchor.set(firstLeaf.getKey(), 0, "text")
+    } else {
+      selection.anchor.set(first.getKey(), 0, "element")
+    }
+
+    if ($isTextNode(lastLeaf)) {
+      selection.focus.set(lastLeaf.getKey(), lastLeaf.getTextContentSize(), "text")
+    } else {
+      selection.focus.set(last.getKey(), last.getChildrenSize(), "element")
+    }
+  }
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -215,7 +215,7 @@ function $inwardEdgeLineBreak(caret, paragraph) {
   } else if ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph)) {
     candidateCaret = caret
   } else {
-    const childCaret = $paragraphChildAtInwardEdge(caret, paragraph)
+    const childCaret = $paragraphChildCaretAtInwardEdge(caret, paragraph)
     candidateCaret = childCaret ? $rewindSiblingCaret(childCaret) : null
   }
 
@@ -249,11 +249,11 @@ function $outwardWalkStartCaret(caret, paragraph) {
   ) {
     return caret
   } else {
-    return $paragraphChildContaining(caret, paragraph)
+    return $paragraphChildCaretContaining(caret, paragraph)
   }
 }
 
-function $paragraphChildContaining(caret, paragraph) {
+function $paragraphChildCaretContaining(caret, paragraph) {
   let cursor = caret.getSiblingCaret()
   while (cursor && !cursor.origin.getParent()?.is(paragraph)) {
     cursor = cursor.getParentCaret()
@@ -263,7 +263,7 @@ function $paragraphChildContaining(caret, paragraph) {
 
 // Only succeeds when the cursor is flush against the inward edge of every
 // ancestor between itself and the paragraph child.
-function $paragraphChildAtInwardEdge(caret, paragraph) {
+function $paragraphChildCaretAtInwardEdge(caret, paragraph) {
   let cursor = caret.getSiblingCaret()
   while (cursor && !cursor.origin.getParent()?.is(paragraph)) {
     if (cursor.getNodeAtCaret()) return null

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -243,10 +243,7 @@ function $outwardLineBreak(caret, paragraph) {
 }
 
 function $outwardWalkStartCaret(caret, paragraph) {
-  if (
-    ($isChildCaret(caret) && caret.origin.is(paragraph)) ||
-    ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph))
-  ) {
+  if (caret.getParentAtCaret()?.is(paragraph)) {
     return caret
   } else {
     return $paragraphChildCaretContaining(caret, paragraph)

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -209,13 +209,7 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
 
   const innerStart = anchorOuter?.getNextSibling() ?? selection.anchor.getNode().getTopLevelElement()
   const innerEnd = focusOuter?.getPreviousSibling() ?? selection.focus.getNode().getTopLevelElement()
-  if (!innerStart || !innerEnd) return []
-
-  const paragraphs = []
-  for (const c of $rewindSiblingCaret($getSiblingCaret(innerStart, "next"))) {
-    paragraphs.push(c.origin)
-    if (c.origin.is(innerEnd)) break
-  }
+  if (!innerStart || !innerEnd) return
 
   $setSelectionFromCaretRange($getCaretRange(
     $normalizeCaret($getChildCaret(innerStart, "next")),
@@ -224,8 +218,6 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
       "next",
     ),
   ))
-
-  return paragraphs
 }
 
 function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -212,7 +212,7 @@ function $inwardEdgeLineBreak(caret, paragraph) {
     ($isTextPointCaret(caret) && $isExtendableTextPointCaret(caret.getFlipped()))
   ) {
     candidateCaret = null
-  } else if ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph)) {
+  } else if ($isSiblingCaret(caret) && caret.getParentAtCaret().is(paragraph)) {
     candidateCaret = caret
   } else {
     const childCaret = $paragraphChildCaretAtInwardEdge(caret, paragraph)

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -154,6 +154,117 @@ test.describe("Block formatting", () => {
     )
   })
 
+  test("quote only the selected line when browser selection uses paragraph offsets", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue("<p>First line<br>Second line<br>Third line</p>")
+
+    await editor.content.evaluate((el) => {
+      const paragraph = el.querySelector("p")
+      const range = document.createRange()
+      range.setStart(paragraph, 2)
+      range.setEnd(paragraph, 3)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>First line</p><blockquote><p>Second line</p></blockquote><p>Third line</p>",
+    )
+  })
+
+  test("quote wraps only the current line when cursor is collapsed at end of a middle line", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue("<p>aaaa<br>bbbb<br>cccc</p>")
+
+    await editor.content.evaluate((el) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let bbbb
+      let node
+      while ((node = walker.nextNode())) {
+        if (node.nodeValue === "bbbb") bbbb = node
+      }
+      const range = document.createRange()
+      range.setStart(bbbb, 4)
+      range.setEnd(bbbb, 4)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>aaaa</p><blockquote><p>bbbb</p></blockquote><p>cccc</p>",
+    )
+  })
+
+  test("quote wraps only the current line when cursor is collapsed at end of first line", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue("<p>aaaa<br>bbbb<br>cccc</p>")
+
+    await editor.content.evaluate((el) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let aaaa
+      let node
+      while ((node = walker.nextNode())) {
+        if (node.nodeValue === "aaaa") aaaa = node
+      }
+      const range = document.createRange()
+      range.setStart(aaaa, 4)
+      range.setEnd(aaaa, 4)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>aaaa</p></blockquote><p>bbbb<br>cccc</p>",
+    )
+  })
+
+  test("quote wraps only the current line when cursor is collapsed at start of a middle line", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue("<p>aaaa<br>bbbb<br>cccc<br>dddd</p>")
+
+    await editor.content.evaluate((el) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let bbbb
+      let node
+      while ((node = walker.nextNode())) {
+        if (node.nodeValue === "bbbb") bbbb = node
+      }
+      const range = document.createRange()
+      range.setStart(bbbb, 0)
+      range.setEnd(bbbb, 0)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>aaaa</p><blockquote><p>bbbb</p></blockquote><p>cccc<br>dddd</p>",
+    )
+  })
+
   test("quote preserves line breaks when entire paragraph with BRs is selected", async ({
     page,
     editor,
@@ -270,6 +381,21 @@ test.describe("Block formatting", () => {
     )
   })
 
+  test("bullet list explodes BRs in middle paragraphs of a multi-paragraph selection", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue("<p>aa<br>bb</p><p>cc<br>dd</p><p>ee<br>ff</p>")
+    await editor.selectAll()
+
+    await page.getByRole("button", { name: "Bullet list" }).click()
+
+    await assertEditorHtml(
+      editor,
+      '<ul><li value="1">aa</li><li value="2">bb</li><li value="3">cc</li><li value="4">dd</li><li value="5">ee</li><li value="6">ff</li></ul>',
+    )
+  })
+
   test("shift+enter inside a list item creates a line break, not a new item", async ({
     editor,
   }) => {
@@ -369,4 +495,90 @@ test.describe("Block formatting", () => {
     await expect(input).toBeVisible({ timeout: 2_000 })
     await expect(input).toHaveValue("")
   })
+})
+
+test.describe("Blockquote selection matrix", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  async function selectRange(editor, anchor, focus) {
+    await editor.content.evaluate((el, args) => {
+      function resolve(spec) {
+        const target = el.querySelector(spec.selector)
+        if (spec.kind === "para") {
+          return [target, spec.childIndex]
+        }
+        const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT)
+        return [walker.nextNode(), spec.offset]
+      }
+      const [aNode, aOff] = resolve(args.anchor)
+      const [fNode, fOff] = resolve(args.focus)
+      const sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.setBaseAndExtent(aNode, aOff, fNode, fOff)
+    }, { anchor, focus })
+  }
+
+  const t = (selector, offset) => ({ kind: "text", selector, offset })
+  const p = (selector, childIndex) => ({ kind: "para", selector, childIndex })
+
+  const PLAIN = "<p>aaaa<br><br>bbbb</p>"
+  const LINK = '<p><a href="https://example.com/">aaaa</a><br><br><a href="https://example.com/">bbbb</a></p>'
+
+  const PLAIN_AAAA = 'p > span:nth-of-type(1)'
+  const PLAIN_BBBB = 'p > span:nth-of-type(2)'
+  const A1 = 'p > a:nth-of-type(1)'
+  const A2 = 'p > a:nth-of-type(2)'
+
+  const A = '<a href="https://example.com/">aaaa</a>'
+  const B = '<a href="https://example.com/">bbbb</a>'
+
+  const cases = [
+    { name: "01. <p>|aaaa|<br><br>bbbb</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 0), focus: t(PLAIN_AAAA, 4), expected: "<blockquote><p>aaaa</p></blockquote><p><br>bbbb</p>" },
+    { name: "02. <p>|aaaa<br>|<br>bbbb</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 0), focus: p("p", 2),        expected: "<blockquote><p>aaaa<br></p></blockquote><p>bbbb</p>" },
+    { name: "03. <p>|aaaa<br><br>|bbbb</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 0), focus: t(PLAIN_BBBB, 0), expected: "<blockquote><p>aaaa<br></p></blockquote><p>bbbb</p>" },
+    { name: "04. <p>|aaaa<br><br>bbbb|</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 0), focus: t(PLAIN_BBBB, 4), expected: "<blockquote><p>aaaa<br><br>bbbb</p></blockquote>" },
+    { name: "05. <p>aaaa|<br>|<br>bbbb</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 4), focus: p("p", 2),        expected: "<p>aaaa</p><blockquote><p><br></p></blockquote><p>bbbb</p>" },
+    { name: "06. <p>aaaa|<br><br>|bbbb</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 4), focus: t(PLAIN_BBBB, 0), expected: "<p>aaaa</p><blockquote><p><br></p></blockquote><p>bbbb</p>" },
+    { name: "07. <p>aaaa|<br><br>bbbb|</p>",                     html: PLAIN, anchor: t(PLAIN_AAAA, 4), focus: t(PLAIN_BBBB, 4), expected: "<p>aaaa</p><blockquote><p><br>bbbb</p></blockquote>" },
+    { name: "08. <p>aaaa<br>|<br>|bbbb</p>",                     html: PLAIN, anchor: p("p", 2),        focus: t(PLAIN_BBBB, 0), expected: "<p>aaaa</p><blockquote><p><br></p></blockquote><p>bbbb</p>" },
+    { name: "09. <p>aaaa<br>|<br>bbbb|</p>",                     html: PLAIN, anchor: p("p", 2),        focus: t(PLAIN_BBBB, 4), expected: "<p>aaaa</p><blockquote><p><br>bbbb</p></blockquote>" },
+    { name: "10. <p>aaaa<br><br>|bbbb|</p>",                     html: PLAIN, anchor: t(PLAIN_BBBB, 0), focus: t(PLAIN_BBBB, 4), expected: "<p>aaaa<br></p><blockquote><p>bbbb</p></blockquote>" },
+
+    { name: "11. <p>|<a>aaaa</a>|<br><br><a>bbbb</a></p>",       html: LINK,  anchor: p("p", 0),    focus: p("p", 1),    expected: `<blockquote><p>${A}</p></blockquote><p><br>${B}</p>` },
+    { name: "12. <p>|<a>aaaa</a><br>|<br><a>bbbb</a></p>",       html: LINK,  anchor: p("p", 0),    focus: p("p", 2),    expected: `<blockquote><p>${A}<br></p></blockquote><p>${B}</p>` },
+    { name: "13. <p>|<a>aaaa</a><br><br>|<a>bbbb</a></p>",       html: LINK,  anchor: p("p", 0),    focus: p("p", 3),    expected: `<blockquote><p>${A}<br></p></blockquote><p>${B}</p>` },
+    { name: "14. <p>|<a>aaaa</a><br><br><a>|bbbb</a></p>",       html: LINK,  anchor: p("p", 0),    focus: t(A2, 0),     expected: `<blockquote><p>${A}<br></p></blockquote><p>${B}</p>` },
+    { name: "15. <p>|<a>aaaa</a><br><br><a>bbbb|</a></p>",       html: LINK,  anchor: p("p", 0),    focus: t(A2, 4),     expected: `<blockquote><p>${A}<br><br>${B}</p></blockquote>` },
+    { name: "16. <p><a>aaaa|</a><br>|<br><a>bbbb</a></p>",       html: LINK,  anchor: t(A1, 4),     focus: p("p", 2),    expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "17. <p><a>aaaa|</a><br><br>|<a>bbbb</a></p>",       html: LINK,  anchor: t(A1, 4),     focus: p("p", 3),    expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "18. <p><a>aaaa|</a><br><br><a>|bbbb</a></p>",       html: LINK,  anchor: t(A1, 4),     focus: t(A2, 0),     expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "19. <p><a>aaaa|</a><br><br><a>bbbb|</a></p>",       html: LINK,  anchor: t(A1, 4),     focus: t(A2, 4),     expected: `<p>${A}</p><blockquote><p><br>${B}</p></blockquote>` },
+    { name: "20. <p><a>aaaa</a>|<br>|<br><a>bbbb</a></p>",       html: LINK,  anchor: p("p", 1),    focus: p("p", 2),    expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "21. <p><a>aaaa</a>|<br><br>|<a>bbbb</a></p>",       html: LINK,  anchor: p("p", 1),    focus: p("p", 3),    expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "22. <p><a>aaaa</a>|<br><br><a>|bbbb</a></p>",       html: LINK,  anchor: p("p", 1),    focus: t(A2, 0),     expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "23. <p><a>aaaa</a>|<br><br><a>bbbb|</a></p>",       html: LINK,  anchor: p("p", 1),    focus: t(A2, 4),     expected: `<p>${A}</p><blockquote><p><br>${B}</p></blockquote>` },
+    { name: "24. <p><a>aaaa</a><br>|<br>|<a>bbbb</a></p>",       html: LINK,  anchor: p("p", 2),    focus: p("p", 3),    expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "25. <p><a>aaaa</a><br>|<br><a>|bbbb</a></p>",       html: LINK,  anchor: p("p", 2),    focus: t(A2, 0),     expected: `<p>${A}</p><blockquote><p><br></p></blockquote><p>${B}</p>` },
+    { name: "26. <p><a>aaaa</a><br>|<br><a>bbbb|</a></p>",       html: LINK,  anchor: p("p", 2),    focus: t(A2, 4),     expected: `<p>${A}</p><blockquote><p><br>${B}</p></blockquote>` },
+  ]
+
+  for (const c of cases) {
+    test(c.name, async ({ page, editor }) => {
+      await editor.setValue(c.html)
+      await selectRange(editor, c.anchor, c.focus)
+      await page.getByRole("button", { name: "Quote" }).click()
+      await assertEditorHtml(editor, c.expected)
+    })
+
+    test(c.name + " reversed", async ({ page, editor }) => {
+      await editor.setValue(c.html)
+      await selectRange(editor, c.focus, c.anchor)
+      await page.getByRole("button", { name: "Quote" }).click()
+      await assertEditorHtml(editor, c.expected)
+    })
+  }
 })


### PR DESCRIPTION
Makes the block-toggle toolbar tools (Quote, Code, Normal, Large/Medium/Small Heading, Bullet/Numbered list) treat soft line breaks as paragraph-like boundaries. Selecting a single line out of a paragraph with `<br>`s now converts only that line, leaving the surrounding lines as a paragraph with their `<br>`s intact.

Problems being solved by these commits:

### Blockquote tool handles `<br>` boundary selection

``` html
<p>
  Sentence 1 in a paragraph followed by two soft line breaks.<br/><br/>
  Sentence 2 in the same paragraph.
</p>
```

Starting or ending a selection on a `<br>`:

https://github.com/user-attachments/assets/cb3d81c0-a2e6-4b92-9dfd-9dec15e6e856

https://github.com/user-attachments/assets/58891d9b-a28c-46d5-b5d0-3e3156b1d809


Cursor on a whitespace boundary:

https://github.com/user-attachments/assets/93ea31c1-3034-465e-ae8e-1b952acf0b0c

https://github.com/user-attachments/assets/6df640df-d95a-4c99-b779-fe9ae83d5e9a


A 26-case matrix in block_formatting.test.js exercises every combination of anchor and focus position (text/paragraph offsets, segment edges, between <br>s) against plain and linked single-paragraph content.


### Apply these `<br>` fixes to remaining block-toggle tools

``` html
<p>
  aaaa<br>bbbb<br>cccc<br>dddd
</p>
```

Selecting a single line out of a paragraph with soft line breaks now converts only that line, leaving the surrounding lines as a paragraph with their `<br>`s intact.

- Code
- Heading
- Lists


https://github.com/user-attachments/assets/3f29702b-4946-4881-9f18-7efa896b6d8c

https://github.com/user-attachments/assets/864602c7-ee04-4489-9cf6-d5dfe989daec

The list tools use a two-pass approach: first the boundary-aware helper isolates the selected range as its own paragraph (preserving outside `<br>`s), then the existing `#splitParagraphsAtLineBreaks` explodes every `<br>` inside that paragraph so each selected line becomes its own list item.


### Explode BRs in middle (non-terminal) paragraphs of a multi-paragraph list selection

``` html
<p>aaaa<br/>bbbb<br/>cccc</p>
<p>dddd<br/>eeee<br/>ffff</p>
<p>gggg<br/>hhhh<br/>iiii</p>
```

https://github.com/user-attachments/assets/831b3770-bf22-4021-bef9-cfd3a66f002a

https://github.com/user-attachments/assets/cdc94c3d-2248-4b98-9be4-295de4f5b507



