### PR TITLE
Prompt vertical direction

### DIFF
--- a/docs/prompts/options-reference.md
+++ b/docs/prompts/options-reference.md
@@ -18,6 +18,7 @@ nav_order: 6
 - `insert-editable-text`: Insert prompt item HTML directly as editable text instead of Action Text attachments.
 - `supports-space-in-searches`: Allow spaces in search queries (useful with remote filtering for full name searches).
 - `only-at`: Regular expression controlling where the trigger can open the prompt. The pattern is matched against the document text immediately before the trigger and the prompt opens only when it matches. Defaults to `^|[ \n]`, meaning the trigger fires at the very start of the document or right after a space or paragraph break. See [Restricting where the prompt opens](#restricting-where-the-prompt-opens-with-only-at).
+- `vertical-direction`: Can be set to `top` or `bottom`. Forces the prompt menu to open either upward or downward. By default, Lexxy uses the window viewport to calculate the best direction. Useful when there are floating elements that might cover up the prompt.
 
 ## `<lexxy-prompt-item>`
 

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -65,6 +65,10 @@ export class LexicalPromptElement extends HTMLElement {
     return this.getAttribute("only-at")
   }
 
+  get verticalDirection() {
+    return this.getAttribute("vertical-direction")
+  }
+
   get open() {
     return this.popoverElement?.classList?.contains("lexxy-prompt-menu--visible")
   }
@@ -297,7 +301,11 @@ export class LexicalPromptElement extends HTMLElement {
       this.popoverElement.toggleAttribute("data-clipped-at-right", true)
     }
 
-    if (popoverRect.bottom > window.innerHeight) {
+    const forceTop = this.verticalDirection === "top"
+    const forceBottom = this.verticalDirection === "bottom"
+    const overflowsWindow = popoverRect.bottom > window.innerHeight
+
+    if (!forceBottom && (forceTop || overflowsWindow)) {
       this.#setPopoverOffsetY(contentRect.height - y + fontSize)
       this.popoverElement.toggleAttribute("data-clipped-at-bottom", true)
     }

--- a/test/browser/fixtures/prompt-vertical-direction.html
+++ b/test/browser/fixtures/prompt-vertical-direction.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test - Prompt vertical direction</title>
+  <link rel="stylesheet" href="/styles.css">
+
+  <style>
+    body {
+      margin: 0;
+    }
+
+    .body {
+      inline-size: 360px;
+      position: absolute;
+    }
+
+    .body[data-editor="top"] {
+      inset-block-start: 160px;
+      inset-inline-start: 20px;
+    }
+
+    .body[data-editor="bottom"] {
+      inset-block-start: 250px;
+      inset-inline-start: 20px;
+    }
+
+    lexxy-editor {
+      border: 1px solid #ccc;
+      display: block;
+    }
+
+    .lexxy-editor__content {
+      min-block-size: 64px;
+      padding: 8px;
+    }
+  </style>
+</head>
+<body>
+  <form>
+    <div class="body" data-editor="top">
+      <lexxy-editor class="lexxy-content" placeholder="Top prompt">
+        <lexxy-prompt trigger="@" name="mention" vertical-direction="top">
+          <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
+            <template type="menu">
+              <span class="person person--prompt-item">Alice</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Alice</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Zacharias" sgid="test-sgid-zacharias">
+            <template type="menu">
+              <span class="person person--prompt-item">Zacharias</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Zacharias</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Sam" sgid="test-sgid-sam">
+            <template type="menu">
+              <span class="person person--prompt-item">Sam</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Sam</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Taylor" sgid="test-sgid-taylor">
+            <template type="menu">
+              <span class="person person--prompt-item">Taylor</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Taylor</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+
+    <div class="body" data-editor="bottom">
+      <lexxy-editor class="lexxy-content" placeholder="Bottom prompt">
+        <lexxy-prompt trigger="@" name="mention" vertical-direction="bottom">
+          <lexxy-prompt-item search="Alice" sgid="test-sgid-alice">
+            <template type="menu">
+              <span class="person person--prompt-item">Alice</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Alice</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Zacharias" sgid="test-sgid-zacharias">
+            <template type="menu">
+              <span class="person person--prompt-item">Zacharias</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Zacharias</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Sam" sgid="test-sgid-sam">
+            <template type="menu">
+              <span class="person person--prompt-item">Sam</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Sam</span>
+            </template>
+          </lexxy-prompt-item>
+          <lexxy-prompt-item search="Taylor" sgid="test-sgid-taylor">
+            <template type="menu">
+              <span class="person person--prompt-item">Taylor</span>
+            </template>
+            <template type="editor">
+              <span class="person person--inline">Taylor</span>
+            </template>
+          </lexxy-prompt-item>
+        </lexxy-prompt>
+      </lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/prompts/vertical_direction.test.js
+++ b/test/browser/tests/prompts/vertical_direction.test.js
@@ -1,0 +1,65 @@
+import { test } from "../../test_helper.js"
+import { EditorHandle } from "../../helpers/editor_handle.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt vertical-direction attribute", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 500, height: 340 })
+    await page.goto("/prompt-vertical-direction.html")
+  })
+
+  test("vertical-direction=\"top\" opens the prompt above the cursor", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='top'] lexxy-editor")
+    await editor.waitForConnected()
+
+    await editor.send("@")
+
+    const popover = page.locator("[data-editor='top'] .lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+    await expect(popover).toHaveAttribute("data-clipped-at-bottom", "")
+
+    const positions = await page.locator("[data-editor='top']").evaluate((container) => {
+      const editor = container.querySelector("lexxy-editor")
+      const popover = container.querySelector(".lexxy-prompt-menu--visible")
+      const editorRect = editor.getBoundingClientRect()
+      const popoverRect = popover.getBoundingClientRect()
+
+      return {
+        editorBottom: editorRect.bottom,
+        popoverBottom: popoverRect.bottom,
+        viewportBottom: window.innerHeight,
+      }
+    })
+
+    expect(positions.popoverBottom).toBeLessThanOrEqual(positions.editorBottom)
+    expect(positions.popoverBottom).toBeLessThanOrEqual(positions.viewportBottom)
+  })
+
+  test("vertical-direction=\"bottom\" keeps the prompt below the cursor even at the viewport edge", async ({ page }) => {
+    const editor = new EditorHandle(page, "[data-editor='bottom'] lexxy-editor")
+    await editor.waitForConnected()
+
+    await editor.send("@")
+
+    const popover = page.locator("[data-editor='bottom'] .lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+    await expect(popover).not.toHaveAttribute("data-clipped-at-bottom", "")
+
+    const positions = await page.locator("[data-editor='bottom']").evaluate((container) => {
+      const editor = container.querySelector("lexxy-editor")
+      const popover = container.querySelector(".lexxy-prompt-menu--visible")
+      const editorRect = editor.getBoundingClientRect()
+      const popoverRect = popover.getBoundingClientRect()
+
+      return {
+        editorTop: editorRect.top,
+        popoverTop: popoverRect.top,
+        popoverBottom: popoverRect.bottom,
+        viewportBottom: window.innerHeight,
+      }
+    })
+
+    expect(positions.popoverTop).toBeGreaterThanOrEqual(positions.editorTop)
+    expect(positions.popoverBottom).toBeGreaterThanOrEqual(positions.viewportBottom)
+  })
+})


### PR DESCRIPTION
This PR adds a new `vertical-direction` attribute for prompts, allowing the prompt menu to be forced to open either upward or downward.

Supported values:
- `top`
- `bottom`

```HTML
<lexxy-prompt trigger="@" src="..." name="mention" vertical-direction="top"></lexxy-prompt>
```

By default, Lexxy chooses the prompt menu direction based on the available space in the window. In layouts with fixed or floating elements, parts of the screen may be visually covered even though they are still within the window bounds. This attribute lets applications override the automatic positioning so the prompt menu opens in the direction that best fits their UI.
