### PR TITLE
Handle solo "text/uri-list" clipboardData as a link

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -79,8 +79,12 @@ export default class Clipboard {
 
   #isOnlyURLPasted(clipboardData) {
     // Safari URLs are copied as a text/plain + text/uri-list object
+    // App ShareSheet URLs are copied as solo text/uri-list object
     const types = Array.from(clipboardData.types)
-    return types.length === 2 && types.includes("text/uri-list") && types.includes("text/plain")
+    return types.length
+      && types.length <= 2
+      && types.includes("text/uri-list")
+      && (types.length < 2 || types.includes("text/plain"))
   }
 
   #isPastingIntoCodeBlock() {

--- a/test/browser/helpers/editor_handle.js
+++ b/test/browser/helpers/editor_handle.js
@@ -88,10 +88,10 @@ export class EditorHandle {
     await this.flush()
   }
 
-  async paste(text, { html, files = [] } = {}) {
+  async paste(text, { html, files = [], uriList } = {}) {
     await this.#ensureFirstInteraction()
     await this.content.evaluate(
-      (el, { text, html, files }) => {
+      (el, { text, html, files, uriList }) => {
         const buildFiles = () => {
           return files.map(({ base64, name, type }) => {
             const binary = atob(base64)
@@ -127,13 +127,14 @@ export class EditorHandle {
             cancelable: true,
             clipboardData: new DataTransfer(),
           })
-          event.clipboardData.setData("text/plain", text)
+          if (typeof text === "string") event.clipboardData.setData("text/plain", text)
           if (html) event.clipboardData.setData("text/html", html)
+          if (uriList) event.clipboardData.setData("text/uri-list", uriList)
         }
 
         el.dispatchEvent(event)
       },
-      { text, html, files },
+      { text, html, files, uriList },
     )
   }
 

--- a/test/browser/tests/paste/links.test.js
+++ b/test/browser/tests/paste/links.test.js
@@ -32,6 +32,28 @@ test.describe("Paste — Links", () => {
     )
   })
 
+  test("creates a link when pasting a solo text/uri-list payload (App ShareSheet)", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+
+    await editor.paste(null, { uriList: "https://37signals.com" })
+
+    await assertEditorHtml(
+      editor,
+      '<p>Hello everyone<a href="https://37signals.com">https://37signals.com</a></p>',
+    )
+  })
+
+  test("creates a link when pasting text/uri-list with a text/plain companion (Safari)", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+
+    await editor.paste("https://37signals.com", { uriList: "https://37signals.com" })
+
+    await assertEditorHtml(
+      editor,
+      '<p>Hello everyone<a href="https://37signals.com">https://37signals.com</a></p>',
+    )
+  })
+
   test("create links when pasting URLs keeps formatting", async ({
     page,
     editor,


### PR DESCRIPTION
App ShareSheets can place a solo "text/uri-list" data type in the pasteboard

- Add test for solo text/uri-list
- Add test for text/plain + text/uri-list

https://app.3.basecamp.com/2914079/buckets/41746046/card_tables/cards/9889602604