### PR TITLE
Blockquote LineBreak Refactor

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -114,12 +114,6 @@ export default class Contents {
     if (allCode) {
       blockElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
-      // We first split the enclosing paragraph at the <br>s on either side of
-      // the selection, so that a one-line selection out of a paragraph with
-      // soft line breaks becomes its own paragraph. We then re-collect block
-      // elements from the updated selection, because the split above is a
-      // no-op when the selection lives inside a container like a blockquote,
-      // where the elements to convert are the container's child paragraphs.
       $splitParagraphsAtLineBreakBoundaries(selection)
       const elements = this.#blockLevelElementsInSelection(selection)
       if (elements.length === 0) return

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -16,7 +16,7 @@ import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_nod
 import { $createActionTextAttachmentUploadNode, ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils"
 import NodeInserter from "./contents/node_inserter"
-import { $isShadowRoot, $splitParagraphsAtLineBreakBoundaries } from "../helpers/lexical_helper"
+import { $expandSelectionToLineBreaksAndSplitAtEdges, $isShadowRoot, $splitSelectedParagraphsAtInnerLineBreaks } from "../helpers/lexical_helper"
 
 export default class Contents {
   constructor(editorElement) {
@@ -64,7 +64,7 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
-    $splitParagraphsAtLineBreakBoundaries(selection)
+    $expandSelectionToLineBreaksAndSplitAtEdges(selection)
     $setBlocksType(selection, () => $createParagraphNode())
   }
 
@@ -72,7 +72,7 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
-    $splitParagraphsAtLineBreakBoundaries(selection)
+    $expandSelectionToLineBreaksAndSplitAtEdges(selection)
     $setBlocksType(selection, () => $createHeadingNode(tag))
   }
 
@@ -114,7 +114,7 @@ export default class Contents {
     if (allCode) {
       blockElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
-      $splitParagraphsAtLineBreakBoundaries(selection)
+      $expandSelectionToLineBreaksAndSplitAtEdges(selection)
       const elements = this.#blockLevelElementsInSelection(selection)
       if (elements.length === 0) return
 
@@ -140,7 +140,7 @@ export default class Contents {
     } else {
       topLevelElements.filter($isQuoteNode).forEach(node => this.#unwrap(node))
 
-      const elements = $splitParagraphsAtLineBreakBoundaries(selection)
+      const elements = $expandSelectionToLineBreaksAndSplitAtEdges(selection)
       if (elements.length === 0) return
 
       const blockquote = $createQuoteNode()
@@ -407,41 +407,8 @@ export default class Contents {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
 
-    // Two-pass: first isolate the selected range as its own paragraph so that
-    // <br>s outside the selection stay grouped (boundary-aware); then explode
-    // every <br> within the isolated paragraph so each selected line becomes
-    // its own list item.
-    $splitParagraphsAtLineBreakBoundaries(selection)
-    this.#splitParagraphsAtLineBreaks(selection)
-  }
-
-  #splitParagraphsAtLineBreaks(selection) {
-    const topLevelElements = this.#topLevelElementsInSelection(selection)
-
-    for (const element of topLevelElements) {
-      if (!$isParagraphNode(element)) continue
-
-      const children = element.getChildren()
-      if (!children.some($isLineBreakNode)) continue
-
-      const groups = [ [] ]
-      for (const child of children) {
-        if ($isLineBreakNode(child)) {
-          groups.push([])
-          child.remove()
-        } else {
-          groups[groups.length - 1].push(child)
-        }
-      }
-
-      for (const group of groups) {
-        if (group.length === 0) continue
-        const paragraph = $createParagraphNode()
-        group.forEach(child => paragraph.append(child))
-        element.insertBefore(paragraph)
-      }
-      if (groups.some(group => group.length > 0)) element.remove()
-    }
+    $expandSelectionToLineBreaksAndSplitAtEdges(selection)
+    $splitSelectedParagraphsAtInnerLineBreaks(selection)
   }
 
   #blockLevelElementsInSelection(selection) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -140,7 +140,8 @@ export default class Contents {
     } else {
       topLevelElements.filter($isQuoteNode).forEach(node => this.#unwrap(node))
 
-      const elements = $expandSelectionToLineBreaksAndSplitAtEdges(selection)
+       $expandSelectionToLineBreaksAndSplitAtEdges(selection)
+      const elements = this.#topLevelElementsInSelection(selection)
       if (elements.length === 0) return
 
       const blockquote = $createQuoteNode()

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -163,19 +163,19 @@ export function $splitParagraphsAtLineBreakBoundaries(selection) {
   // A collapsed cursor adjacent to a <br> would claim it from both sides via
   // inward-edge; force outward-only walks so each side finds its own boundary.
   const skipInwardEdge = selection.isCollapsed()
-  const focusBr = $getCaretAtLineBreakBoundary(focusCaret, skipInwardEdge)
-  let anchorBr = $getCaretAtLineBreakBoundary(anchorCaret, skipInwardEdge)
+  const focusBrCaret = $getCaretAtLineBreakBoundary(focusCaret, skipInwardEdge)
+  let anchorBrCaret = $getCaretAtLineBreakBoundary(anchorCaret, skipInwardEdge)
 
-  if (focusBr?.is(anchorBr)) {
-    anchorBr = null
+  if (focusBrCaret?.origin.is(anchorBrCaret?.origin)) {
+    anchorBrCaret = null
   }
 
   // Splitting focus first keeps the anchor <br>'s position stable.
-  const focusOuter = focusBr ? $splitAroundLineBreak($getSiblingCaret(focusBr, "next")) : null
-  const anchorOuter = anchorBr ? $splitAroundLineBreak($getSiblingCaret(anchorBr, "previous")) : null
+  const focusOuter = focusBrCaret && $splitAroundLineBreak(focusBrCaret)
+  const anchorOuter = anchorBrCaret && $splitAroundLineBreak(anchorBrCaret)
 
-  const innerStart = anchorOuter ? anchorOuter.getNextSibling() : selection.anchor.getNode().getTopLevelElement()
-  const innerEnd = focusOuter ? focusOuter.getPreviousSibling() : selection.focus.getNode().getTopLevelElement()
+  const innerStart = anchorOuter?.getNextSibling() ?? selection.anchor.getNode().getTopLevelElement()
+  const innerEnd = focusOuter?.getPreviousSibling() ?? selection.focus.getNode().getTopLevelElement()
   if (!innerStart || !innerEnd) return []
 
   const paragraphs = []
@@ -191,11 +191,10 @@ function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {
   const paragraph = caret.origin.getTopLevelElement()
   if (!paragraph || !$isParagraphNode(paragraph)) return null
 
-  if (!skipInwardEdge) {
-    const br = $inwardEdgeLineBreak(caret, paragraph)
-    if (br) return br
-  }
-  return $outwardLineBreak(caret, paragraph)
+  const lineBreak = (skipInwardEdge ? null : $inwardEdgeLineBreak(caret, paragraph))
+    ?? $outwardLineBreak(caret, paragraph)
+
+  return lineBreak ? $getSiblingCaret(lineBreak, caret.direction) : null
 }
 
 // Prefer a <br> the cursor is sitting flush against, except when a further <br>

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -233,11 +233,11 @@ function $candidateUnlessShadowed(candidateCaret) {
 
 function $outwardLineBreak(caret, paragraph) {
   const startCaret = $outwardWalkStartCaret(caret, paragraph)
-  if (startCaret) {
-    for (const c of startCaret) {
-      if (!c.origin.getParent()?.is(paragraph)) break
-      if ($isLineBreakNode(c.origin)) return c.origin
-    }
+  if (!startCaret) return null
+
+  for (const { origin } of startCaret) {
+    if (!origin.getParent().is(paragraph)) break
+    if ($isLineBreakNode(origin)) return origin
   }
   return null
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -154,7 +154,40 @@ export function isAttachmentSpacerTextNode(node, previousNode, index, childCount
     && previousNode instanceof CustomActionTextAttachmentNode
 }
 
-export function $splitParagraphsAtLineBreakBoundaries(selection) {
+export function $splitSelectedParagraphsAtInnerLineBreaks(selection) {
+  const topLevelElements = new Set()
+  for (const node of selection.getNodes()) {
+    const topLevel = node.getTopLevelElement()
+    if (topLevel) topLevelElements.add(topLevel)
+  }
+
+  for (const element of topLevelElements) {
+    if (!$isParagraphNode(element)) continue
+
+    const children = element.getChildren()
+    if (!children.some($isLineBreakNode)) continue
+
+    const groups = [ [] ]
+    for (const child of children) {
+      if ($isLineBreakNode(child)) {
+        groups.push([])
+        child.remove()
+      } else {
+        groups[groups.length - 1].push(child)
+      }
+    }
+
+    for (const group of groups) {
+      if (group.length === 0) continue
+      const paragraph = $createParagraphNode()
+      group.forEach(child => paragraph.append(child))
+      element.insertBefore(paragraph)
+    }
+    if (groups.some(group => group.length > 0)) element.remove()
+  }
+}
+
+export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
   $ensureForwardRangeSelection(selection)
 
   const focusCaret = $caretFromPoint(selection.focus, "next")

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -271,7 +271,7 @@ function $outwardLineBreak(caret, paragraph) {
 }
 
 function $outwardWalkStartCaret(caret, paragraph) {
-  if (caret.getParentAtCaret()?.is(paragraph)) {
+  if (caret.getParentAtCaret().is(paragraph)) {
     return caret
   } else {
     return $paragraphChildCaretContaining(caret, paragraph)

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,4 +1,4 @@
-import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCommonAncestor, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $rewindSiblingCaret, $splitAtPointCaretNext, TextNode } from "lexical"
+import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
@@ -216,7 +216,15 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
     paragraphs.push(c.origin)
     if (c.origin.is(innerEnd)) break
   }
-  $selectParagraphs(selection, paragraphs)
+
+  $setSelectionFromCaretRange($getCaretRange(
+    $normalizeCaret($getChildCaret(innerStart, "next")),
+    $getCaretInDirection(
+      $normalizeCaret($getChildCaret(innerEnd, "previous")),
+      "next",
+    ),
+  ))
+
   return paragraphs
 }
 
@@ -314,23 +322,3 @@ function $splitAroundLineBreak(lineBreakCaret) {
   return outer
 }
 
-function $selectParagraphs(selection, paragraphs) {
-  if (paragraphs.length > 0) {
-    const first = paragraphs[0]
-    const last = paragraphs[paragraphs.length - 1]
-    const firstLeaf = first.getFirstDescendant() ?? first
-    const lastLeaf = last.getLastDescendant() ?? last
-
-    if ($isTextNode(firstLeaf)) {
-      selection.anchor.set(firstLeaf.getKey(), 0, "text")
-    } else {
-      selection.anchor.set(first.getKey(), 0, "element")
-    }
-
-    if ($isTextNode(lastLeaf)) {
-      selection.focus.set(lastLeaf.getKey(), lastLeaf.getTextContentSize(), "text")
-    } else {
-      selection.focus.set(last.getKey(), last.getChildrenSize(), "element")
-    }
-  }
-}

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -160,18 +160,14 @@ export function $splitParagraphsAtLineBreakBoundaries(selection) {
   const focusCaret = $caretFromPoint(selection.focus, "next")
   const anchorCaret = $caretFromPoint(selection.anchor, "previous")
 
-  let focusBr = $boundaryLineBreak(focusCaret)
-  let anchorBr = $boundaryLineBreak(anchorCaret)
+  // A collapsed cursor adjacent to a <br> would claim it from both sides via
+  // inward-edge; force outward-only walks so each side finds its own boundary.
+  const skipInwardEdge = selection.isCollapsed()
+  const focusBr = $getCaretAtLineBreakBoundary(focusCaret, skipInwardEdge)
+  let anchorBr = $getCaretAtLineBreakBoundary(anchorCaret, skipInwardEdge)
 
-  // A collapsed cursor adjacent to a <br> claims it via inward-edge on one
-  // side and outward walk on the other; force outward-only on both so each
-  // side finds its own boundary.
-  if (focusBr && anchorBr && focusBr.is(anchorBr)) {
-    focusBr = $boundaryLineBreak(focusCaret, true)
-    anchorBr = $boundaryLineBreak(anchorCaret, true)
-    if (focusBr && anchorBr && focusBr.is(anchorBr)) {
-      anchorBr = null
-    }
+  if (focusBr?.is(anchorBr)) {
+    anchorBr = null
   }
 
   // Splitting focus first keeps the anchor <br>'s position stable.
@@ -191,7 +187,7 @@ export function $splitParagraphsAtLineBreakBoundaries(selection) {
   return paragraphs
 }
 
-function $boundaryLineBreak(caret, skipInwardEdge = false) {
+function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {
   const paragraph = caret.origin.getTopLevelElement()
   if (!paragraph || !$isParagraphNode(paragraph)) return null
 

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -215,7 +215,7 @@ function $inwardEdgeLineBreak(caret, paragraph) {
   } else if ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph)) {
     candidateCaret = caret
   } else {
-    const childCaret = $paragraphChildAtInwardEdge(caret, paragraph)
+    const childCaret = $paragraphChildCaretAtInwardEdge(caret, paragraph)
     candidateCaret = childCaret ? $rewindSiblingCaret(childCaret) : null
   }
 
@@ -249,11 +249,11 @@ function $outwardWalkStartCaret(caret, paragraph) {
   ) {
     return caret
   } else {
-    return $paragraphChildContaining(caret, paragraph)
+    return $paragraphChildCaretContaining(caret, paragraph)
   }
 }
 
-function $paragraphChildContaining(caret, paragraph) {
+function $paragraphChildCaretContaining(caret, paragraph) {
   let cursor = caret.getSiblingCaret()
   while (cursor && !cursor.origin.getParent()?.is(paragraph)) {
     cursor = cursor.getParentCaret()
@@ -263,7 +263,7 @@ function $paragraphChildContaining(caret, paragraph) {
 
 // Only succeeds when the cursor is flush against the inward edge of every
 // ancestor between itself and the paragraph child.
-function $paragraphChildAtInwardEdge(caret, paragraph) {
+function $paragraphChildCaretAtInwardEdge(caret, paragraph) {
   let cursor = caret.getSiblingCaret()
   while (cursor && !cursor.origin.getParent()?.is(paragraph)) {
     if (cursor.getNodeAtCaret()) return null

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -243,10 +243,7 @@ function $outwardLineBreak(caret, paragraph) {
 }
 
 function $outwardWalkStartCaret(caret, paragraph) {
-  if (
-    ($isChildCaret(caret) && caret.origin.is(paragraph)) ||
-    ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph))
-  ) {
+  if (caret.getParentAtCaret()?.is(paragraph)) {
     return caret
   } else {
     return $paragraphChildCaretContaining(caret, paragraph)

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -209,13 +209,7 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
 
   const innerStart = anchorOuter?.getNextSibling() ?? selection.anchor.getNode().getTopLevelElement()
   const innerEnd = focusOuter?.getPreviousSibling() ?? selection.focus.getNode().getTopLevelElement()
-  if (!innerStart || !innerEnd) return []
-
-  const paragraphs = []
-  for (const c of $rewindSiblingCaret($getSiblingCaret(innerStart, "next"))) {
-    paragraphs.push(c.origin)
-    if (c.origin.is(innerEnd)) break
-  }
+  if (!innerStart || !innerEnd) return
 
   $setSelectionFromCaretRange($getCaretRange(
     $normalizeCaret($getChildCaret(innerStart, "next")),
@@ -224,8 +218,6 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection) {
       "next",
     ),
   ))
-
-  return paragraphs
 }
 
 function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -212,7 +212,7 @@ function $inwardEdgeLineBreak(caret, paragraph) {
     ($isTextPointCaret(caret) && $isExtendableTextPointCaret(caret.getFlipped()))
   ) {
     candidateCaret = null
-  } else if ($isSiblingCaret(caret) && caret.origin.getParent()?.is(paragraph)) {
+  } else if ($isSiblingCaret(caret) && caret.getParentAtCaret().is(paragraph)) {
     candidateCaret = caret
   } else {
     const childCaret = $paragraphChildCaretAtInwardEdge(caret, paragraph)


### PR DESCRIPTION
Refactors for https://github.com/basecamp/lexxy/pull/1049

- Refactors internal helpers to be caret-native to remove $getCaret calls between steps
- Collapse logic for collapsed selection: force outward-only search directly
- Sets selection directly from the carets (normalized to get the deepest leaf TextSelection possible)
- Use `getParentAtCaret` which return the expected node in child vs sibling mode
- Naming tweaks to differentiate between helpers (splitAtEdges vs splitAtInnerLineBreaks)
- Removes paragraph return from `$expandSelectionToLineBreaksAndSplitParagraphs` for the single caller in favor of `Contents.#topLevelElementsInSelection()`
- Drop unneeded optionals
- Comment clean-up 