### PR TITLE
Add a script to develop against a local lexical directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A modern rich text editor for Rails.
 
 - Bug reports and pull requests are welcome on [GitHub Issues](https://github.com/basecamp/lexxy/issues). Help is especially welcome with [those tagged as "Help Wanted"](https://github.com/basecamp/lexxy/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22).
 - For questions and general Lexxy discussion, please use the [Discussions section](https://github.com/basecamp/lexxy/discussions)
+- To build with a development version of Lexical, use `bin/link-to-local-lexical`.
 
 ## License
 

--- a/bin/link-to-local-lexical
+++ b/bin/link-to-local-lexical
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Develop Lexxy against a local checkout of the lexical monorepo
+# (https://github.com/facebook/lexical) instead of the published npm packages.
+#
+# Uses yalc (https://github.com/wclr/yalc), which simulates publishing by
+# copying built packages into a local store and wiring them in as
+# "file:.yalc/<name>" dependencies.
+#
+# Usage: bin/link-to-local-lexical link <path-to-lexical-monorepo>
+#        bin/link-to-local-lexical unlink
+#        bin/link-to-local-lexical status
+#
+# Linking (bin/link-to-local-lexical link <path-to-lexical-monorepo>):
+#   1. Runs "pnpm install" and "pnpm prepare-release" in the lexical repo,
+#      which builds every package into its packages/<name>/npm directory.
+#   2. Publishes each of those packages to the local yalc store. All monorepo
+#      packages are published, not just Lexxy's direct dependencies, so that
+#      inter-package dependencies (e.g. @lexical/list depending on
+#      @lexical/utils) also resolve to the local build.
+#   3. Runs "yalc add" for the packages here, then writes matching yarn
+#      "resolutions" entries into package.json. The resolutions force every
+#      transitive lexical dependency to the local copies; without them, yarn
+#      would install registry versions alongside the linked ones and the
+#      editor would break with duplicate-module errors.
+#   4. Runs "yarn install" to apply it all.
+#
+# Unlinking (bin/link-to-local-lexical unlink):
+#   Reverses the above: collects the linked packages (from package.json and
+#   from whatever is present in .yalc/), runs "yalc remove", deletes the
+#   "resolutions" entries, removes the .yalc directory and yalc.lock, and
+#   runs "yarn install" to restore the registry versions.
+#
+# Status (bin/link-to-local-lexical status):
+#   Reports the current state with machine-readable output: prints
+#   "linked <path-to-lexical-checkout>" and exits 0 when yalc.lock is present
+#   (the path is recorded in .yalc/.lexical-dir during linking), prints
+#   "unlinked" and exits 1 otherwise.
+
+set -euo pipefail
+
+LEXXY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: bin/link-to-local-lexical link <path-to-lexical-monorepo>
+       bin/link-to-local-lexical unlink
+       bin/link-to-local-lexical status
+
+The "link" command links lexxy to a local lexical checkout via yalc. It runs pnpm install +
+build in the lexical repo, publishes each lexical package lexxy depends on, then yalc-adds
+them here.
+
+The "unlink" command removes the yalc-linked packages and restores the registry versions.
+
+The "status" command prints "linked <path-to-lexical>" (exit 0) or "unlinked" (exit 1).
+
+After source changes in lexical, iterate with:
+    (cd <lexical-path> && pnpm prepare-release)
+    (cd <lexical-path>/packages/<name>/npm && npx yalc push)
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+lexxy_direct_lexical_deps() {
+  node -e "
+    const pkg = require('$LEXXY_DIR/package.json');
+    const deps = Object.keys(pkg.dependencies || {});
+    console.log(deps.filter(d => d === 'lexical' || d.startsWith('@lexical/')).join('\n'));
+  "
+}
+
+all_lexical_packages_in_monorepo() {
+  local lexical_dir="$1"
+  node -e "
+    const fs = require('fs'), path = require('path');
+    const dir = path.join('$lexical_dir', 'packages');
+    const names = fs.readdirSync(dir)
+      .map(d => path.join(dir, d, 'npm', 'package.json'))
+      .filter(p => fs.existsSync(p))
+      .map(p => JSON.parse(fs.readFileSync(p)).name)
+      .filter(n => n === 'lexical' || n.startsWith('@lexical/'));
+    console.log(names.join('\n'));
+  "
+}
+
+dep_to_package_dir() {
+  if [[ "$1" == "lexical" ]]; then
+    echo "lexical"
+  else
+    echo "lexical-${1#@lexical/}"
+  fi
+}
+
+write_resolutions() {
+  local mode="$1"   # "add" or "remove"
+  shift
+  node -e "
+    const fs = require('fs');
+    const path = '$LEXXY_DIR/package.json';
+    const pkg = JSON.parse(fs.readFileSync(path));
+    const deps = process.argv.slice(1);
+    if ('$mode' === 'add') {
+      pkg.resolutions = pkg.resolutions || {};
+      for (const d of deps) pkg.resolutions[d] = 'file:.yalc/' + d;
+    } else {
+      if (pkg.resolutions) {
+        for (const d of deps) delete pkg.resolutions[d];
+        if (Object.keys(pkg.resolutions).length === 0) delete pkg.resolutions;
+      }
+    }
+    fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+  " -- "$@"
+}
+
+if [[ "$1" == "status" && $# -eq 1 ]]; then
+  if [[ -f "$LEXXY_DIR/yalc.lock" ]]; then
+    echo "linked $(cat "$LEXXY_DIR/.yalc/.lexical-dir")"
+    exit 0
+  else
+    echo "unlinked"
+    exit 1
+  fi
+fi
+
+if [[ "$1" == "unlink" && $# -eq 1 ]]; then
+  cd "$LEXXY_DIR"
+  mapfile -t packages < <(lexxy_direct_lexical_deps)
+  if [[ -d .yalc ]]; then
+    for d in .yalc/@lexical/*; do
+      [[ -d "$d" ]] && packages+=("@lexical/${d##*/}")
+    done
+    [[ -d .yalc/lexical ]] && packages+=("lexical")
+  fi
+  if [[ ${#packages[@]} -gt 0 ]]; then
+    npx yalc remove "${packages[@]}" 2>/dev/null || true
+    write_resolutions remove "${packages[@]}"
+  fi
+  rm -rf .yalc yalc.lock
+  yarn install
+  echo "==> Unlinked. Lexxy is back on registry versions."
+  exit 0
+fi
+
+if [[ "$1" != "link" || $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+LEXICAL_DIR="$(cd "$2" && pwd)"
+
+if [[ ! -f "$LEXICAL_DIR/package.json" ]]; then
+  echo "Error: $LEXICAL_DIR has no package.json" >&2
+  exit 1
+fi
+
+if [[ "$(node -p "require('$LEXICAL_DIR/package.json').name")" != "@lexical/monorepo" ]]; then
+  echo "Error: $LEXICAL_DIR is not the lexical monorepo root (@lexical/monorepo)" >&2
+  exit 1
+fi
+
+echo "==> Building lexical at $LEXICAL_DIR"
+(cd "$LEXICAL_DIR" && pnpm install && pnpm prepare-release)
+
+mapfile -t packages < <(all_lexical_packages_in_monorepo "$LEXICAL_DIR")
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "Error: no @lexical/* packages found under $LEXICAL_DIR/packages" >&2
+  exit 1
+fi
+
+echo "==> Publishing ${#packages[@]} lexical packages via yalc (incl. transitives)"
+for dep in "${packages[@]}"; do
+  pkg_dir="$LEXICAL_DIR/packages/$(dep_to_package_dir "$dep")/npm"
+  if [[ ! -d "$pkg_dir" ]]; then
+    echo "Error: expected publish directory not found: $pkg_dir" >&2
+    echo "       (did pnpm prepare-release succeed?)" >&2
+    exit 1
+  fi
+  echo "  -> $dep"
+  (cd "$pkg_dir" && npx yalc publish)
+done
+
+echo "==> Adding linked packages to lexxy"
+cd "$LEXXY_DIR"
+npx yalc add "${packages[@]}"
+echo "$LEXICAL_DIR" > .yalc/.lexical-dir
+write_resolutions add "${packages[@]}"
+yarn install
+
+echo "==> Done. Lexxy is now linked to $LEXICAL_DIR"


### PR DESCRIPTION
Uses `yalc` to link a local Lexical directory into Lexxy.  Runs "pnpm install" and "pnpm build" in the Lexical repo, publishes each Lexical package that Lexxy depends on, then yalc-adds them here.

An "unlink" command returns the project to registry versions.

(@samuelpecher and I discussed this last week, just getting around to it now.)