### PR TITLE
Prevent loss of editor focus during prompt navigation

### DIFF
--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -87,32 +87,6 @@ export default class Selection {
     return { node: null, offset: 0 }
   }
 
-  preservingSelection(fn) {
-    let selectionState = null
-
-    this.editor.getEditorState().read(() => {
-      const selection = $getSelection()
-      if (selection && $isRangeSelection(selection)) {
-        selectionState = {
-          anchor: { key: selection.anchor.key, offset: selection.anchor.offset },
-          focus: { key: selection.focus.key, offset: selection.focus.offset }
-        }
-      }
-    })
-
-    fn()
-
-    if (selectionState) {
-      this.editor.update(() => {
-        const selection = $getSelection()
-        if (selection && $isRangeSelection(selection)) {
-          selection.anchor.set(selectionState.anchor.key, selectionState.anchor.offset, "text")
-          selection.focus.set(selectionState.focus.key, selectionState.focus.offset, "text")
-        }
-      })
-    }
-  }
-
   getFormat() {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return {}

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -237,16 +237,12 @@ export class LexicalPromptElement extends HTMLElement {
     return Array.from(this.popoverElement.querySelectorAll(".lexxy-prompt-menu__item"))
   }
 
-  #selectOption(listItem) {
+  #selectOption(listItem, { scrollIntoView = false } = {}) {
     this.#clearListItemSelection()
     listItem.toggleAttribute("aria-selected", true)
-    listItem.scrollIntoView({ block: "nearest", behavior: "smooth" })
-    listItem.focus()
-
-    // Preserve selection to prevent cursor jump
-    this.#selection.preservingSelection(() => {
-      this.#editorElement.focus()
-    })
+    if (scrollIntoView) {
+      listItem.scrollIntoView({ block: "nearest", container: "nearest", behavior: "smooth" })
+    }
 
     this.#setEditorAssociationAttribute("aria-controls", this.popoverElement.id)
     this.#setEditorAssociationAttribute("aria-activedescendant", listItem.id)
@@ -390,17 +386,17 @@ export class LexicalPromptElement extends HTMLElement {
         }
       })
     }
-    // Arrow keys are now handled via Lexical commands with HIGH priority
+    // Arrow keys are handled via Lexical commands
   }
 
   #moveSelectionDown() {
     const nextIndex = this.#selectedIndex + 1
-    if (nextIndex < this.#listItemElements.length) this.#selectOption(this.#listItemElements[nextIndex])
+    if (nextIndex < this.#listItemElements.length) this.#selectOption(this.#listItemElements[nextIndex], { scrollIntoView: true })
   }
 
   #moveSelectionUp() {
     const previousIndex = this.#selectedIndex - 1
-    if (previousIndex >= 0) this.#selectOption(this.#listItemElements[previousIndex])
+    if (previousIndex >= 0) this.#selectOption(this.#listItemElements[previousIndex], { scrollIntoView: true })
   }
 
   get #selectedIndex() {

--- a/test/browser/tests/prompts/filter_keeps_editor_focused.test.js
+++ b/test/browser/tests/prompts/filter_keeps_editor_focused.test.js
@@ -1,0 +1,49 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt filter focus", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-filtering.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  // Android IMEs tear the soft keyboard down on any focus shift, so per-keystroke focus moves to a <li> and back dismiss-and-reopen the keyboard on every character.
+  test("typing into the filter keeps focus on the editor", async ({ page, editor }) => {
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const editorIsActive = () =>
+      editor.content.evaluate((el) => document.activeElement === el)
+
+    expect(await editorIsActive()).toBe(true)
+
+    await editor.content.pressSequentially("j")
+    await editor.flush()
+    expect(await editorIsActive()).toBe(true)
+
+    // Catches once-only side effects on subsequent keystrokes
+    await editor.content.pressSequentially("a")
+    await editor.flush()
+    expect(await editorIsActive()).toBe(true)
+  })
+
+  test("aria-activedescendant points to the currently selected option", async ({ page, editor }) => {
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.content.pressSequentially("ja")
+    await editor.flush()
+
+    const activeMatches = await editor.content.evaluate((el) => {
+      const id = el.getAttribute("aria-activedescendant")
+      if (!id) return false
+      const option = document.getElementById(id)
+      return option != null && option.hasAttribute("aria-selected")
+    })
+    expect(activeMatches).toBe(true)
+  })
+})


### PR DESCRIPTION
Android IME is sensitive to the loss of editor focus, so `listItem.focus()` was cycling the keyboard off and on at each keypress during prompt navigation.

- Given aria behavior accommodations, `focus()` is not needed to announce the active choice.
- Remove unused `Selection.preservingSelection()`

https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9871433736
