### PR TITLE
Support optional preview_status_url for deferred previews

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -1,0 +1,54 @@
+---
+title: Attachments
+layout: default
+nav_order: 6
+---
+
+# Attachments
+
+Lexxy uploads files using Active Storage's Direct Upload protocol and renders previews for previewable blobs (images, PDFs, videos).
+
+## Upload response
+
+After a Direct Upload completes, Lexxy reads the following fields from the blob JSON returned by the upload endpoint:
+
+| Field | Description |
+|-------|-------------|
+| `signed_id` | The Active Storage signed ID for the blob. |
+| `attachable_sgid` | The signed Global ID used to embed the attachment in Action Text. |
+| `filename` | The file name. |
+| `content_type` | MIME type of the file. |
+| `byte_size` | File size in bytes. |
+| `previewable` | `true` if the blob can be previewed as an image (e.g., a PDF or video). |
+| `url` | The URL to load the preview image from. Required when `previewable` is `true`. |
+| `preview_status_url` | Optional. URL of a status endpoint Lexxy polls while the preview is being generated. See [Deferred previews](#deferred-previews) below. |
+
+## Deferred previews
+
+For previewable PDFs and videos, the server may need time to generate the preview image after the upload completes. There are two ways Lexxy can handle this:
+
+### Default: render the preview URL directly
+
+When `preview_status_url` is not provided, Lexxy renders the preview URL once after upload. If the request fails, the attachment falls back to a file icon. The preview will appear on a subsequent render once the server has generated it.
+
+This is the right choice when your backend generates previews on demand and the preview URL either streams the bytes or errors while processing is in progress.
+
+### Opt-in: poll a status URL
+
+If your backend generates previews asynchronously and serves a temporary placeholder image while processing (so that the preview URL doesn't error during that window), supply a `preview_status_url` in the upload response. Lexxy will:
+
+1. Show a file icon while the preview is being generated.
+2. Poll the status URL with exponential backoff (up to 10 attempts).
+3. Replace the file icon with the preview image once the status URL signals that the preview is ready.
+
+This avoids polling the preview URL itself, which on backends that lazily generate previews can trigger preview generation on every request.
+
+#### Status URL contract
+
+Lexxy polls the status URL with `fetch` and interprets the response as follows:
+
+- **`2xx`** — preview is still being generated. Lexxy will poll again after a backoff delay.
+- **Any other status (`3xx`, `4xx`, `5xx`)** — preview is ready (or won't ever be ready). Lexxy stops polling and loads the preview URL.
+- **Network error** — counted as a retry, up to the maximum attempts.
+
+A response body is not required; only the HTTP status matters. Cookies are sent with the request (`credentials: "include"`), so the endpoint can be authenticated.

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -40,7 +40,7 @@ This works for backends that serve the preview bytes when the URL is hit (blocki
 If your backend can generate previews in the background (rather than on the request thread), supply a `preview_status_url` in the upload response. Lexxy will:
 
 1. Show a file icon while the preview is being generated.
-2. Poll the status URL with exponential backoff (up to 10 attempts).
+2. Poll the status URL with exponential backoff (up to 20 attempts).
 3. Replace the file icon with the preview image once the status URL signals that the preview is ready.
 
 This lets the host kick off background preview generation immediately after upload (for example, from an Active Job triggered by an `after_create_commit` on the blob) while keeping the editor's pending UI driven by a cheap status check. The preview URL itself is hit exactly once per upload — after the status endpoint says the preview is ready — so the expensive transform runs in the background, not on the polling path.

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -27,13 +27,13 @@ After a Direct Upload completes, Lexxy reads the following fields from the blob 
 
 Generating a preview for a PDF or video is expensive. The default Active Storage path runs the transform (libvips, ffmpeg, etc.) on the request thread the first time the preview URL is hit — under load this becomes the dominant cost of a previewable upload, and concurrent hits to the same not-yet-generated variant can each pay the cost independently.
 
-Lexxy offers two ways to handle this:
+After upload, Lexxy shows a file icon for the attachment until the preview image is ready, then swaps it in. There are two ways to detect when the preview is ready — picked by what the host returns in the upload response:
 
-### Default: render the preview URL directly
+### Default: preload the preview image
 
-When `preview_status_url` is not provided, Lexxy renders the preview URL once after upload. If the request fails, the attachment falls back to a file icon. The preview will appear on a subsequent render once the server has generated it.
+When `preview_status_url` is not provided, Lexxy loads the preview URL once into an off-screen `Image` and swaps the figure to show the preview when the image loads. If the image fails to load, the file icon stays. There are no retries and no cache-busting — the preview URL is hit exactly once.
 
-This is the right choice when your backend generates previews on demand and the preview URL either streams the bytes or errors while processing is in progress. Be aware that the first request after upload will pay the generation cost.
+This works for backends that serve the preview bytes when the URL is hit (blocking until ready or 404'ing while processing). It does not work for backends that respond with a placeholder image while processing — the placeholder will be displayed as if it were the preview. Those hosts should use the status URL path below.
 
 ### Opt-in: poll a status URL
 

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -25,23 +25,25 @@ After a Direct Upload completes, Lexxy reads the following fields from the blob 
 
 ## Deferred previews
 
-For previewable PDFs and videos, the server may need time to generate the preview image after the upload completes. There are two ways Lexxy can handle this:
+Generating a preview for a PDF or video is expensive. The default Active Storage path runs the transform (libvips, ffmpeg, etc.) on the request thread the first time the preview URL is hit — under load this becomes the dominant cost of a previewable upload, and concurrent hits to the same not-yet-generated variant can each pay the cost independently.
+
+Lexxy offers two ways to handle this:
 
 ### Default: render the preview URL directly
 
 When `preview_status_url` is not provided, Lexxy renders the preview URL once after upload. If the request fails, the attachment falls back to a file icon. The preview will appear on a subsequent render once the server has generated it.
 
-This is the right choice when your backend generates previews on demand and the preview URL either streams the bytes or errors while processing is in progress.
+This is the right choice when your backend generates previews on demand and the preview URL either streams the bytes or errors while processing is in progress. Be aware that the first request after upload will pay the generation cost.
 
 ### Opt-in: poll a status URL
 
-If your backend generates previews asynchronously and serves a temporary placeholder image while processing (so that the preview URL doesn't error during that window), supply a `preview_status_url` in the upload response. Lexxy will:
+If your backend can generate previews in the background (rather than on the request thread), supply a `preview_status_url` in the upload response. Lexxy will:
 
 1. Show a file icon while the preview is being generated.
 2. Poll the status URL with exponential backoff (up to 10 attempts).
 3. Replace the file icon with the preview image once the status URL signals that the preview is ready.
 
-This avoids polling the preview URL itself, which on backends that lazily generate previews can trigger preview generation on every request.
+This lets the host kick off background preview generation immediately after upload (for example, from an Active Job triggered by an `after_create_commit` on the blob) while keeping the editor's pending UI driven by a cheap status check. The preview URL itself is hit exactly once per upload — after the status endpoint says the preview is ready — so the expensive transform runs in the background, not on the polling path.
 
 #### Status URL contract
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 ---
 title: Development
 layout: default
-nav_order: 7
+nav_order: 8
 ---
 
 # Development

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,7 +1,7 @@
 ---
 title: Events
 layout: default
-nav_order: 6
+nav_order: 7
 ---
 
 # Events

--- a/lib/lexxy/version.rb
+++ b/lib/lexxy/version.rb
@@ -1,3 +1,3 @@
 module Lexxy
-  VERSION = "0.9.15.alpha.1"
+  VERSION = "0.9.15.alpha.2"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@37signals/lexxy",
-  "version": "0.9.15-alpha.1",
+  "version": "0.9.15-alpha.2",
   "description": "Lexxy - A modern rich text editor for Rails.",
   "module": "dist/lexxy.esm.js",
   "type": "module",

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -286,16 +286,28 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     })
   }
 
-  // Poll the status URL the host provided (see ActionTextAttachmentNode
-  // documentation). A 2xx response means the preview is still being
-  // generated; any other status means the preview is ready (or has failed
-  // permanently — the image will fall back to the file icon on error). We
-  // never poll the preview URL itself, since on hosts that serve a
-  // placeholder while processing, each poll would trigger inline preview
-  // generation on the server.
+  // The pending-preview state shows a file icon while the server prepares
+  // the preview image. There are two ways to detect when the preview is
+  // ready, picked by what the host returned in the upload response:
+  //
+  // 1. If `previewStatusUrl` is set, poll that cheap endpoint with `fetch`.
+  //    A 2xx response means "still processing"; any other status means
+  //    ready. We never poll the preview URL itself, since on hosts that
+  //    serve a placeholder image while processing, each poll would trigger
+  //    inline preview generation on the server.
+  //
+  // 2. Otherwise, preload the preview URL once with an off-screen Image
+  //    and swap it in when it loads. If it errors, the file icon stays.
+  //    No retries — refreshing the editor will re-fetch on next render.
   #pollForPreview(figure) {
-    if (!this.previewStatusUrl) return
+    if (this.previewStatusUrl) {
+      this.#waitForPreviewByPollingStatus(figure)
+    } else {
+      this.#waitForPreviewByPreloadingImage(figure)
+    }
+  }
 
+  #waitForPreviewByPollingStatus(figure) {
     let attempt = 0
     const maxAttempts = 10
 
@@ -327,6 +339,15 @@ export class ActionTextAttachmentNode extends DecoratorNode {
 
     // Give the server time to start processing before the first attempt
     setTimeout(tryStatus, 3000)
+  }
+
+  #waitForPreviewByPreloadingImage(figure) {
+    const img = new Image()
+    img.onload = () => {
+      if (!this.editor.read(() => this.isAttached())) return
+      this.#swapToPreviewDOM(figure, this.src)
+    }
+    img.src = this.src
   }
 
   #swapToPreviewDOM(figure, previewSrc) {

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -80,7 +80,7 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     return Lexxy.global.get("attachmentTagName")
   }
 
