### PR TITLE
Calculate for `prevent-overflow` items correctly in toolbar

### DIFF
--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -266,6 +266,7 @@ export class LexicalToolbarElement extends HTMLElement {
   #refreshOverflow() {
     this.#resetToolbarOverflow()
     this.#reindexToolbarItems()
+    this.#overflow.style.display = "none"
     this.#compactMenu()
 
     const isOverflowing = this.#overflowMenu.children.length > 0
@@ -278,37 +279,32 @@ export class LexicalToolbarElement extends HTMLElement {
     this.#overflowMenu.toggleAttribute("disabled", !isOverflowing)
   }
 
-  // Separates layout reads from DOM writes to avoid forced reflows during init.
-  // Measures every button's right edge in a single read pass, figures out which
-  // buttons overflow using math, and then moves them in a single write pass.
   #compactMenu() {
-    const buttons = this.#overflowButtons
-    if (buttons.length === 0) return
+    if (!this.#isToolbarOverflowing()) return
 
-    const availableWidth = this.clientWidth
-    const buttonRightEdges = buttons.map(button => {
-      const style = window.getComputedStyle(button)
-      return button.offsetLeft + button.offsetWidth + parseFloat(style.marginRight)
-    })
+    this.#overflow.style.display = "block"
 
-    let firstOverflowing = -1
-    for (let i = 0; i < buttons.length; i++) {
-      if (buttonRightEdges[i] > availableWidth) {
-        firstOverflowing = i
-        break
-      }
-    }
+    while (this.#isToolbarOverflowing()) {
+      const button = this.#overflowButtons.at(-1)
+      if (!button) return
 
-    if (firstOverflowing === -1) return
-
-    // Move one extra button to reserve space for the overflow control, which is
-    // `display: none` until we show it
-    const overflowIndex = Math.max(0, firstOverflowing - 1)
-    const overflowButtons = buttons.slice(overflowIndex).reverse()
-    for (const button of overflowButtons) {
       this.#overflowMenu.prepend(button)
       button.role = "menuitem"
     }
+  }
+
+  #isToolbarOverflowing() {
+    const toolbarRect = this.getBoundingClientRect()
+
+    return this.#visibleToolbarItems.some((item) => {
+      const rect = item.getBoundingClientRect()
+      const style = window.getComputedStyle(item)
+
+      return (
+        rect.left - parseFloat(style.marginLeft) < toolbarRect.left ||
+        rect.right + parseFloat(style.marginRight) > toolbarRect.right
+      )
+    })
   }
 
   #resetToolbarOverflow() {
@@ -353,11 +349,15 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   get #overflowButtons() {
-    return Array.from(this.querySelectorAll(":scope > button:not([data-prevent-overflow='true'])"))
+    return Array.from(this.querySelectorAll(":scope > button:not([data-prevent-overflow])"))
   }
 
   get #buttons() {
     return Array.from(this.querySelectorAll(":scope button"))
+  }
+
+  get #visibleToolbarItems() {
+    return Array.from(this.children).filter((item) => item.getClientRects().length > 0)
   }
 
   get #toolbarItems() {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -272,89 +272,36 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #refreshOverflow() {
+    this.#hideOverflowMenuButton()
     this.#resetToolbarOverflow()
     this.#reindexToolbarItems()
-    this.#overflow.style.display = "none"
     this.#compactMenu()
 
-    const isOverflowing = this.#overflowMenu.children.length > 0
+    const isOverflowing = this.#overflowMenuDropdown.children.length > 0
 
     this.toggleAttribute("overflowing", isOverflowing)
