### PR TITLE
Add only-at attribute to <lexxy-prompt>

### DIFF
--- a/docs/prompts/options-reference.md
+++ b/docs/prompts/options-reference.md
@@ -17,6 +17,7 @@ nav_order: 6
 - `remote-filtering`: Enable server-side filtering instead of loading all options at once.
 - `insert-editable-text`: Insert prompt item HTML directly as editable text instead of Action Text attachments.
 - `supports-space-in-searches`: Allow spaces in search queries (useful with remote filtering for full name searches).
+- `only-at`: Regular expression controlling where the trigger can open the prompt. The pattern is matched against the document text immediately before the trigger and the prompt opens only when it matches. Defaults to `^|[ \n]`, meaning the trigger fires at the very start of the document or right after a space or paragraph break. See [Restricting where the prompt opens](#restricting-where-the-prompt-opens-with-only-at).
 
 ## `<lexxy-prompt-item>`
 
@@ -29,3 +30,24 @@ Each `<lexxy-prompt-item>` can contain one or more `<template type="editor">` el
 
 - `sgid`: The prompt item's sgid to reference a different attachable record.
 - `content-type` (optional): Override the default content type for this specific attachment. If not specified, uses `application/vnd.{namespace}.{prompt-name}`.
+
+## Restricting where the prompt opens with `only-at`
+
+By default the prompt opens when its `trigger` appears at the start of the document or right after a space or paragraph break. This is what you usually want for `@mentions` and similar features, where you don't want a stray `@` inside an email address to pop the prompt open.
+
+The `only-at` attribute lets you change this rule by providing a regular expression. The pattern is matched against the document text immediately before the trigger, and the prompt opens only when the pattern matches.
+
+The text passed to the regex is the full editor text up to the trigger, with paragraph breaks rendered as `\n\n`. The pattern is anchored at the end automatically, so you only need to describe what should precede the trigger.
+
+Some useful patterns:
+
+```html
+<!-- Default. Trigger fires at the start of the document or after whitespace/paragraph break. -->
+<lexxy-prompt trigger="@" name="mention">…</lexxy-prompt>
+
+<!-- Trigger fires only when it is the very first character of the document. -->
+<lexxy-prompt trigger="!" name="bot" only-at="^">…</lexxy-prompt>
+
+<!-- Trigger fires anywhere, including at the start of the document and in the middle of a word. -->
+<lexxy-prompt trigger="#" name="tag" only-at=".*">…</lexxy-prompt>
+```

--- a/lib/lexxy/version.rb
+++ b/lib/lexxy/version.rb
@@ -1,3 +1,3 @@
 module Lexxy
-  VERSION = "0.9.14.beta"
+  VERSION = "0.9.15.alpha.1"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@37signals/lexxy",
-  "version": "0.9.14-beta",
+  "version": "0.9.15-alpha.1",
   "description": "Lexxy - A modern rich text editor for Rails.",
   "module": "dist/lexxy.esm.js",
   "type": "module",

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -127,6 +127,10 @@ export class LexicalPromptElement extends HTMLElement {
   }
 
   get #promptContentTypePermitted() {
+    // `insert-editable-text` prompts never create attachments, so the
+    // editor's attachment support and content-type allowlist don't apply.
+    if (this.hasAttribute("insert-editable-text")) return true
+
     const el = this.#editorElement
     if (!el.supportsAttachments) {
       return false

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -2,6 +2,7 @@ import Lexxy from "../config/lexxy"
 import { createElement, generateDomId, parseHtml } from "../helpers/html_helper"
 import { getNonce } from "../helpers/csp_helper"
 import { $createTextNode, $getSelection, $isRangeSelection, $isTextNode, COMMAND_PRIORITY_CRITICAL, INPUT_COMMAND, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_UP_COMMAND, KEY_ENTER_COMMAND, KEY_SPACE_COMMAND, KEY_TAB_COMMAND } from "lexical"
+import { $textBeforeOffset } from "../helpers/lexical_helper"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import InlinePromptSource from "../editor/prompt/inline_source"
 import DeferredPromptSource from "../editor/prompt/deferred_source"
@@ -11,6 +12,9 @@ import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 
 const NOTHING_FOUND_DEFAULT_MESSAGE = "Nothing found"
 const FILTER_DEBOUNCE_INTERVAL = 50
+
+// Start of line, or after a space or newline.
+const DEFAULT_ONLY_AT_PATTERN = "^|[ \\n]"
 
 export class LexicalPromptElement extends HTMLElement {
   #globalListeners = new ListenerBin()
@@ -57,6 +61,10 @@ export class LexicalPromptElement extends HTMLElement {
     return this.hasAttribute("supports-space-in-searches")
   }
 
+  get onlyAt() {
+    return this.getAttribute("only-at")
+  }
+
   get open() {
     return this.popoverElement?.classList?.contains("lexxy-prompt-menu--visible")
   }
@@ -100,14 +108,10 @@ export class LexicalPromptElement extends HTMLElement {
           if (offset >= triggerLength) {
             const textBeforeCursor = fullText.slice(offset - triggerLength, offset)
 
-            // Check if trigger is at the start of the text node (new line case) or preceded by space or newline
             if (textBeforeCursor === this.trigger) {
-              const isAtStart = offset === triggerLength
+              const textBeforeTrigger = $textBeforeOffset(node, offset - triggerLength)
 
-              const charBeforeTrigger = offset > triggerLength ? fullText[offset - triggerLength - 1] : null
-              const isPrecededBySpaceOrNewline = charBeforeTrigger === " " || charBeforeTrigger === "\n"
-
-              if (isAtStart || isPrecededBySpaceOrNewline) {
+              if (this.#onlyAtRegExp.test(textBeforeTrigger)) {
                 this.#popoverListeners.dispose()
                 this.#showPopover()
               }
@@ -116,6 +120,10 @@ export class LexicalPromptElement extends HTMLElement {
         }
       })
     }))
+  }
+
+  get #onlyAtRegExp() {
+    return new RegExp(`(?:${this.onlyAt ?? DEFAULT_ONLY_AT_PATTERN})$`)
   }
 
   get #promptContentTypePermitted() {

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,4 +1,4 @@
-import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
+import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getRoot, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
@@ -146,6 +146,39 @@ export function $isListItemStructurallyEmpty(listItem) {
     }
   }
   return true