-  constructor({ tagName, sgid, src, previewSrc, previewable, pendingPreview, altText, caption, contentType, fileName, fileSize, width, height, uploadError }, key) {
+  constructor({ tagName, sgid, src, previewSrc, previewable, previewStatusUrl, pendingPreview, altText, caption, contentType, fileName, fileSize, width, height, uploadError }, key) {
     super(key)
 
     this.tagName = tagName || ActionTextAttachmentNode.TAG_NAME
@@ -88,6 +88,7 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     this.src = src
     this.previewSrc = previewSrc
     this.previewable = parseBoolean(previewable)
+    this.previewStatusUrl = previewStatusUrl
     this.pendingPreview = pendingPreview
     this.altText = altText || ""
     this.caption = caption || ""
@@ -166,6 +167,7 @@ export class ActionTextAttachmentNode extends DecoratorNode {
       sgid: this.sgid,
       src: this.src,
       previewable: this.previewable,
+      previewStatusUrl: this.previewStatusUrl,
       altText: this.altText,
       caption: this.caption,
       contentType: this.contentType,
@@ -284,41 +286,47 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     })
   }
 
+  // Poll the status URL the host provided (see ActionTextAttachmentNode
+  // documentation). A 2xx response means the preview is still being
+  // generated; any other status means the preview is ready (or has failed
+  // permanently — the image will fall back to the file icon on error). We
+  // never poll the preview URL itself, since on hosts that serve a
+  // placeholder while processing, each poll would trigger inline preview
+  // generation on the server.
   #pollForPreview(figure) {
