### PR TITLE
Editor validity API & prevent submit on in-progress uploads

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -41,6 +41,7 @@ import { AttachmentsExtension } from "../extensions/attachments_extension.js"
 import { FormatEscapeExtension } from "../extensions/format_escape_extension.js"
 import { LinkOpenerExtension } from "../extensions/link_opener_extension.js"
 import { PreventLexicalTripleClickExtension } from "../extensions/prevent_lexical_triple_click_extension.js"
+import { nextFrame } from "../helpers/timing_helper.js"
 
 
 export class LexicalEditorElement extends HTMLElement {
@@ -51,11 +52,13 @@ export class LexicalEditorElement extends HTMLElement {
   static observedAttributes = [ "connected", "required" ]
 
   #initialValue = ""
-  #validationTextArea = document.createElement("textarea")
   #editorInitializedRafId = null
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
+
+  #validity = new Map()
+  #validationTextArea = document.createElement("textarea")
 
   constructor() {
     super()
@@ -104,14 +107,18 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    if (name === "connected" && this.isConnected && oldValue != null && oldValue !== newValue) {
+    if (name === "connected") this.connectedChangedCallback(oldValue, newValue)
+    if (name === "required") this.requiredChangedCallback(oldValue, newValue)
+  }
+
+  connectedChangedCallback(oldValue, newValue) {
+    if (this.isConnected && oldValue != null && oldValue !== newValue) {
       requestAnimationFrame(() => this.#reconnect())
     }
+  }
 
-    if (name === "required" && this.isConnected) {
-      this.#validationTextArea.required = this.hasAttribute("required")
-      this.#setValidity()
-    }
+  requiredChangedCallback() {
+    if (this.isConnected) this.#requestValidityRefresh()
   }
 
   formResetCallback() {
@@ -135,6 +142,27 @@ export class LexicalEditorElement extends HTMLElement {
 
   get name() {
     return this.getAttribute("name")
+  }
+
+  get required() {
+    return this.hasAttribute("required")
+  }
+
+  get validity() {
+    return this.internals.validity
+  }
+
+  checkValidity() {
+    return this.internals.checkValidity()
+  }
+
+  reportValidity() {
+    return this.internals.reportValidity()
+  }
+
+  setElementValidity(key, flags, message) {
+    this.#validity.set(key, { flags, message })
+    this.#requestValidityRefresh()
   }
 
   get toolbarElement() {
@@ -444,7 +472,6 @@ export class LexicalEditorElement extends HTMLElement {
 
     this.internals.setFormValue(html)
     this._internalFormValue = html
-    this.#validationTextArea.value = this.isEmpty ? "" : html
 
     if (changed) {
       dispatch(this, "lexxy:change")
@@ -479,9 +506,48 @@ export class LexicalEditorElement extends HTMLElement {
       this.#clearCachedValues()
       this.#internalFormValue = this.value
       this.#toggleEmptyStatus()
-      this.#setValidity()
+      this.#requestValidityRefresh()
       this.#dispatchAttributesChange()
     }))
+  }
+
+  async #requestValidityRefresh() {
+    await nextFrame()
+
+    if (this.isConnected) this.#refreshValidity()
+  }
+
+  #refreshValidity() {
+    this.#refreshInternalValidity()
+    const { validity, message } = this.#calculateValidity()
+    this.internals.setValidity(validity, message, this.editorContentElement)
+  }
+
+  #refreshInternalValidity() {
+    this.#validationTextArea.required = this.required && this.isBlank
+    const flags = this.#validationTextArea.validity
+    const message = this.#validationTextArea.validationMessage
+
+    this.#validity.set(this, { flags, message })
+  }
+
+  #calculateValidity() {
+    const validity = {}
+    const messages = []
+
+    for (const { flags, message } of this.#validity.values()) {
+      // internal TextArea's ValidityState can contain `valid: true`
+      if (flags.valid === true) continue
+
+      for (const flag in flags) {
+        if (flags[flag]) {
+          validity[flag] = true
+          messages.push(message)
+        }
+      }
+    }
+
+    return { validity, message: messages.join("\n") }
   }
 
   #clearCachedValues() {
@@ -646,14 +712,6 @@ export class LexicalEditorElement extends HTMLElement {
     this.classList.toggle("lexxy-editor--empty", this.isEmpty)
   }
 
-  #setValidity() {
-    if (this.#validationTextArea.validity.valid) {
-      this.internals.setValidity({})
-    } else {
-      this.internals.setValidity(this.#validationTextArea.validity, this.#validationTextArea.validationMessage, this.editorContentElement)
-    }
-  }
-
   #configureSanitizer() {
     setSanitizerConfig(this.#allowedElements)
   }
@@ -785,6 +843,7 @@ export class LexicalEditorElement extends HTMLElement {
   #reset() {
     this.#cancelEditorInitializedDispatch()
     this.#dispose()
+    this.#resetValidity()
     this.editorContentElement?.remove()
     this.editorContentElement = null
 
@@ -803,6 +862,10 @@ export class LexicalEditorElement extends HTMLElement {
     this.disconnectedCallback()
     this.valueBeforeDisconnect = null
     this.connectedCallback()
+  }
+
+  #resetValidity() {
+    this.#validity = new Map()
   }
 }
 

--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -12,7 +12,11 @@ import { $isAtNodeEdge } from "../helpers/lexical_helper.js"
 const ATTACHMENT_ATTRIBUTES = [ "alt", "caption", "content", "content-type", "data-direct-upload-id",
   "data-sgid", "filename", "filesize", "height", "presentation", "previewable", "sgid", "url", "width" ]
 
+const UPLOADS_BUSY_MESSAGE = "Please wait for all files to upload"
+
 export class AttachmentsExtension extends LexxyExtension {
+  #uploadsCount = 0
+
   get enabled() {
     return this.editorElement.supportsAttachments
   }
@@ -29,16 +33,40 @@ export class AttachmentsExtension extends LexxyExtension {
         ActionTextAttachmentUploadNode,
         ImageGalleryNode
       ],
-      register(editor) {
+      register: (editor) => {
         const dragAndDrop = new AttachmentDragAndDrop(editor)
 
         return mergeRegister(
           editor.registerNodeTransform(ActionTextAttachmentNode, $extractAttachmentFromParagraph),
           editor.registerCommand(DELETE_CHARACTER_COMMAND, $collapseIntoGallery, COMMAND_PRIORITY_NORMAL),
+          editor.registerMutationListener(ActionTextAttachmentUploadNode, this.#handleUploadMutations.bind(this)),
           () => dragAndDrop.destroy()
         )
       }
     })
+  }
+
+  #handleUploadMutations(mutations) {
+    const previousUploadsCount = this.#uploadsCount
+    for (const [ , mutation ] of mutations) {
+      if (mutation === "created") {
+        this.#uploadsCount++
+      } else if (mutation === "destroyed") {
+        this.#uploadsCount--
+      }
+    }
+
+    if (this.#uploadsCount !== previousUploadsCount) {
+      this.#setUploadsValidity()
+    }
+  }
+
+  #setUploadsValidity() {
+    if (this.#uploadsCount) {
+      this.setEditorValidity({ customError: true }, UPLOADS_BUSY_MESSAGE)
+    } else {
+      this.setEditorValidity({})
+    }
   }
 }
 