-
-    this.#overflow.style.display = isOverflowing ? "block" : "none"
-    this.#overflow.setAttribute("nonce", getNonce())
-
-    this.#overflowMenu.toggleAttribute("disabled", !isOverflowing)
-  }
-
-  #compactMenu() {
-    if (!this.#isToolbarOverflowing()) return
-
-    this.#overflow.style.display = "block"
-
-    const overflowAmount = this.#toolbarOverflowAmount() + 1
-    const buttons = this.#overflowButtons
-    const overflowButtons = []
-    let recoveredWidth = 0
-
-    while (recoveredWidth < overflowAmount) {
-      const button = buttons.pop()
-      if (!button) break
-
-      overflowButtons.push(button)
-      recoveredWidth += this.#outerWidthFor(button) + this.#toolbarGap
-    }
-
-    for (const button of overflowButtons) {
-      this.#overflowMenu.prepend(button)
-      button.role = "menuitem"
-    }
-  }
-
-  #isToolbarOverflowing() {
-    return this.#toolbarOverflowAmount() > 0
-  }
-
-  #outerWidthFor(item) {
-    const rect = item.getBoundingClientRect()
-    const style = window.getComputedStyle(item)
-
-    return rect.width + (parseFloat(style.marginLeft) || 0) + (parseFloat(style.marginRight) || 0)
-  }
-
-  get #toolbarGap() {
-    return parseFloat(window.getComputedStyle(this).columnGap) || 0
-  }
-
-  #toolbarOverflowAmount() {
-    const { left, right } = this.#toolbarContentBounds
-
-    return this.#visibleToolbarItems.reduce((amount, item) => {
-      const rect = item.getBoundingClientRect()
-
-      return Math.max(amount, rect.right - right, left - rect.left)
-    }, 0)
-  }
-
-  get #toolbarContentBounds() {
-    const rect = this.getBoundingClientRect()
-    const style = window.getComputedStyle(this)
-
-    return {
-      left: rect.left + (parseFloat(style.paddingLeft) || 0),
-      right: rect.right - (parseFloat(style.paddingRight) || 0)
-    }
+    this.#setOverflowMenuNonce()
+    this.#showOverflowMenuButton(isOverflowing)
   }
 
   #resetToolbarOverflow() {
-    const items = Array.from(this.#overflowMenu.children)
+    const items = Array.from(this.#overflowMenuDropdown.children)
     items.sort((a, b) => this.#itemPosition(b) - this.#itemPosition(a))
 
     for (const item of items) {
-      const nextItem = this.querySelector(`[data-position="${this.#itemPosition(item) + 1}"]`) ?? this.#overflow
+      const nextItem = this.querySelector(`[data-position="${this.#itemPosition(item) + 1}"]`) ?? this.#overflowMenuButton
       item.removeAttribute("role")
       this.insertBefore(item, nextItem)
     }
+  }
+
+  #showOverflowMenuButton(show = true) {
+    this.#overflowMenuDropdown.toggleAttribute("disabled", !show)
+    this.#overflowMenuButton.style.display = show ? "block" : "none"
+  }
+
+  #hideOverflowMenuButton() {
+    this.#showOverflowMenuButton(false)
   }
 
   #itemPosition(item) {
@@ -367,28 +314,63 @@ export class LexicalToolbarElement extends HTMLElement {
     })
   }
 
+  #compactMenu() {
+    const overflowWidth = this.#getOverflowWidth()
+
+    if (overflowWidth > 0) {
+      this.#showOverflowMenuButton()
+      const gap = this.#getToolbarGap()
+      const spaceForOverflow = gap + this.#overflowMenuButton.offsetWidth
+      this.#reclaimWidth(overflowWidth + spaceForOverflow, { gap })
+    }
+  }
+
+  #getOverflowWidth() {
+    return this.scrollWidth - this.clientWidth
+  }
+
+  #reclaimWidth(overflowWidth, { gap }) {
+    const buttons = this.#overflowableButtons
+    const overflowButtons = []
+    let recoveredWidth = 0
+
+    while (recoveredWidth < overflowWidth && buttons.length) {
+      const button = buttons.pop()
+
+      overflowButtons.push(button)
+      button.role = "menuitem"
+      recoveredWidth += button.offsetWidth + gap
+    }
+
+    this.#overflowMenuDropdown.append(...overflowButtons.reverse())
+  }
+
+  #setOverflowMenuNonce() {
+    this.#overflowMenuButton.setAttribute("nonce", getNonce())
+  }
+
+  #getToolbarGap() {
+    return parseFloat(window.getComputedStyle(this).columnGap) || 0
+  }
+
   get #dropdowns() {
     return this.querySelectorAll(":scope .lexxy-editor__toolbar-dropdown")
   }
 