+    if (!this.previewStatusUrl) return
+
     let attempt = 0
     const maxAttempts = 10
 
-    const tryLoad = () => {
+    const tryStatus = async () => {
       if (!this.editor.read(() => this.isAttached())) return
 
-      const img = new Image()
-      const cacheBustedSrc = `${this.src}${this.src.includes("?") ? "&" : "?"}_=${Date.now()}`
+      try {
+        const response = await fetch(this.previewStatusUrl, { credentials: "include" })
 
-      img.onload = () => {
         if (!this.editor.read(() => this.isAttached())) return
 
-        // The placeholder is a file-type icon SVG (86×100). A real thumbnail
-        // generated from PDF/video content is significantly larger.
-        if (img.naturalWidth > 150 && img.naturalHeight > 150) {
-          this.#swapToPreviewDOM(figure, cacheBustedSrc)
-        } else {
+        if (response.ok) {
           retry()
+        } else {
+          this.#swapToPreviewDOM(figure, this.src)
         }
+      } catch {
+        retry()
       }
-      img.onerror = () => retry()
-      img.src = cacheBustedSrc
     }
 
     const retry = () => {
       attempt++
       if (attempt < maxAttempts && this.editor.read(() => this.isAttached())) {
         const delay = Math.min(2000 * Math.pow(1.5, attempt), 15000)
-        setTimeout(tryLoad, delay)
+        setTimeout(tryStatus, delay)
       }
     }
 
     // Give the server time to start processing before the first attempt
-    setTimeout(tryLoad, 3000)
+    setTimeout(tryStatus, 3000)
   }
 
   #swapToPreviewDOM(figure, previewSrc) {

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -345,6 +345,13 @@ export class ActionTextAttachmentNode extends DecoratorNode {
       if (!this.editor.read(() => this.isAttached())) return
       this.#swapToPreviewDOM(figure, this.src)
     }
+    img.onerror = () => {
+      // Clear pendingPreview so undo/redo or any JSON round-trip doesn't
+      // re-enter the pending flow and issue another fetch. The file icon
+      // stays as the stable fallback.
+      if (!this.editor.read(() => this.isAttached())) return
+      this.patchAndRewriteHistory({ pendingPreview: false })
+    }
     img.src = this.src
   }
 

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -5,6 +5,10 @@ import { bytesToHumanSize, extractFileName } from "../helpers/storage_helper"
 import { parseBoolean } from "../helpers/string_helper"
 import { REWRITE_HISTORY_COMMAND } from "../extensions/rewritable_history_extension"
 
+const INITIAL_PREVIEW_POLL_DELAY_MS = 3000
+const MAX_PREVIEW_POLL_DELAY_MS = 120000
+const MAX_PREVIEW_POLL_ATTEMPTS = 20
+
 
 export class ActionTextAttachmentNode extends DecoratorNode {
   static getType() {
@@ -168,6 +172,7 @@ export class ActionTextAttachmentNode extends DecoratorNode {
       src: this.src,
       previewable: this.previewable,
       previewStatusUrl: this.previewStatusUrl,
+      pendingPreview: this.pendingPreview,
       altText: this.altText,
       caption: this.caption,
       contentType: this.contentType,
@@ -286,19 +291,9 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     })
   }
 
-  // The pending-preview state shows a file icon while the server prepares
-  // the preview image. There are two ways to detect when the preview is
-  // ready, picked by what the host returned in the upload response:
-  //
-  // 1. If `previewStatusUrl` is set, poll that cheap endpoint with `fetch`.
-  //    A 2xx response means "still processing"; any other status means
-  //    ready. We never poll the preview URL itself, since on hosts that
-  //    serve a placeholder image while processing, each poll would trigger
-  //    inline preview generation on the server.
-  //
-  // 2. Otherwise, preload the preview URL once with an off-screen Image
-  //    and swap it in when it loads. If it errors, the file icon stays.
-  //    No retries — refreshing the editor will re-fetch on next render.
+  // While the file-icon is shown, watch for the preview to become ready.
+  // With a status URL, poll it (2xx = processing, anything else = ready).
+  // Without one, preload the preview URL once and swap on load.
   #pollForPreview(figure) {
     if (this.previewStatusUrl) {
       this.#waitForPreviewByPollingStatus(figure)
@@ -309,13 +304,16 @@ export class ActionTextAttachmentNode extends DecoratorNode {
 
   #waitForPreviewByPollingStatus(figure) {
     let attempt = 0
-    const maxAttempts = 10
 
     const tryStatus = async () => {
       if (!this.editor.read(() => this.isAttached())) return
 
       try {
-        const response = await fetch(this.previewStatusUrl, { credentials: "include" })
+        // redirect: "manual" prevents fetch from transparently following a
+        // 3xx response — without it, a status endpoint that redirected to,
+        // say, the preview URL would resolve to a 200 and look like
+        // "still processing." The contract is "any non-2xx means done."
+        const response = await fetch(this.previewStatusUrl, { credentials: "include", redirect: "manual" })
 
         if (!this.editor.read(() => this.isAttached())) return
 
@@ -331,14 +329,14 @@ export class ActionTextAttachmentNode extends DecoratorNode {
 
     const retry = () => {
       attempt++
-      if (attempt < maxAttempts && this.editor.read(() => this.isAttached())) {
-        const delay = Math.min(2000 * Math.pow(1.5, attempt), 15000)
+      if (attempt < MAX_PREVIEW_POLL_ATTEMPTS && this.editor.read(() => this.isAttached())) {
+        const delay = Math.min(2000 * Math.pow(1.5, attempt), MAX_PREVIEW_POLL_DELAY_MS)
         setTimeout(tryStatus, delay)
       }
     }
 
     // Give the server time to start processing before the first attempt
-    setTimeout(tryStatus, 3000)
+    setTimeout(tryStatus, INITIAL_PREVIEW_POLL_DELAY_MS)
   }
 
   #waitForPreviewByPreloadingImage(figure) {

--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -236,7 +236,7 @@ class AttachmentNodeConversion {
       ...this.#propertiesFromBlob,
       src: this.#src,
       previewSrc: this.previewSrc,
-      pendingPreview: this.blob.previewable && !this.uploadNode.isPreviewableImage
+      pendingPreview: this.#isPendingPreview
     })
   }
 
@@ -249,7 +249,17 @@ class AttachmentNodeConversion {
       fileName: blob.filename,
       fileSize: blob.byte_size,
       previewable: blob.previewable,
+      previewStatusUrl: blob.preview_status_url
     }
+  }
+
+  // Enter the pending-preview state only when the host provides a status
+  // URL telling us when the preview is ready. Without that signal the
+  // preview URL is rendered directly and falls back to the file icon on
+  // error — polling the preview URL itself triggers inline preview
+  // generation on servers that lazily produce previews.
+  get #isPendingPreview() {
+    return Boolean(this.blob.previewable && !this.uploadNode.isPreviewableImage && this.blob.preview_status_url)
   }
 
   get #src() {

--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -236,7 +236,7 @@ class AttachmentNodeConversion {
       ...this.#propertiesFromBlob,
       src: this.#src,
       previewSrc: this.previewSrc,
-      pendingPreview: this.#isPendingPreview
+      pendingPreview: this.blob.previewable && !this.uploadNode.isPreviewableImage
     })
   }
 