+}
+
+// Returns the document text up to `offset` inside `targetNode`. Non-inline
+// element siblings are joined with `\n\n`, matching Lexical's own
+// ElementNode.getTextContent behavior.
+export function $textBeforeOffset(targetNode, offset) {
+  const parts = []
+  let done = false
+
+  function visit(node) {
+    if (done) return
+    if (node === targetNode) {
+      parts.push(node.getTextContent().slice(0, offset))
+      done = true
+      return
+    }
+    if ($isElementNode(node)) {
+      const children = node.getChildren()
+      for (let i = 0; i < children.length; i++) {
+        visit(children[i])
+        if (done) return
+        const child = children[i]
+        if ($isElementNode(child) && !child.isInline() && i < children.length - 1) {
+          parts.push("\n\n")
+        }
+      }
+    } else {
+      parts.push(node.getTextContent())
+    }
+  }
+
+  visit($getRoot())
+  return parts.join("")
 }
 
 export function isAttachmentSpacerTextNode(node, previousNode, index, childCount) {

--- a/test/browser/fixtures/prompt-insert-editable-text-bypasses-content-type.html
+++ b/test/browser/fixtures/prompt-insert-editable-text-bypasses-content-type.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — insert-editable-text bypasses the content-type gate</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import * as Lexxy from "lexxy"
+    Lexxy.configure({ global: { attachmentTagName: "bc-attachment" }})
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body" data-editor="restricted-allowlist">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Bots prompt"
+        attachments="true"
+        permitted-attachment-types="application/vnd.basecamp.mention">
+        <lexxy-prompt trigger="!" name="bot" only-at=".*" insert-editable-text>
+          <lexxy-prompt-item search="opus">
+            <template type="menu">
+              <span class="bot bot--prompt-item">opus</span>
+            </template>
+            <template type="editor">!opus </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="body" data-editor="attachments-false">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Bots prompt"
+        attachments="false">
+        <lexxy-prompt trigger="!" name="bot" only-at=".*" insert-editable-text>
+          <lexxy-prompt-item search="opus">
+            <template type="menu">
+              <span class="bot bot--prompt-item">opus</span>
+            </template>
+            <template type="editor">!opus </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+  </form>
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/prompt-only-at.html
+++ b/test/browser/fixtures/prompt-only-at.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Prompt only-at</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body" data-editor="start-of-input">
+      <lexxy-editor class="lexxy-content" placeholder="Bots prompt">
+        <lexxy-prompt trigger="!" name="bot" only-at="^">
+          <lexxy-prompt-item search="opus" sgid="test-sgid-opus">
+            <template type="menu">
+              <span class="bot bot--prompt-item">opus</span>
+            </template>
+            <template type="editor">
+              <span class="bot bot--inline">opus</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="haiku" sgid="test-sgid-haiku">
+            <template type="menu">
+              <span class="bot bot--prompt-item">haiku</span>
+            </template>
+            <template type="editor">
+              <span class="bot bot--inline">haiku</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="body" data-editor="anywhere">
+      <lexxy-editor class="lexxy-content" placeholder="Hashtag prompt">
+        <lexxy-prompt trigger="#" name="tag" only-at=".*">
+          <lexxy-prompt-item search="bug" sgid="test-sgid-bug">
+            <template type="menu">
+              <span class="tag tag--prompt-item">bug</span>
+            </template>
+            <template type="editor">
+              <span class="tag tag--inline">bug</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="body" data-editor="default">
+      <lexxy-editor class="lexxy-content" placeholder="Mention prompt">
+        <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="alice" sgid="test-sgid-alice">
+            <template type="menu">
+              <span class="person person--prompt-item">Alice</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Alice</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/prompts/only_at.test.js
+++ b/test/browser/tests/prompts/only_at.test.js
@@ -1,0 +1,80 @@
+import { test } from "../../test_helper.js"
+import { EditorHandle } from "../../helpers/editor_handle.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt only-at attribute", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/prompt-only-at.html")
+  })
+
+  test("only-at=\"^\" opens the prompt at the very start of the document", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='start-of-input'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='start-of-input'] .lexxy-prompt-menu--visible")
+
+    await editor.send("!")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
+
+  test("only-at=\"^\" does not open the prompt after other text", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='start-of-input'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='start-of-input'] .lexxy-prompt-menu--visible")
+
+    await editor.send("hello ")
+    await editor.send("!")
+    await expect(popover).toHaveCount(0)
+  })
+
+  test("only-at=\"^\" does not open the prompt at the start of a later paragraph", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='start-of-input'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='start-of-input'] .lexxy-prompt-menu--visible")
+
+    await editor.send("hello")
+    await editor.send("Enter")
+    await editor.send("!")
+    await expect(popover).toHaveCount(0)
+  })
+
+  test("only-at=\".*\" opens the prompt in the middle of a word", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='anywhere'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='anywhere'] .lexxy-prompt-menu--visible")
+
+    await editor.send("email")
+    await editor.send("#")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
+
+  test("default behavior: does not open the prompt mid-word when only-at is not set", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='default'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='default'] .lexxy-prompt-menu--visible")
+
+    await editor.send("hello")
+    await editor.send("@")
+    await expect(popover).toHaveCount(0)
+  })
+
+  test("default behavior: opens after a space when only-at is not set", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='default'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='default'] .lexxy-prompt-menu--visible")
+
+    await editor.send("hello ")
+    await editor.send("@")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
+
+  test("default behavior: opens at the start of a later paragraph", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='default'] lexxy-editor")
+    await editor.waitForConnected()
+    const popover = page.locator("[data-editor='default'] .lexxy-prompt-menu--visible")
+
+    await editor.send("hello")
+    await editor.send("Enter")
+    await editor.send("@")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/test/browser/tests/prompts/prompt_suppression.test.js
+++ b/test/browser/tests/prompts/prompt_suppression.test.js
@@ -41,4 +41,30 @@ test.describe("Prompt activation is gated on permitted-attachment-types", () => 
     const popover = page.locator(".lexxy-prompt-menu--visible")
     await expect(popover).toBeVisible({ timeout: 5_000 })
   })
