### PR TITLE
Support Elixir

### DIFF
--- a/src/config/prism.js
+++ b/src/config/prism.js
@@ -34,5 +34,6 @@ import "prismjs/components/prism-go"
 import "prismjs/components/prism-bash"
 import "prismjs/components/prism-json"
 import "prismjs/components/prism-kotlin"
+import "prismjs/components/prism-elixir"
 
 export default Prism

--- a/src/elements/code_language_picker.js
+++ b/src/elements/code_language_picker.js
@@ -71,6 +71,7 @@ export class CodeLanguagePicker extends HTMLElement {
     languages.json ||= "JSON"
     languages.diff ||= "Diff"
     languages.kotlin ||= "Kotlin"
+    languages.elixir ||= "Elixir"
 
 
     // Place the "plain" entry first, then the rest of language sorted alphabetically

--- a/test/dummy/app/views/sandbox/_code.html.erb
+++ b/test/dummy/app/views/sandbox/_code.html.erb
@@ -142,6 +142,26 @@ h1 {
 
 <p><br/></p>
 
+<h4>Elixir</h4>
+<pre data-language="elixir" data-highlight-language="elixir">
+defmodule Greeter do
+  @greeting "Hello"
+
+  def greet(name) when is_binary(name) do
+    "#{@greeting}, #{name}!"
+  end
+
+  def greet_all(names) do
+    names
+    |> Enum.map(&amp;greet/1)
+    |> Enum.join("\n")
+  end
+end
+
+IO.puts(Greeter.greet("Kate"))</pre>
+
+<p><br/></p>
+
 <h4>Go</h4>
 <pre data-language="go" data-highlight-language="go">
 package main

--- a/test/javascript/unit/helpers/code_highlighting_helper.test.js
+++ b/test/javascript/unit/helpers/code_highlighting_helper.test.js
@@ -31,7 +31,8 @@ const expectedGrammars = [
   "go",
   "bash",
   "json",
-  "kotlin"
+  "kotlin",
+  "elixir"
 ]
 
 test.each(expectedGrammars)("Prism includes the %s grammar", (grammar) => {


### PR DESCRIPTION
## What

Adds **Elixir** as a supported code-block language, so it appears in the language picker and gets syntax highlighting.

## Why

Elixir was missing from the picker (the dropdown jumps from Diff to Go), so code blocks couldn't be highlighted as Elixir. Prism ships an Elixir grammar, so this is a small, self-contained addition.

## How

Mirrors the existing manual language entries (Ruby/PHP/Go/Bash/JSON/Diff/Kotlin):

- `src/config/prism.js` — register the grammar: `import "prismjs/components/prism-elixir"`.
- `src/elements/code_language_picker.js` — add `languages.elixir ||= "Elixir"` to the picker (needed because `@lexical/code`'s `CODE_LANGUAGE_FRIENDLY_NAME_MAP` doesn't include Elixir — same reason the other languages above are hand-added). The getter sorts alphabetically, so it slots in automatically.
- `test/javascript/unit/helpers/code_highlighting_helper.test.js` — add `"elixir"` to `expectedGrammars` so the parametric test asserts the grammar loads.
- `test/dummy/app/views/sandbox/_code.html.erb` — add an Elixir example (alphabetically between Diff and Go).

`prismjs/components/prism-elixir` has no extra Prism dependency (no `require` in `components.json`), so nothing else needs importing.

## Testing

- `yarn test` — passes, including the new `Prism includes the elixir grammar` assertion.
- `yarn lint` — clean.
- `yarn build` — builds cleanly with the new import.