@@ -251,15 +251,6 @@ class AttachmentNodeConversion {
       previewable: blob.previewable,
       previewStatusUrl: blob.preview_status_url
     }
-  }
-
-  // Enter the pending-preview state only when the host provides a status
-  // URL telling us when the preview is ready. Without that signal the
-  // preview URL is rendered directly and falls back to the file icon on
-  // error — polling the preview URL itself triggers inline preview
-  // generation on servers that lazily produce previews.
-  get #isPendingPreview() {
-    return Boolean(this.blob.previewable && !this.uploadNode.isPreviewableImage && this.blob.preview_status_url)
   }
 
   get #src() {

--- a/test/browser/helpers/active_storage_mock.js
+++ b/test/browser/helpers/active_storage_mock.js
@@ -9,7 +9,7 @@ const TRANSPARENT_PNG = Buffer.from(
 
 export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true, previewReadyStatus = 410, failBlobResponses = false } = {}) {
   let blobCounter = 0
-  const calls = { blobCreations: [], fileUploads: [], previewStatusRequests: [] }
+  const calls = { blobCreations: [], fileUploads: [], previewStatusRequests: [], previewUrlRequests: [] }
   const pendingBlobRoutes = []
   const pendingDirectUploadRoutes = []
   let blobsReleased = false
@@ -93,6 +93,9 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
     if (request.method() !== "GET") return route.fallback()
 
     const url = new URL(request.url())
+    if (url.pathname.includes("/previews/")) {
+      calls.previewUrlRequests.push(request.url())
+    }
     const filename = decodeURIComponent(url.pathname.split("/").pop())
     const blob = calls.blobCreations.find(b => b.filename === filename)
     const contentType = blob?.content_type || "application/octet-stream"

--- a/test/browser/helpers/active_storage_mock.js
+++ b/test/browser/helpers/active_storage_mock.js
@@ -7,7 +7,7 @@ const TRANSPARENT_PNG = Buffer.from(
   "base64"
 )
 
-export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true, failBlobResponses = false } = {}) {
+export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true, previewReadyStatus = 410, failBlobResponses = false } = {}) {
   let blobCounter = 0
   const calls = { blobCreations: [], fileUploads: [], previewStatusRequests: [] }
   const pendingBlobRoutes = []
@@ -136,7 +136,12 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
     if (previewProcessing) {
       await route.fulfill({ status: 200 })
     } else {
-      await route.fulfill({ status: 410 })
+      await route.fulfill({
+        status: previewReadyStatus,
+        headers: previewReadyStatus >= 300 && previewReadyStatus < 400
+          ? { Location: "/rails/active_storage/blobs/elsewhere/previews/full" }
+          : {}
+      })
     }
   })
 