--- a/src/extensions/lexxy_extension.js
+++ b/src/extensions/lexxy_extension.js
@@ -30,6 +30,10 @@ export default class LexxyExtension {
 
   }
 
+  setEditorValidity(flags, message) {
+    this.editorElement.setElementValidity(this, flags, message)
+  }
+
   dispose() {
   }
 }

--- a/test/browser/tests/attachments/form_validity.test.js
+++ b/test/browser/tests/attachments/form_validity.test.js
@@ -1,0 +1,35 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+test.describe("Form validity during uploads", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("editor is invalid while an upload is in flight and valid after it completes", async ({ page, editor }) => {
+    const calls = await mockActiveStorageUploads(page, { delayDirectUploadResponse: true })
+
+    await editor.send("Hello")
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(true)
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await expect(page.locator("figure.attachment progress")).toBeVisible({ timeout: 10_000 })
+
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(false)
+    expect(await editor.locator.evaluate((el) => el.internals.validationMessage)).toBe(
+      "Please wait for all files to upload",
+    )
+
+    await calls.releaseDirectUploadResponses()
+    await expect(page.locator("figure.attachment img")).toHaveAttribute(
+      "src",
+      /\/rails\/active_storage\/blobs\//,
+      { timeout: 10_000 },
+    )
+
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(true)
+  })
+})

--- a/test/system/tables_test.rb
+++ b/test/system/tables_test.rb
@@ -8,6 +8,7 @@ class TableTest < ApplicationSystemTestCase
 
   test "tables render with action text" do
     find_editor.toggle_command("insertTable")
+    find_editor.send "Hello"
     click_on "Update Post"
 
     assert_no_selector "lexxy-editor"


### PR DESCRIPTION
Fully participate in ElementInternals validity API

- respond to `required`, `checkValidity`, and `setValidity`
- allow extensions to set extension-scoped validity states
- use API to set editor invalid while uploads are in progress
- Use a counter for in-progress uploads to prevent a whole tree search

Extraction of the work in https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9858945566#__recording_9885571906