+
+  test("insert-editable-text prompt activates even when its content-type is not in the editor's allowlist", async ({ page }) => {
+    await page.goto("/prompt-insert-editable-text-bypasses-content-type.html")
+    const editorElement = page.locator("[data-editor='restricted-allowlist'] lexxy-editor")
+    await editorElement.waitFor({ state: "attached" })
+    await page.waitForSelector("[data-editor='restricted-allowlist'] lexxy-editor[connected]")
+
+    await editorElement.locator(".lexxy-editor__content").click()
+    await page.keyboard.type("!")
+
+    const popover = page.locator("[data-editor='restricted-allowlist'] .lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
+
+  test("insert-editable-text prompt activates even when the editor has attachments=\"false\"", async ({ page }) => {
+    await page.goto("/prompt-insert-editable-text-bypasses-content-type.html")
+    const editorElement = page.locator("[data-editor='attachments-false'] lexxy-editor")
+    await editorElement.waitFor({ state: "attached" })
+    await page.waitForSelector("[data-editor='attachments-false'] lexxy-editor[connected]")
+
+    await editorElement.locator(".lexxy-editor__content").click()
+    await page.keyboard.type("!")
+
+    const popover = page.locator("[data-editor='attachments-false'] .lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+  })
 })


### PR DESCRIPTION
## Summary

Two small additions to `<lexxy-prompt>`:

### `only-at` attribute

Controls *where* the trigger character is allowed to open the prompt. The attribute takes a regular expression that is matched against the text immediately preceding the trigger; the prompt opens only when the regex matches.

The default behavior is preserved — when `only-at` isn't set, the prompt still opens at the start of a line or right after a space/newline (`^|[ \n]`).

This unlocks cases like:

- A "bot" prompt that should only fire when the trigger is the first character on the line:
  ```html
  <lexxy-prompt trigger="!" name="bot" only-at="^">…</lexxy-prompt>
  ```
- A prompt that should fire anywhere, including mid-word:
  ```html
  <lexxy-prompt trigger="#" name="tag" only-at=".*">…</lexxy-prompt>
  ```

The pattern is anchored at the end automatically, so users only describe what should precede the trigger.

### `insert-editable-text` bypasses the content-type gate

`<lexxy-prompt insert-editable-text>` never creates an Action Text attachment — the chosen template is inserted verbatim as editor text. The existing `#promptContentTypePermitted` gate still forced these prompts to satisfy the editor's `supportsAttachments` flag and `permitted-attachment-types` allowlist, so a text-only prompt would silently fail to register its trigger listener whenever the host editor restricted attachments.

The gate now short-circuits to `true` when `insert-editable-text` is present, since no attachment is ever created.

## Context

Discussed on [this Basecamp card](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9937270443) — needed for the BC4 bots prompt, where pressing `!` should open the bot selector at the start of a chat line and insert plain text without any attachment plumbing.

## Changes

- `src/elements/prompt.js` — read the `only-at` attribute and use it to gate the trigger detector; short-circuit `#promptContentTypePermitted` for `insert-editable-text` prompts.
- `test/browser/fixtures/prompt-only-at.html` + `test/browser/tests/prompts/only_at.test.js` — Playwright coverage for `only-at` (start-of-line, anywhere, and the default).
- `test/browser/fixtures/prompt-insert-editable-text-bypasses-content-type.html` + two new cases in `test/browser/tests/prompts/prompt_suppression.test.js` — Playwright coverage for the `insert-editable-text` short-circuit, with both a restricted allowlist and `attachments="false"`.
- `docs/prompts/options-reference.md` — document `only-at` with examples.