### PR TITLE
Stop propagation of the triple-click to prevent Lexical's handler from running

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -40,6 +40,7 @@ import { RewritableHistoryExtension } from "../extensions/rewritable_history_ext
 import { AttachmentsExtension } from "../extensions/attachments_extension.js"
 import { FormatEscapeExtension } from "../extensions/format_escape_extension.js"
 import { LinkOpenerExtension } from "../extensions/link_opener_extension.js"
+import { PreventLexicalTripleClickExtension } from "../extensions/prevent_lexical_triple_click_extension.js"
 
 
 export class LexicalEditorElement extends HTMLElement {
@@ -152,7 +153,8 @@ export class LexicalEditorElement extends HTMLElement {
       RewritableHistoryExtension,
       AttachmentsExtension,
       FormatEscapeExtension,
-      LinkOpenerExtension
+      LinkOpenerExtension,
+      PreventLexicalTripleClickExtension
     ]
   }
 

--- a/src/extensions/prevent_lexical_triple_click_extension.js
+++ b/src/extensions/prevent_lexical_triple_click_extension.js
@@ -1,0 +1,35 @@
+import { defineExtension } from "lexical"
+import { registerEventListener } from "../helpers/listener_helper"
+import LexxyExtension from "./lexxy_extension"
+
+export class PreventLexicalTripleClickExtension extends LexxyExtension {
+  get lexicalExtension() {
+    return defineExtension({
+      name: "lexxy/prevent-lexical-triple-click",
+      register: (editor) => editor.registerRootListener((rootElement) => {
+        if (rootElement) {
+          return registerEventListener(
+            rootElement,
+            "click",
+            this.#handleTripleClick.bind(this),
+            { capture: true }
+          )
+        }
+      })
+    })
+  }
+
+  // Stop propagation of the triple-click to prevent Lexical's handler from running.
+  //
+  // Lexical's onClick handler implements a triple-click handler that is trivial/anemic/naïve. The
+  // intention of the change, made in facebook/lexical#4512, seems to be to deal with browsers'
+  // "overselection" behavior, where a triple-click selection might end at offset 0 of the following
+  // block, which can cause issues when transforming the selection. But the implementation breaks
+  // many common real-world use cases and Lexxy does not demonstrate the behavior it's intended to
+  // work around (in headers or tables).
+  #handleTripleClick(event) {
+    if (event.detail === 3) {
+      event.stopPropagation()
+    }
+  }
+}

--- a/test/browser/tests/editor/prevent_lexical_triple_click.test.js
+++ b/test/browser/tests/editor/prevent_lexical_triple_click.test.js
@@ -1,0 +1,52 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+async function readSelection(page) {
+  const selected = await page.evaluate(() => window.getSelection().toString())
+  return selected.replace(/\s+/g, " ").trim()
+}
+
+async function tripleClickDrag(page, fromPoint, toPoint) {
+  await page.mouse.move(fromPoint.x, fromPoint.y)
+  await page.mouse.down({ clickCount: 1 })
+  await page.mouse.up({ clickCount: 1 })
+  await page.mouse.down({ clickCount: 2 })
+  await page.mouse.up({ clickCount: 2 })
+  await page.mouse.down({ clickCount: 3 })
+  await page.mouse.move(toPoint.x, toPoint.y, { steps: 5 })
+  await page.mouse.up({ clickCount: 3 })
+}
+
+function lineMidCenter(box) {
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+function lineMidRight(box) {
+  return { x: box.x + box.width - 1, y: box.y + box.height / 2 }
+}
+
+const TWO_PARAGRAPHS = "<p>P1 Line one<br>P1 Line two<br>P1 Line three</p><p>P2 Line one<br>P2 Line two<br>P2 Line three</p>"
+
+test.describe("Prevent Lexical triple-click", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    await editor.setValue(TWO_PARAGRAPHS)
+    await editor.flush()
+  })
+
+  test("triple-clicking 'P1 Line two' selects only that visual line", async ({ page, editor }) => {
+    await editor.content.locator("p span", { hasText: "P1 Line two" }).first().click({ clickCount: 3 })
+
+    expect(await readSelection(page)).toBe("P1 Line two")
+  })
+
+  test("triple-click and drag from 'P1 Line two' to 'P2 Line two' selects only the four spanned lines", async ({ page, editor }) => {
+    const fromBox = await editor.content.locator("p span", { hasText: "P1 Line two" }).first().boundingBox()
+    const toBox = await editor.content.locator("p span", { hasText: "P2 Line two" }).first().boundingBox()
+
+    await tripleClickDrag(page, lineMidCenter(fromBox), lineMidRight(toBox))
+
+    expect(await readSelection(page)).toBe("P1 Line two P1 Line three P2 Line one P2 Line two")
+  })
+})


### PR DESCRIPTION
Lexical's onClick handler implements a triple-click handler that is trivial/anemic/naïve. The intention of the change, made in facebook/lexical#4512, seems to be to deal with browsers' "overselection" behavior, where a triple-click selection might end at offset 0 of the following block, which can cause issues when transforming the selection. But the implementation breaks many common real-world use cases.

An upstream bug report was filed in June 2025 for this behavior: https://github.com/facebook/lexical/issues/7592

Just to name two common impacted scenarios that are top-of-mind:

- triple-clicking in a paragraph with soft line breaks (`<br>` tags)
- triple-click-dragging to select multiple lines

The specific motivating reason for Lexical's handler seems to be that the "Header" tool in Lexical doesn't handle this overselection and will header-ify the following line; and that table cells can be deleted entirely once selected.

However, Lexxy has its own "Header" tool that doesn't have this issue; and Lexical tables no longer exhibit the cell-deletion behavior. I think it might be better to improve the formatting tool(s) than to hack the selection mechanism.

Hopefully, we can remove this once Lexical addresses this behavior. Some possible upstream approaches for that might be:

- Move the existing selection handling logic into a real handler that applications can pre-empt.
- Fix the selection behavior, or drop the triple-click handler completely.

ref: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9861391060