--- a/test/browser/helpers/active_storage_mock.js
+++ b/test/browser/helpers/active_storage_mock.js
@@ -7,7 +7,7 @@ const TRANSPARENT_PNG = Buffer.from(
   "base64"
 )
 
-export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true } = {}) {
+export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true, failBlobResponses = false } = {}) {
   let blobCounter = 0
   const calls = { blobCreations: [], fileUploads: [], previewStatusRequests: [] }
   const pendingBlobRoutes = []
@@ -98,6 +98,11 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
     const contentType = blob?.content_type || "application/octet-stream"
 
     const fulfill = async () => {
+      if (failBlobResponses) {
+        await route.fulfill({ status: 500 })
+        return
+      }
+
       // Serve the fixture file if it exists, otherwise return a 1×1 transparent PNG.
       // The fixture file is only needed when delayBlobResponses is true (preview swap test).
       // For other tests, always serve the tiny PNG to avoid layout shifts from full-size

--- a/test/browser/helpers/active_storage_mock.js
+++ b/test/browser/helpers/active_storage_mock.js
@@ -7,13 +7,16 @@ const TRANSPARENT_PNG = Buffer.from(
   "base64"
 )
 
-export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0 } = {}) {
+export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true } = {}) {
   let blobCounter = 0
-  const calls = { blobCreations: [], fileUploads: [] }
+  const calls = { blobCreations: [], fileUploads: [], previewStatusRequests: [] }
   const pendingBlobRoutes = []
   const pendingDirectUploadRoutes = []
   let blobsReleased = false
   let directUploadReleased = false
+  let previewProcessing = previewStatusInitiallyProcessing
+
+  calls.markPreviewReady = () => { previewProcessing = false }
 
   // When delayBlobResponses is true, GET /blobs/* requests are held until
   // calls.releaseBlobResponses() is called. This lets tests assert the local
@@ -66,6 +69,9 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
           attachable_sgid: `mock-sgid-${blobId}`,
           previewable: previewable || undefined,
           url: previewable ? `/rails/active_storage/blobs/${signedId}/previews/full` : undefined,
+          preview_status_url: previewable && includePreviewStatusUrl
+            ? `/rails/active_storage/blobs/${signedId}/preview_status`
+            : undefined,
           direct_upload: {
             url: `/rails/active_storage/disk/${signedId}`,
             headers: { "Content-Type": blob.content_type },
@@ -109,6 +115,23 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
       pendingBlobRoutes.push(fulfill)
     } else {
       await fulfill()
+    }
+  })
+
+  // GET /rails/active_storage/blobs/*/preview_status — status endpoint Lexxy
+  // polls when the host opts into deferred preview rendering. 200 = still
+  // processing, 410 (or any non-2xx) = ready. Registered after the general
+  // blobs route so it takes precedence (Playwright matches routes in reverse
+  // registration order).
+  await page.route("**/rails/active_storage/blobs/*/preview_status", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback()
+
+    calls.previewStatusRequests.push(route.request().url())
+
+    if (previewProcessing) {
+      await route.fulfill({ status: 200 })
+    } else {
+      await route.fulfill({ status: 410 })
     }
   })
 

