### PR TITLE
Apply $makeSafeForRoot when unwrapping a singular child of ImageGallery

### DIFF
--- a/src/nodes/image_gallery_node.js
+++ b/src/nodes/image_gallery_node.js
@@ -128,7 +128,7 @@ export class ImageGalleryNode extends ElementNode {
   replaceWithSingularChild() {
     if (this.#hasSingularChild) {
       const child = this.getFirstChild()
-      return this.replace(child)
+      return this.replace($makeSafeForRoot(child))
     }
   }
 

--- a/test/browser/tests/attachments/gallery.test.js
+++ b/test/browser/tests/attachments/gallery.test.js
@@ -380,6 +380,25 @@ test.describe("Gallery", () => {
       page.locator(".attachment-gallery.attachment-gallery--2"),
     ).toBeVisible()
   })
+
+  test("gallery with a nbsp child does not throw any errors", async ({
+    page,
+    editor,
+  }) => {
+    startMonitoringConsole(page)
+
+    // Value must contain two mentions before the &nbsp; to trigger the bug
+    await editor.setValue(`<div class="attachment-gallery attachment-gallery--2">
+      <action-text-attachment sgid="abc" content="Mention" content-type="application/vnd.basecamp.mention"></action-text-attachment>
+      <action-text-attachment sgid="abc" content="Mention" content-type="application/vnd.basecamp.mention"></action-text-attachment>
+      &nbsp;
+      </div>`)
+
+    await editor.content.click()
+    await page.waitForTimeout(200)
+
+    expect(page).toHaveNoErrors()
+  })
 })
 
 // --- Helpers ---


### PR DESCRIPTION
It appears Trix galleries contained unexpected singular children such as `&nbsp`, mentions, and other such unexpected goofs which cannot be appended to root.