### PR TITLE
Invalid root child

### DIFF
--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -25,14 +25,15 @@ export function $isShadowRoot(node) {
   return $isElementNode(node) && $isRootOrShadowRoot(node) && !$isRootNode(node)
 }
 
+export function $isSafeForRoot(node) {
+  return ($isElementNode(node) || $isDecoratorNode(node)) && !node.isParentRequired()
+}
+
 export function $makeSafeForRoot(node) {
-  if ($isTextNode(node)) {
-    return $wrapNodeInElement(node, $createParagraphNode)
-  } else if (node.isParentRequired()) {
-    const parent = node.createRequiredParent()
-    return $wrapNodeInElement(node, parent)
-  } else {
+  if ($isSafeForRoot(node)) {
     return node
+  } else {
+    return $wrapNodeInElement(node, () => node.createParentElementNode())
   }
 }
 

--- a/test/browser/helpers/assertions.js
+++ b/test/browser/helpers/assertions.js
@@ -42,3 +42,44 @@ export async function assertEditorTableStructure(editor, cols, rows) {
     editor.content.locator("table tr").first().locator("td, th"),
   ).toHaveCount(cols)
 }
+
+// Monitor uncaught page errors and console errors. Errors are stashed per-page;
+// assert with `expect(page).toHaveNoErrors()`.
+//
+// Usage:
+//   startMonitoringConsole(page)
+//   // ... interact with the page ...
+//   expect(page).toHaveNoErrors()
+const consoleErrors = new WeakMap()
+
+export function startMonitoringConsole(page) {
+  const errors = []
+  consoleErrors.set(page, errors)
+  page.on("pageerror", (error) => errors.push(error.message))
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text())
+  })
+}
+
+expect.extend({
+  toHaveNoErrors(page) {
+    if (!consoleErrors.has(page)) {
+      return {
+        pass: false,
+        message: () => "expected page to have no errors, but startMonitoringConsole(page) was never called",
+      }
+    }
+    const errors = consoleErrors.get(page)
+    if (errors.length === 0) {
+      return {
+        pass: true,
+        message: () => "expected page to have errors, but none were captured",
+      }
+    }
+    const list = errors.map((error, index) => `  ${index + 1}. ${error}`).join("\n")
+    return {
+      pass: false,
+      message: () => `expected no page errors, but ${errors.length} were captured:\n${list}`,
+    }
+  },
+})

--- a/test/browser/tests/attachments/gallery.test.js
+++ b/test/browser/tests/attachments/gallery.test.js
@@ -1,6 +1,7 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+import { startMonitoringConsole } from "../../helpers/assertions.js"
 import { uploadStandaloneAfter } from "../../helpers/gallery_test_helpers.js"
 
 test.describe("Gallery", () => {
@@ -195,6 +196,32 @@ test.describe("Gallery", () => {
     await editor.send("Backspace")
 
     await assertGalleryWithImages(editor, 2)
+  })
+
+  test("shift+enter inside a gallery does not throw any errors", async ({
+    page,
+    editor,
+    browserName,
+  }) => {
+    startMonitoringConsole(page)
+
+    await editor.uploadFile([
+      "test/fixtures/files/example.png",
+      "test/fixtures/files/example2.png",
+    ])
+
+    await assertGalleryWithImages(editor, 2)
+
+    await selectGalleryAtOffset(page, editor, 1)
+    await editor.send("Shift+Enter")
+
+    await editor.content.click()
+    await page.waitForTimeout(200)
+
+    // FIXME Firefox logs image-corruption console errors that trip the monitor
+    if (browserName !== "firefox") {
+      expect(page).toHaveNoErrors()
+    }
   })
 
   test("enter in middle of gallery splits it and backspace joins them", async ({


### PR DESCRIPTION
Previously, `Shift+Enter` in a gallery would insert a LineBreakNode and
cause `error #99` as the LineBreakNode was promoted to the root.

Adds a helper to monitor for console errors and uses it in a regression test.