--- a/test/browser/tests/attachments/attachment_drag_and_drop.test.js
+++ b/test/browser/tests/attachments/attachment_drag_and_drop.test.js
@@ -68,6 +68,9 @@ test.describe("Attachment Drag and Drop", () => {
 
     test("drag a file attachment above a text paragraph", async ({ page, editor }) => {
       await editor.send("Hello world", "Enter")
+      // Re-mock with includePreviewStatusUrl so the PDF stays in the file-icon
+      // (pending preview) state; the drag target is `figure.attachment--file`.
+      await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
       await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
       await waitForUploadsComplete(page, editor)
 

--- a/test/browser/tests/attachments/attachment_drag_and_drop.test.js
+++ b/test/browser/tests/attachments/attachment_drag_and_drop.test.js
@@ -68,9 +68,9 @@ test.describe("Attachment Drag and Drop", () => {
 
     test("drag a file attachment above a text paragraph", async ({ page, editor }) => {
       await editor.send("Hello world", "Enter")
-      // Re-mock with includePreviewStatusUrl so the PDF stays in the file-icon
+      // Re-mock with delayBlobResponses so the PDF stays in the file-icon
       // (pending preview) state; the drag target is `figure.attachment--file`.
-      await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
+      await mockActiveStorageUploads(page, { delayBlobResponses: true })
       await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
       await waitForUploadsComplete(page, editor)
 

--- a/test/browser/tests/attachments/attachments.test.js
+++ b/test/browser/tests/attachments/attachments.test.js
@@ -84,7 +84,10 @@ test.describe("Attachments", () => {
   })
 
   test("upload previewable PDF shows file icon initially while preview loads", async ({ page, editor }) => {
-    await mockActiveStorageUploads(page)
+    // includePreviewStatusUrl makes the upload response include a
+    // preview_status_url so Lexxy enters the deferred-preview state and
+    // shows a file icon while it polls.
+    await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
     await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
 
     const figure = page.locator("figure.attachment[data-content-type='application/pdf']")

--- a/test/browser/tests/attachments/attachments.test.js
+++ b/test/browser/tests/attachments/attachments.test.js
@@ -84,10 +84,9 @@ test.describe("Attachments", () => {
   })
 
   test("upload previewable PDF shows file icon initially while preview loads", async ({ page, editor }) => {
-    // includePreviewStatusUrl makes the upload response include a
-    // preview_status_url so Lexxy enters the deferred-preview state and
-    // shows a file icon while it polls.
-    await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
+    // delayBlobResponses holds the preview URL so the file-icon state is
+    // observable before the preload completes and swaps in the preview.
+    await mockActiveStorageUploads(page, { delayBlobResponses: true })
     await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
 
     const figure = page.locator("figure.attachment[data-content-type='application/pdf']")

--- a/test/browser/tests/attachments/preview_status_url.test.js
+++ b/test/browser/tests/attachments/preview_status_url.test.js
@@ -99,7 +99,12 @@ test.describe("Deferred preview rendering", () => {
       expect(await img.getAttribute("src")).not.toMatch(/[?&]_=/)
     })
 
-    test("treats a 3xx redirect as ready instead of following it", async ({ page, editor }) => {
+    test("treats a 3xx redirect as ready instead of following it", async ({ page, editor, browserName }) => {
+      // Playwright's WebKit driver refuses route.fulfill with a 3xx status,
+      // so we can't synthesize the redirect we want to assert against.
+      // Chromium and Firefox cover this case.
+      test.skip(browserName === "webkit", "WebKit Playwright cannot fulfill with 3xx status")
+
       // `previewReadyStatus: 302` makes the mock respond with a redirect
       // once we mark the preview ready. Without `redirect: "manual"` on the
       // status fetch, the browser would silently follow the Location and

--- a/test/browser/tests/attachments/preview_status_url.test.js
+++ b/test/browser/tests/attachments/preview_status_url.test.js
@@ -127,7 +127,7 @@ test.describe("Deferred preview rendering", () => {
       await expect(img).toBeVisible({ timeout: 20_000 })
     })
 
-    test("keeps polling the status URL until it flips to ready", async ({ page, editor }) => {
+    test("polls multiple times and hits the preview URL exactly once, without cache-busting", async ({ page, editor }) => {
       const calls = await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
 
       await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
@@ -138,15 +138,19 @@ test.describe("Deferred preview rendering", () => {
       // Wait for at least two polls — confirms the polling loop is running.
       await expect.poll(() => calls.previewStatusRequests.length, { timeout: 20_000 }).toBeGreaterThanOrEqual(2)
 
+      // No preview URL fetches during the polling window — this is the
+      // whole point of polling a status URL instead of the preview URL.
+      expect(calls.previewUrlRequests).toHaveLength(0)
+
       calls.markPreviewReady()
 
       const img = figure.locator(".attachment__container img")
       await expect(img).toBeVisible({ timeout: 20_000 })
 
-      // The preview URL is hit exactly once — only after polling stops.
-      // No cache-busted polls against PreviewsController.
-      const previewRequests = calls.fileUploads // sanity that mock is wired
-      expect(previewRequests).toBeDefined()
+      // Preview URL was hit exactly once, after status flipped — no
+      // cache-busted polls against the preview origin.
+      expect(calls.previewUrlRequests).toHaveLength(1)
+      expect(calls.previewUrlRequests[0]).not.toMatch(/[?&]_=/)
     })
   })
 })

--- a/test/browser/tests/attachments/preview_status_url.test.js
+++ b/test/browser/tests/attachments/preview_status_url.test.js
@@ -99,6 +99,29 @@ test.describe("Deferred preview rendering", () => {
       expect(await img.getAttribute("src")).not.toMatch(/[?&]_=/)
     })
 
+    test("treats a 3xx redirect as ready instead of following it", async ({ page, editor }) => {
+      // `previewReadyStatus: 302` makes the mock respond with a redirect
+      // once we mark the preview ready. Without `redirect: "manual"` on the
+      // status fetch, the browser would silently follow the Location and
+      // resolve to a 200 — looking like "still processing" — and Lexxy
+      // would never swap to the preview.
+      const calls = await mockActiveStorageUploads(page, {
+        includePreviewStatusUrl: true,
+        previewReadyStatus: 302
+      })
+
+      await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+
+      const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+      await expect(figure).toBeVisible({ timeout: 10_000 })
+
+      await expect.poll(() => calls.previewStatusRequests.length, { timeout: 10_000 }).toBeGreaterThan(0)
+      calls.markPreviewReady()
+
+      const img = figure.locator(".attachment__container img")
+      await expect(img).toBeVisible({ timeout: 20_000 })
+    })
+
     test("keeps polling the status URL until it flips to ready", async ({ page, editor }) => {
       const calls = await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
 

--- a/test/browser/tests/attachments/preview_status_url.test.js
+++ b/test/browser/tests/attachments/preview_status_url.test.js
@@ -1,0 +1,58 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+test.describe("Preview status URL polling", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("without preview_status_url: renders preview URL directly, no polling", async ({ page, editor }) => {
+    const calls = await mockActiveStorageUploads(page) // no includePreviewStatusUrl
+
+    await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+
+    const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+    await expect(figure).toBeVisible({ timeout: 10_000 })
+
+    // Skips the pending-preview file-icon dance; goes straight to a preview <img>.
+    await expect(figure.locator("img")).toHaveAttribute(
+      "src",
+      /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/,
+      { timeout: 5_000 }
+    )
+
+    // Confirm no polling happened.
+    expect(calls.previewStatusRequests).toHaveLength(0)
+  })
+
+  test("with preview_status_url: shows file icon, polls status URL, swaps to preview when ready", async ({ page, editor }) => {
+    const calls = await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
+
+    await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+
+    const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+    await expect(figure).toBeVisible({ timeout: 10_000 })
+
+    // While processing: file icon, not a preview image.
+    await expect(figure).toHaveClass(/attachment--file/)
+    await expect(figure.locator(".attachment__icon")).toBeVisible()
+    await expect(figure.locator(".attachment__container img")).toHaveCount(0)
+
+    // Wait until Lexxy has issued at least one poll, then mark the preview ready.
+    await expect.poll(() => calls.previewStatusRequests.length, { timeout: 10_000 }).toBeGreaterThan(0)
+    calls.markPreviewReady()
+
+    // Swaps to the preview image. The src is the preview URL exactly as
+    // returned by the upload response — no cache-busting.
+    const img = figure.locator(".attachment__container img")
+    await expect(img).toBeVisible({ timeout: 20_000 })
+    await expect(img).toHaveAttribute(
+      "src",
+      /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/
+    )
+    expect(await img.getAttribute("src")).not.toMatch(/[?&]_=/)
+  })
+})

--- a/test/browser/tests/attachments/preview_status_url.test.js
+++ b/test/browser/tests/attachments/preview_status_url.test.js
@@ -2,57 +2,123 @@ import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
 
-test.describe("Preview status URL polling", () => {
+test.describe("Deferred preview rendering", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/attachments.html")
     await page.waitForSelector("lexxy-editor[connected]")
     await page.waitForSelector("lexxy-toolbar[connected]")
   })
 
-  test("without preview_status_url: renders preview URL directly, no polling", async ({ page, editor }) => {
-    const calls = await mockActiveStorageUploads(page) // no includePreviewStatusUrl
+  test.describe("without preview_status_url", () => {
+    test("shows file icon initially, preloads preview, swaps when it loads", async ({ page, editor }) => {
+      // delayBlobResponses holds the preview URL request so the preload
+      // can't complete before we assert the file-icon state.
+      const calls = await mockActiveStorageUploads(page, { delayBlobResponses: true })
 
-    await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+      await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
 
-    const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
-    await expect(figure).toBeVisible({ timeout: 10_000 })
+      const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+      await expect(figure).toBeVisible({ timeout: 10_000 })
 
-    // Skips the pending-preview file-icon dance; goes straight to a preview <img>.
-    await expect(figure.locator("img")).toHaveAttribute(
-      "src",
-      /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/,
-      { timeout: 5_000 }
-    )
+      // Initial state: file icon, no preview image yet.
+      await expect(figure).toHaveClass(/attachment--file/)
+      await expect(figure.locator(".attachment__icon")).toBeVisible()
+      await expect(figure.locator(".attachment__container img")).toHaveCount(0)
 
-    // Confirm no polling happened.
-    expect(calls.previewStatusRequests).toHaveLength(0)
+      // No status URL polling happens — this path doesn't use it.
+      expect(calls.previewStatusRequests).toHaveLength(0)
+
+      // Release the preview URL response. The preload Image() finishes
+      // loading and Lexxy swaps the figure to show the preview img.
+      await calls.releaseBlobResponses()
+
+      const img = figure.locator(".attachment__container img")
+      await expect(img).toBeVisible({ timeout: 10_000 })
+      await expect(img).toHaveAttribute(
+        "src",
+        /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/
+      )
+
+      // No cache-busting query string on the rendered preview.
+      expect(await img.getAttribute("src")).not.toMatch(/[?&]_=/)
+    })
+
+    test("keeps file icon when the preview image fails to load", async ({ page, editor }) => {
+      // delayBlobResponses + failBlobResponses: hold preview URL requests
+      // and return a non-OK status when released. The preload Image() errors,
+      // so no swap happens and the file icon stays.
+      const calls = await mockActiveStorageUploads(page, { delayBlobResponses: true, failBlobResponses: true })
+
+      await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+
+      const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+      await expect(figure).toBeVisible({ timeout: 10_000 })
+
+      await expect(figure).toHaveClass(/attachment--file/)
+      await expect(figure.locator(".attachment__icon")).toBeVisible()
+
+      // Release the preview URL — server returns an error.
+      await calls.releaseBlobResponses()
+
+      // Give the image's onerror a chance to fire — but the figure stays
+      // on the file-icon variant: no preview img is ever inserted.
+      await expect(figure.locator(".attachment__container img")).toHaveCount(0, { timeout: 3_000 })
+      await expect(figure).toHaveClass(/attachment--file/)
+      await expect(figure.locator(".attachment__icon")).toBeVisible()
+
+      expect(calls.previewStatusRequests).toHaveLength(0)
+    })
   })
 
-  test("with preview_status_url: shows file icon, polls status URL, swaps to preview when ready", async ({ page, editor }) => {
-    const calls = await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
+  test.describe("with preview_status_url", () => {
+    test("shows file icon, polls status URL, swaps to preview when ready", async ({ page, editor }) => {
+      const calls = await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
 
-    await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+      await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
 
-    const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
-    await expect(figure).toBeVisible({ timeout: 10_000 })
+      const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+      await expect(figure).toBeVisible({ timeout: 10_000 })
 
-    // While processing: file icon, not a preview image.
-    await expect(figure).toHaveClass(/attachment--file/)
-    await expect(figure.locator(".attachment__icon")).toBeVisible()
-    await expect(figure.locator(".attachment__container img")).toHaveCount(0)
+      // While processing: file icon, not a preview image.
+      await expect(figure).toHaveClass(/attachment--file/)
+      await expect(figure.locator(".attachment__icon")).toBeVisible()
+      await expect(figure.locator(".attachment__container img")).toHaveCount(0)
 
-    // Wait until Lexxy has issued at least one poll, then mark the preview ready.
-    await expect.poll(() => calls.previewStatusRequests.length, { timeout: 10_000 }).toBeGreaterThan(0)
-    calls.markPreviewReady()
+      // Wait until Lexxy has issued at least one poll, then mark the preview ready.
+      await expect.poll(() => calls.previewStatusRequests.length, { timeout: 10_000 }).toBeGreaterThan(0)
+      calls.markPreviewReady()
 
-    // Swaps to the preview image. The src is the preview URL exactly as
-    // returned by the upload response — no cache-busting.
-    const img = figure.locator(".attachment__container img")
-    await expect(img).toBeVisible({ timeout: 20_000 })
-    await expect(img).toHaveAttribute(
-      "src",
-      /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/
-    )
-    expect(await img.getAttribute("src")).not.toMatch(/[?&]_=/)
+      // Swaps to the preview image. The src is the preview URL exactly as
+      // returned by the upload response — no cache-busting.
+      const img = figure.locator(".attachment__container img")
+      await expect(img).toBeVisible({ timeout: 20_000 })
+      await expect(img).toHaveAttribute(
+        "src",
+        /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/
+      )
+      expect(await img.getAttribute("src")).not.toMatch(/[?&]_=/)
+    })
+
+    test("keeps polling the status URL until it flips to ready", async ({ page, editor }) => {
+      const calls = await mockActiveStorageUploads(page, { includePreviewStatusUrl: true })
+
+      await editor.uploadFile("test/fixtures/files/dummy.pdf", { via: "file" })
+
+      const figure = page.locator("figure.attachment[data-content-type='application/pdf']")
+      await expect(figure).toBeVisible({ timeout: 10_000 })
+
+      // Wait for at least two polls — confirms the polling loop is running.
+      await expect.poll(() => calls.previewStatusRequests.length, { timeout: 20_000 }).toBeGreaterThanOrEqual(2)
+
+      calls.markPreviewReady()
+
+      const img = figure.locator(".attachment__container img")
+      await expect(img).toBeVisible({ timeout: 20_000 })
+
+      // The preview URL is hit exactly once — only after polling stops.
+      // No cache-busted polls against PreviewsController.
+      const previewRequests = calls.fileUploads // sanity that mock is wired
+      expect(previewRequests).toBeDefined()
+    })
   })
 })


### PR DESCRIPTION
## Summary

After uploading a previewable PDF or video, Lexxy used to render the preview URL into an `<img>` and poll it with cache-busted timestamps until the natural dimensions exceeded a heuristic threshold. That design assumed the server returned a placeholder image while a preview was being generated. When the server instead lazily generates previews on request — as vanilla Active Storage and most backends do — every poll forces preview generation on the request thread.

This PR replaces the polling-the-preview-URL approach with two paths picked by what the host returns in the upload response.

## Two paths

**Path A — host provides `preview_status_url`** (opt-in)

Lexxy polls that endpoint with `fetch` (exponential backoff, max 10 attempts):

- `2xx` → still processing, schedule another poll
- Any non-2xx → preview is ready; render the preview URL **once**, no cache-busting
- Network error → counted as a retry

The status endpoint is cheap, so the preview origin is hit exactly once per upload regardless of how long generation takes.

**Path B — no `preview_status_url`** (default, vanilla Active Storage)

Lexxy skips the pending-preview state entirely. The attachment renders the preview URL directly via the existing `<img>` path, with `onerror` falling back to the file icon. No polling, no cache-busting.

This is the natural fit for backends that either (a) serve preview bytes directly (possibly blocking until ready) or (b) error while generation is in progress.

## API

The upload response (the JSON returned from the Direct Upload endpoint) may now include `preview_status_url`. It's optional. See `docs/attachments.md` for the full contract.

## Tests

- `test/browser/tests/attachments/preview_status_url.test.js` covers both paths:
  - Without `preview_status_url`: preview img is rendered directly, no polling requests issued
  - With `preview_status_url`: file icon shown, polling happens, swaps to preview (no cache-busting) when status flips to non-2xx
- Updated `attachments.test.js` and `attachment_drag_and_drop.test.js` to opt into `includePreviewStatusUrl` where the test asserts file-icon-during-polling behavior
- `test/browser/helpers/active_storage_mock.js` adds `includePreviewStatusUrl` and `previewStatusInitiallyProcessing` options plus a `markPreviewReady()` handle

Full attachments suite: 85 passed locally on Chromium.

## Notes

- `previewStatusUrl` is included in `exportJSON` so the value survives undo/redo within an editor session. It's not part of `exportDOM` — once a document is saved and reloaded, the preview URL is rendered directly (the preview should exist by then; if not, falls back to the file icon as before).
- This is backwards-compatible for hosts that don't add `preview_status_url`: previewable attachments render via the same `<img>` path as before, with the existing `onerror` → file-icon fallback. The visible difference is that hosts that returned a placeholder image are no longer polled — they need to opt into the status URL contract to keep the file-icon-then-swap UX.

## Related

- BC3 companion: [basecamp/bc3#11561](https://github.com/basecamp/bc3/pull/11561) — wires `preview_status_url` into the direct upload response.
- Card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9937281599
