### PR TITLE
Top Level Strikethrough and Underline

### DIFF
--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -227,14 +227,14 @@ export class LexicalToolbarElement extends HTMLElement {
 
     this.#setButtonPressed("bold", isBold)
     this.#setButtonPressed("italic", isItalic)
+    this.#setButtonPressed("strikethrough", isStrikethrough)
+    this.#setButtonPressed("underline", isUnderline)
 
-    this.#setButtonPressed("format", isInHeading || isStrikethrough || isUnderline)
+    this.#setButtonPressed("format", isInHeading)
     this.#setButtonPressed("paragraph", !isInHeading)
     this.#setButtonPressed("heading-large", headingTag === "h2")
     this.#setButtonPressed("heading-medium", headingTag === "h3")
     this.#setButtonPressed("heading-small", headingTag === "h4")
-    this.#setButtonPressed("strikethrough", isStrikethrough)
-    this.#setButtonPressed("underline", isUnderline)
 
     this.#setButtonPressed("lists", isInList)
     this.#setButtonPressed("unordered-list", isInList && listType === "bullet")
@@ -397,6 +397,14 @@ export class LexicalToolbarElement extends HTMLElement {
       ${ToolbarIcons.italic}
       </button>
 
+      <button class="lexxy-editor__toolbar-button" type="button" name="strikethrough" data-command="strikethrough" title="Strikethrough">
+        ${ToolbarIcons.strikethrough}
+      </button>
+
+      <button class="lexxy-editor__toolbar-button lexxy-editor__toolbar-group-end" type="button" name="underline" data-command="underline" title="Underline">
+        ${ToolbarIcons.underline}
+      </button>
+
       <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-dropdown">
         <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="format" title="Text formatting" aria-haspopup="menu" aria-expanded="false">
           ${ToolbarIcons.heading}
@@ -413,13 +421,6 @@ export class LexicalToolbarElement extends HTMLElement {
           </button>
           <button class="lexxy-editor__toolbar-group-end" type="button" name="heading-small" data-command="setFormatHeadingSmall" title="Small heading" role="menuitem">
             ${ToolbarIcons.h4} <span>Small Heading</span>
-          </button>
-          <div class="lexxy-editor__toolbar-separator" role="separator"></div>
-          <button type="button" name="strikethrough" data-command="strikethrough" title="Strikethrough" role="menuitem">
-            ${ToolbarIcons.strikethrough} <span>Strikethrough</span>
-          </button>
-          <button type="button" name="underline" data-command="underline" title="Underline" role="menuitem">
-            ${ToolbarIcons.underline} <span>Underline</span>
           </button>
           <div class="lexxy-editor__toolbar-separator" role="separator"></div>
           <button type="button" name="clear-formatting" data-command="clearFormatting" title="Clear formatting" role="menuitem">

--- a/test/browser/helpers/toolbar.js
+++ b/test/browser/helpers/toolbar.js
@@ -10,7 +10,7 @@ export async function openToolbarDropdown(page, name) {
 
 const FORMAT_DROPDOWN_COMMANDS = new Set([
   "setFormatParagraph", "setFormatHeadingLarge", "setFormatHeadingMedium",
-  "setFormatHeadingSmall", "strikethrough", "underline", "clearFormatting"
+  "setFormatHeadingSmall", "clearFormatting"
 ])
 
 export async function clickToolbarButton(page, command) {

--- a/test/test_helpers/editor_handler.rb
+++ b/test/test_helpers/editor_handler.rb
@@ -156,7 +156,11 @@ class EditorHandler
   end
 
   def toggle_command(command, toolbar_selector = "lexxy-toolbar")
-    find("#{toolbar_selector} [data-command=\"#{command}\"]").click
+    button = find("#{toolbar_selector} [data-command=\"#{command}\"]", visible: :all)
+    if button.matches_css?(".lexxy-editor__toolbar-overflow-menu *")
+      find("#{toolbar_selector} .lexxy-editor__toolbar-overflow [data-dropdown-trigger]").click
+    end
+    button.click
   end
 
   def inner_html


### PR DESCRIPTION
### Toolbar changes

Moved strikethrough and underline buttons out of the formatting dropdown and into the main toolbar for direct access.
Updated the pressed-state logic to track the buttons in their new location and simplified the "format" button condition.

The main reasoning: these are expected formatting options in the top level, in most text editors. You can hide them with CSS, in case you don't want to support these options:

```css
lexxy-toolbar {
  button[data-command="strikethrough"] { display: none; }
  button[data-command="underline"] { display: none; }
}
```

We'll add a toolbar configuration to dynamically set these buttons.