### PR TITLE
Silence and clean up CSS lint warnings

### DIFF
--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -12,7 +12,10 @@
     hyphens: auto;
     margin-block: 0 var(--lexxy-content-margin);
     overflow-wrap: break-word;
-    text-wrap: balance;
+
+    @supports (text-wrap: balance) {
+      text-wrap: balance;
+    }
   }
 
   h1 { font-size: 2rem; }
@@ -35,7 +38,10 @@
 
     &:not(lexxy-editor &) {
       overflow-wrap: break-word;
-      text-wrap: pretty;
+
+      @supports (text-wrap: pretty) {
+        text-wrap: pretty;
+      }
     }
   }
 
@@ -114,11 +120,14 @@
       hyphens: none;
       margin-block: 0 var(--lexxy-content-margin);
       overflow-x: auto;
+      overflow-wrap: break-word;
       padding: 1ch;
       tab-size: 2;
-      text-wrap: nowrap;
       white-space: pre;
-      word-break: break-word;
+
+      @supports (text-wrap: nowrap) {
+        text-wrap: nowrap;
+      }
     }
   }
 
@@ -275,8 +284,11 @@
 
       *:is(code, pre) {
         hyphens: auto;
-        text-wrap: wrap;
         white-space: pre-wrap;
+
+        @supports (text-wrap: wrap) {
+          text-wrap: wrap;
+        }
       }
     }
   }
@@ -338,7 +350,11 @@
       display: block;
       margin-inline: auto;
       max-inline-size: 100%;
-      user-select: none;
+      -webkit-user-select: none;
+
+      @supports (user-select: none) {
+        user-select: none;
+      }
     }
 
     > a {

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -166,6 +166,7 @@
     }
 
     &.lexxy-content__table--selection {
+      /* eslint-disable-next-line css/use-baseline */
       ::selection {
         background: transparent;
       }
@@ -366,8 +367,11 @@
       inline-size: 100%;
       max-inline-size: 100%;
       padding: 0;
-      resize: none;
       text-align: center;
+
+      @supports (resize: none) {
+        resize: none;
+      }
 
       &:focus {
         background: var(--lexxy-color-canvas);
@@ -497,7 +501,11 @@
       fill: currentColor;
       grid-area: 1/1;
       inline-size: var(--lexxy-toolbar-icon-size);
-      user-select: none;
+      -webkit-user-select: none;
+
+      @supports (user-select: none) {
+        user-select: none;
+      }
     }
 
     &.lexxy-editor__toolbar-group-end {
@@ -528,8 +536,11 @@
 /* Dropdowns */
 
 :where(.lexxy-editor__toolbar-dropdown) {
-  user-select: none;
   -webkit-user-select: none;
+
+  @supports (user-select: none) {
+    user-select: none;
+  }
 
   .lexxy-editor__toolbar-button {
     color: currentColor;
@@ -806,8 +817,11 @@
     line-height: inherit;
     min-block-size: var(--button-size);
     min-inline-size: var(--button-size);
-    user-select: none;
     -webkit-user-select: none;
+
+    @supports (user-select: none) {
+      user-select: none;
+    }
 
     @media(any-hover: hover) {
       &:hover:not([aria-disabled="true"]),


### PR DESCRIPTION
This PR cleans up eslint warnings for the core CSS files:

- Add comments above properties causing invalid eslint issues
- Wrap properties in `@supports` for features above Baseline 2023