### PR TITLE
Insert <hr> at the nearest root

### DIFF
--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -15,7 +15,7 @@ import {
 } from "lexical"
 import { CodeNode } from "@lexical/code"
 import { $createAutoLinkNode, $toggleLink, LinkNode } from "@lexical/link"
-import { $getNearestNodeOfType } from "@lexical/utils"
+import { $getNearestNodeOfType, $insertNodeToNearestRoot } from "@lexical/utils"
 import { INSERT_TABLE_COMMAND } from "@lexical/table"
 
 import { createElement } from "../helpers/html_helper"
@@ -225,8 +225,7 @@ export class CommandDispatcher {
   }
 
   dispatchInsertHorizontalDivider() {
-    this.contents.insertAtCursorEnsuringLineBelow(new HorizontalDividerNode())
-    this.editor.focus()
+    $insertNodeToNearestRoot(new HorizontalDividerNode)
   }
 
   dispatchSetFormatHeadingLarge() {

--- a/test/browser/tests/formatting/horizontal_divider.test.js
+++ b/test/browser/tests/formatting/horizontal_divider.test.js
@@ -75,6 +75,19 @@ test.describe("Horizontal divider", () => {
     await assertEditorHtml(editor, "<p>Text before</p><p>Text after</p>")
   })
 
+  test("insert horizontal divider at start of heading", async ({ page, editor }) => {
+    await editor.setValue("<h2>Heading</h2>")
+    await editor.content.locator("h2").click()
+    await editor.send("Home")
+
+    await page.getByRole("button", { name: "Insert a divider" }).click()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("figure.horizontal-divider hr")).toBeVisible()
+    })
+    await assertEditorHtml(editor, "<h2><br></h2><hr><h2>Heading</h2>")
+  })
+
   test("horizontal divider with surrounding content", async ({
     page,
     editor,


### PR DESCRIPTION
`HorizontalDividerNode` should be a direct child of the root. Attempting to insert it at the cursor throws an error in certain nodes, like headings.