### PR TITLE
Fix Error 230 if table is only/last element in doc

### DIFF
--- a/src/elements/table/table_controller.js
+++ b/src/elements/table/table_controller.js
@@ -123,6 +123,8 @@ export class TableController {
 
     this.currentCellKey = cellNode?.getKey() ?? null
     this.currentTableNodeKey = tableNode?.getKey() ?? null
+
+    return tableNode
   }
 
   executeTableCommand(command, customIndex = null) {

--- a/src/elements/table/table_tools.js
+++ b/src/elements/table/table_tools.js
@@ -216,9 +216,8 @@ export class TableTools extends HTMLElement {
 
   #monitorForTableSelection() {
     this.#listeners.track(this.#editor.registerUpdateListener(() => {
-      this.tableController.updateSelectedTable()
+      const tableNode = this.#editor.getRootElement() && this.tableController.updateSelectedTable()
 
-      const tableNode = this.tableController.currentTableNode
       if (tableNode) {
         this.#show()
       } else {

--- a/test/system/action_text_load_test.rb
+++ b/test/system/action_text_load_test.rb
@@ -27,4 +27,22 @@ class ActionTextLoadTest < ApplicationSystemTestCase
       assert_selector "action-text-attachment[content-type='video/mp4']", count: 1
     end
   end
+
+  test "loads via turbo when content ends with a table" do
+    post = Post.create!(
+      title: "Ends with table",
+      body: <<~HTML
+        <figure class="lexxy-content__table-wrapper"><table><tbody><tr><th><p>Hello</p></th><td><p>there</p></td></tr></tbody></table></figure>
+      HTML
+    )
+
+    visit post_path(post)
+    click_on "Edit this post"
+
+    wait_for_editor
+    wait_until do
+      editor_html = Capybara.string(find_editor.value)
+      editor_html.has_selector?("table") && editor_html.has_text?("Hello") && editor_html.has_text?("there")
+    end
+  end
 end


### PR DESCRIPTION
Only show TableTools when a root element is set. This prevents a bug which crashes Lexxy on load when a Table is at the end of the content. It is selected and TableTools cannot resolve the DOM node.

https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9926521235

edited by @samuelpecher 