### PR TITLE
Test sandbox values load cleanly

### DIFF
--- a/test/system/sandbox_test.rb
+++ b/test/system/sandbox_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class SandboxTest < ApplicationSystemTestCase
+  SANDBOX_BUTTON_LABELS = {
+    "default" => "Default",
+    "tables" => "Tables",
+    "code" => "Code blocks",
+    "lists" => "Lists",
+    "highlights" => "Text Highlights",
+    "images" => "Images",
+    "empty" => "Empty"
+  }
+
+  SandboxController::ALLOWED_TEMPLATES.each do |template|
+    test "sandbox/#{template} loads without console errors" do
+      visit (template == "default") ? "/sandbox" : "/sandbox/#{template}"
+      wait_for_editor
+    end
+  end
+
+  test "navigating between sandbox templates via turbo-frame loads cleanly" do
+    visit "/sandbox"
+    wait_for_editor
+
+    SANDBOX_BUTTON_LABELS.except("default").each_value do |label|
+      click_on label
+      wait_for_editor
+    end
+
+    click_on "Default"
+    wait_for_editor
+  end
+end


### PR DESCRIPTION
- Prevents bugs which would crash the sandbox
- Prevents breaking the sandbox

This would have caught #1068 