### PR TITLE
Select prompt item on INPUT_COMMAND where `data=" "` on Android

### DIFF
--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -1,7 +1,7 @@
 import Lexxy from "../config/lexxy"
 import { createElement, generateDomId, parseHtml } from "../helpers/html_helper"
 import { getNonce } from "../helpers/csp_helper"
-import { $createTextNode, $getSelection, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_CRITICAL, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_UP_COMMAND, KEY_ENTER_COMMAND, KEY_SPACE_COMMAND, KEY_TAB_COMMAND } from "lexical"
+import { $createTextNode, $getSelection, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_CRITICAL, INPUT_COMMAND, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_UP_COMMAND, KEY_ENTER_COMMAND, KEY_SPACE_COMMAND, KEY_TAB_COMMAND } from "lexical"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import InlinePromptSource from "../editor/prompt/inline_source"
 import DeferredPromptSource from "../editor/prompt/deferred_source"
@@ -204,6 +204,7 @@ export class LexicalPromptElement extends HTMLElement {
 
     if (this.#doesSpaceSelect) {
       this.#popoverListeners.track(this.#editor.registerCommand(KEY_SPACE_COMMAND, this.#handleSelectedOption.bind(this), COMMAND_PRIORITY_CRITICAL))
+      this.#popoverListeners.track(this.#editor.registerCommand(INPUT_COMMAND, this.#handleInputCommand.bind(this), COMMAND_PRIORITY_CRITICAL))
     }
 
     // Register arrow keys with CRITICAL priority to prevent Lexical's selection handlers from running
@@ -387,6 +388,11 @@ export class LexicalPromptElement extends HTMLElement {
       })
     }
     // Arrow keys are handled via Lexical commands
+  }
+
+  // Android Mobile keyboard doesn't trigger KEY_SPACE_COMMAND
+  #handleInputCommand(event) {
+    if (event.inputType === "insertText" && event.data === " ") return this.#handleSelectedOption(event)
   }
 
   #moveSelectionDown() {

--- a/test/browser/tests/prompts/space_selection_via_input_event.test.js
+++ b/test/browser/tests/prompts/space_selection_via_input_event.test.js
@@ -1,0 +1,34 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt selection via input event (Android soft keyboard)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("selects the highlighted option when an input event with insertText ' ' fires", async ({ page, editor }) => {
+    await editor.send("Hello @")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    // Simulate the Android soft-keyboard path: an input event without a
+    // matching keydown. Lexical maps this to INPUT_COMMAND, which the prompt
+    // listens to in order to select the highlighted option. We deliberately
+    // avoid pressing Space (which would also fire KEY_SPACE_COMMAND and mask
+    // the regression).
+    await editor.content.evaluate((el) => {
+      el.dispatchEvent(new InputEvent("input", {
+        bubbles: true,
+        cancelable: false,
+        inputType: "insertText",
+        data: " ",
+      }))
+    })
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toBeVisible({ timeout: 5_000 })
+    await expect(popover).toBeHidden()
+  })
+})


### PR DESCRIPTION
Android doesn't fire KEY_SPACE_COMMAND, it's an
CONTROLLED_TEXT_INSERTION_COMMAND followed by INPUT_COMMAND with `data=" "`.