### PR TITLE
Keep prompts horizontally within the editor

### DIFF
--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -281,7 +281,7 @@ export class LexicalPromptElement extends HTMLElement {
 
     const popoverRect = this.popoverElement.getBoundingClientRect()
 
-    if (popoverRect.right > window.innerWidth) {
+    if (popoverRect.right > editorRect.right) {
       this.popoverElement.toggleAttribute("data-clipped-at-right", true)
     }
 

--- a/test/browser/tests/prompts/mentions.test.js
+++ b/test/browser/tests/prompts/mentions.test.js
@@ -82,11 +82,10 @@ test.describe("Mentions", () => {
     expect(positions.textBottom).toBeGreaterThan(positions.mentionTop)
   })
 
-  test("popover stays within viewport when triggered near right edge", async ({ page, editor }) => {
+  test("popover stays within the editor when triggered near the editor's right edge", async ({ page, editor }) => {
     await page.setViewportSize({ width: 400, height: 600 })
     await editor.locator.evaluate((el) => {
-      el.style.width = "150px"
-      el.style.marginLeft = "auto"
+      el.style.width = "220px"
     })
 
     await editor.send("Some text @")
@@ -98,7 +97,11 @@ test.describe("Mentions", () => {
       const r = el.getBoundingClientRect()
       return { left: r.left, right: r.right }
     })
-    expect(rect.right).toBeLessThanOrEqual(400)
-    expect(rect.left).toBeGreaterThanOrEqual(0)
+    const editorRect = await editor.locator.evaluate((el) => {
+      const r = el.getBoundingClientRect()
+      return { left: r.left, right: r.right }
+    })
+    expect(rect.right).toBeLessThanOrEqual(editorRect.right)
+    expect(rect.left).toBeGreaterThanOrEqual(editorRect.left)
   })
 })


### PR DESCRIPTION
When the editor is presented in a modal, opening a prompt close to the right edge was overflowing. This causes the prompt items to be unreadable.

This PR changes the calculation to keep the prompt within the editor itself, instead of calculating against the window.