-  get #overflow() {
+  get #overflowMenuButton() {
     return this.querySelector(".lexxy-editor__toolbar-overflow")
   }
 
-  get #overflowMenu() {
-    return this.#overflow?.querySelector(":scope > [data-dropdown-panel]")
+  get #overflowMenuDropdown() {
+    return this.#overflowMenuButton?.querySelector(":scope > [data-dropdown-panel]")
   }
 
-  get #overflowButtons() {
+  get #overflowableButtons() {
     return Array.from(this.querySelectorAll(":scope > button:not([data-prevent-overflow])"))
   }
 
   get #buttons() {
     return Array.from(this.querySelectorAll(":scope button"))
-  }
-
-  get #visibleToolbarItems() {
-    return Array.from(this.children).filter((item) => item.getClientRects().length > 0)
   }
 
   get #toolbarItems() {

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -92,6 +92,14 @@ export class LexicalToolbarElement extends HTMLElement {
     })
   }
 
+  closeDropdowns({ except } = {}) {
+    this.#dropdowns.forEach((dropdown) => {
+      if (dropdown !== except) {
+        dropdown.close({ focusEditor: false })
+      }
+    })
+  }
+
   #reconnect() {
     this.disconnectedCallback()
     this.connectedCallback()
@@ -284,27 +292,58 @@ export class LexicalToolbarElement extends HTMLElement {
 
     this.#overflow.style.display = "block"
 
-    while (this.#isToolbarOverflowing()) {
-      const button = this.#overflowButtons.at(-1)
-      if (!button) return
+    const overflowAmount = this.#toolbarOverflowAmount() + 1
+    const buttons = this.#overflowButtons
+    const overflowButtons = []
+    let recoveredWidth = 0
 
+    while (recoveredWidth < overflowAmount) {
+      const button = buttons.pop()
+      if (!button) break
+
+      overflowButtons.push(button)
+      recoveredWidth += this.#outerWidthFor(button) + this.#toolbarGap
+    }
+
+    for (const button of overflowButtons) {
       this.#overflowMenu.prepend(button)
       button.role = "menuitem"
     }
   }
 
   #isToolbarOverflowing() {
-    const toolbarRect = this.getBoundingClientRect()
+    return this.#toolbarOverflowAmount() > 0
+  }
 
-    return this.#visibleToolbarItems.some((item) => {
+  #outerWidthFor(item) {
+    const rect = item.getBoundingClientRect()
+    const style = window.getComputedStyle(item)
+
+    return rect.width + (parseFloat(style.marginLeft) || 0) + (parseFloat(style.marginRight) || 0)
+  }
+
+  get #toolbarGap() {
+    return parseFloat(window.getComputedStyle(this).columnGap) || 0
+  }
+
+  #toolbarOverflowAmount() {
+    const { left, right } = this.#toolbarContentBounds
+
+    return this.#visibleToolbarItems.reduce((amount, item) => {
       const rect = item.getBoundingClientRect()
-      const style = window.getComputedStyle(item)
 
-      return (
-        rect.left - parseFloat(style.marginLeft) < toolbarRect.left ||
-        rect.right + parseFloat(style.marginRight) > toolbarRect.right
-      )
-    })
+      return Math.max(amount, rect.right - right, left - rect.left)
+    }, 0)
+  }
+
+  get #toolbarContentBounds() {
+    const rect = this.getBoundingClientRect()
+    const style = window.getComputedStyle(this)
+
+    return {
+      left: rect.left + (parseFloat(style.paddingLeft) || 0),
+      right: rect.right - (parseFloat(style.paddingRight) || 0)
+    }
   }
 
   #resetToolbarOverflow() {
@@ -325,14 +364,6 @@ export class LexicalToolbarElement extends HTMLElement {
   #reindexToolbarItems() {
     this.#toolbarItems.forEach((item, index) => {
       item.dataset.position = index
-    })
-  }
-
-  closeDropdowns({ except } = {}) {
-    this.#dropdowns.forEach((dropdown) => {
-      if (dropdown !== except) {
-        dropdown.close({ focusEditor: false })
-      }
     })
   }
 

--- a/test/browser/tests/formatting/toolbar.test.js
+++ b/test/browser/tests/formatting/toolbar.test.js
@@ -155,6 +155,49 @@ test.describe("Toolbar", () => {
     await expect(toolbar.locator(":scope > button[name='async-injected']")).toHaveCount(1)
   })
 
+  test("overflow compaction accounts for injected buttons that cannot overflow", async ({ page }) => {
+    const toolbar = page.locator("lexxy-toolbar")
+    const overflowMenu = toolbar.locator(".lexxy-editor__toolbar-overflow-menu")
+
+    const originalSize = page.viewportSize()
+    await page.setViewportSize({ width: 360, height: originalSize.height })
+
+    await page.evaluate(async () => {
+      const tb = document.querySelector("lexxy-toolbar")
+      const overflow = tb.querySelector(".lexxy-editor__toolbar-overflow")
+
+      for (const index of [ 1, 2 ]) {
+        const button = document.createElement("button")
+        button.type = "button"
+        button.name = `fixed-injected-${index}`
+        button.className = "lexxy-editor__toolbar-button"
+        button.dataset.preventOverflow = "true"
+        button.textContent = `${index}`
+        tb.insertBefore(button, overflow)
+      }
+
+      tb.requestOverflowRefresh()
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+    })
+
+    await expect(toolbar).toHaveAttribute("overflowing", "")
+    await expect(overflowMenu.locator("button[name^='fixed-injected-']")).toHaveCount(0)
+
+    await expect.poll(async () => {
+      return await toolbar.evaluate((tb) => {
+        const toolbarRect = tb.getBoundingClientRect()
+        const fixedButtons = Array.from(tb.querySelectorAll(":scope > button[name^='fixed-injected-']"))
+
+        return fixedButtons.every((button) => {
+          const rect = button.getBoundingClientRect()
+          return rect.left >= toolbarRect.left && rect.right <= toolbarRect.right
+        })
+      })
+    }).toBe(true)
+
+    await page.setViewportSize(originalSize)
+  })
+
   test("image button opens file picker restricted to images and videos", async ({ page }) => {
     const [fileChooser] = await Promise.all([
       page.waitForEvent("filechooser"),

--- a/test/browser/tests/formatting/toolbar.test.js
+++ b/test/browser/tests/formatting/toolbar.test.js
@@ -186,11 +186,14 @@ test.describe("Toolbar", () => {
     await expect.poll(async () => {
       return await toolbar.evaluate((tb) => {
         const toolbarRect = tb.getBoundingClientRect()
-        const fixedButtons = Array.from(tb.querySelectorAll(":scope > button[name^='fixed-injected-']"))
+        const style = window.getComputedStyle(tb)
+        const contentLeft = toolbarRect.left + parseFloat(style.paddingLeft)
+        const contentRight = toolbarRect.right - parseFloat(style.paddingRight)
+        const items = Array.from(tb.children).filter((item) => item.getClientRects().length > 0)
 
-        return fixedButtons.every((button) => {
-          const rect = button.getBoundingClientRect()
-          return rect.left >= toolbarRect.left && rect.right <= toolbarRect.right
+        return items.every((item) => {
+          const rect = item.getBoundingClientRect()
+          return rect.left >= contentLeft && rect.right <= contentRight
         })
       })
     }).toBe(true)


### PR DESCRIPTION
The calculation of toolbar overflow didn't account for elements with `data-prevent-overflow` attribute, so inserting those items via an extension still broke out of the toolbar's container width.

This PR updates that calculation logic.