### PR TITLE
Load initial value within Lexical build lifecycle 

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -54,7 +54,6 @@ export class LexicalEditorElement extends HTMLElement {
   #initialValue = ""
   #initializeEventDispatched = false
   #editorInitializedDispatched = false
-  #valueLoaded = false
   #listeners = new ListenerBin()
   #disposables = []
   #historyState = { undo: false, redo: false }
@@ -106,12 +105,7 @@ export class LexicalEditorElement extends HTMLElement {
   disconnectedCallback() {
     this.#initializeEventDispatched = false
     this.#editorInitializedDispatched = false
-    if (this.#valueLoaded) {
-      this.valueBeforeDisconnect = this.value
-    } else {
-      this.valueBeforeDisconnect = null
-    }
-    this.#valueLoaded = false
+    this.valueBeforeDisconnect = this.value
     this.#reset() // Prevent hangs with Safari when morphing
   }
 
@@ -316,7 +310,6 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   set value(html) {
-    this.#valueLoaded = true
     const editorHasFocus = this.#isContentFocused
 
     this.editor.update(() => {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -259,7 +259,6 @@ export class LexicalEditorElement extends HTMLElement {
 
     if (!this.editor) return
 
-    this.#editorInitializedDispatched = true
     this.#dispatchEditorInitialized()
     this.#dispatchAttributesChange()
   }
@@ -775,6 +774,8 @@ export class LexicalEditorElement extends HTMLElement {
   #dispatchEditorInitialized() {
     if (!this.adapter) return
 
+    this.#editorInitializedDispatched = true
+
     this.adapter.dispatchEditorInitialized({
       highlightColors: this.#resolvedHighlightColors,
       headingFormats: this.#supportedHeadingFormats
@@ -789,7 +790,6 @@ export class LexicalEditorElement extends HTMLElement {
       }
 
       if (!this.#editorInitializedDispatched) {
-        this.#editorInitializedDispatched = true
         this.#dispatchEditorInitialized()
       }
     }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -105,7 +105,11 @@ export class LexicalEditorElement extends HTMLElement {
   disconnectedCallback() {
     this.#initializeEventDispatched = false
     this.#editorInitializedDispatched = false
+
+    delete this._internalFormValue
     this.valueBeforeDisconnect = this.value
+
+    this.#clearCachedValues()
     this.#reset() // Prevent hangs with Safari when morphing
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,4 +1,4 @@
-import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, HISTORY_MERGE_TAG, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
@@ -226,8 +226,8 @@ export class LexicalEditorElement extends HTMLElement {
     return dispatch(this, "lexxy:file-accept", { file }, true)
   }
 
-  $generateNodesFromDOM(doc) {
-    let nodes = $generateLexicalNodesFromDOM(this.editor, doc)
+  $generateNodesFromDOM(doc, { editor = this.editor } = {}) {
+    let nodes = $generateLexicalNodesFromDOM(editor, doc)
     if ($hasUpdateTag(PASTE_TAG)) nodes = $convertInlineImageDataURIs(nodes, this)
     return filterDisallowedAttachmentNodes(nodes, this)
   }
@@ -336,11 +336,8 @@ export class LexicalEditorElement extends HTMLElement {
         $addUpdateTag(SKIP_DOM_SELECTION_TAG)
       }
 
-      $getRoot()
-        .clear()
-        .selectEnd()
-        .insertNodes(this.#parseHtmlIntoLexicalNodes(html))
 
+      this.#setEditorHtml(html)
       this.#toggleEmptyStatus()
     }, { discrete: true })
   }
@@ -353,9 +350,9 @@ export class LexicalEditorElement extends HTMLElement {
     return this.#historyState.redo
   }
 
-  #parseHtmlIntoLexicalNodes(html) {
+  #parseHtmlIntoLexicalNodes(html, { editor = this.editor } = {}) {
     if (!html) html = "<p></p>"
-    const nodes = this.$generateNodesFromDOM(parseHtml(`${html}`))
+    const nodes = this.$generateNodesFromDOM(parseHtml(`${html}`), { editor })
 
     return nodes
       .filter(this.#isNotWhitespaceOnlyNode)
@@ -391,7 +388,6 @@ export class LexicalEditorElement extends HTMLElement {
     this.#attachDebugHooks()
     this.#attachToolbar()
     this.#configureSanitizer()
-    this.#loadInitialValue()
     this.#resetBeforeTurboCaches()
   }
 
@@ -416,7 +412,8 @@ export class LexicalEditorElement extends HTMLElement {
       nodes: this.#lexicalNodes,
       html: {
         export: new Map([ [ TextNode, exportTextNodeDOM ], [ CodeHighlightNode, exportTextNodeDOM ] ])
-      }
+      },
+      $initialEditorState: (editor) => this.#loadInitialValue(editor)
     },
       ...this.extensions.lexicalExtensions
     )
@@ -498,13 +495,19 @@ export class LexicalEditorElement extends HTMLElement {
     return this._internalFormValue
   }
 
-  #loadInitialValue() {
-    if (!this.#valueLoaded) {
-      const initialHtml = this.valueBeforeDisconnect || this.getAttribute("value") || "<p><br></p>"
-      this.editor.update(() => {
-        this.value = this.#initialValue = initialHtml
-      }, { tag: HISTORY_MERGE_TAG })
-    }
+  #loadInitialValue(editor) {
+    const initialHtml = this.valueBeforeDisconnect || this.getAttribute("value") || "<p><br></p>"
+
+    this.#initialValue = initialHtml
+    this.#internalFormValue = initialHtml
+    this.#setEditorHtml(initialHtml, { editor })
+  }
+
+  #setEditorHtml(html, { editor = this.editor } = { }) {
+    $getRoot()
+      .clear()
+      .selectEnd()
+      .insertNodes(this.#parseHtmlIntoLexicalNodes(html, { editor }))
   }
 
   #resetBeforeTurboCaches() {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -136,13 +136,9 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   toString() {
-    if (this.cachedStringValue == null) {
-      this.editor?.getEditorState().read(() => {
-        this.cachedStringValue = $getReadableTextContent($getRoot())
-      })
-    }
-
-    return this.cachedStringValue
+    return this.cachedStringValue ??= this.editor?.read(() => {
+      return $getReadableTextContent($getRoot())
+    })
   }
 
   get form() {
@@ -314,13 +310,9 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   get value() {
-    if (!this.cachedValue) {
-      this.editor?.getEditorState().read(() => {
-        this.cachedValue = sanitize($generateHtmlFromNodes(this.editor, null))
-      })
-    }
-
-    return this.cachedValue
+    return this.cachedValue ??= this.editor?.read(() => {
+      return sanitize($generateHtmlFromNodes(this.editor, null))
+    }) ?? null
   }
 
   set value(html) {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -52,6 +52,8 @@ export class LexicalEditorElement extends HTMLElement {
   static observedAttributes = [ "connected", "required" ]
 
   #initialValue = ""
+  #previousInternalFormValue = null
+
   #initializeEventDispatched = false
   #editorInitializedDispatched = false
   #listeners = new ListenerBin()
@@ -106,7 +108,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.#initializeEventDispatched = false
     this.#editorInitializedDispatched = false
 
-    delete this._internalFormValue
+    this.#previousInternalFormValue = null
     this.valueBeforeDisconnect = this.value
 
     this.#clearCachedValues()
@@ -468,26 +470,22 @@ export class LexicalEditorElement extends HTMLElement {
     return Array.from(this.attributes).filter(attribute => attribute.name.startsWith("aria-"))
   }
 
-  set #internalFormValue(html) {
-    const changed = this.#internalFormValue !== undefined && this.#internalFormValue !== this.value
+  #setInternalFormValue(html) {
+    const changed = this.#previousInternalFormValue !== null && html !== this.#previousInternalFormValue
 
     this.internals.setFormValue(html)
-    this._internalFormValue = html
+    this.#previousInternalFormValue = html
 
     if (changed) {
       dispatch(this, "lexxy:change")
     }
   }
 
-  get #internalFormValue() {
-    return this._internalFormValue
-  }
-
   #loadInitialValue(editor) {
     const initialHtml = this.valueBeforeDisconnect || this.getAttribute("value") || "<p><br></p>"
 
     this.#initialValue = initialHtml
-    this.#internalFormValue = initialHtml
+    this.#setInternalFormValue(initialHtml)
     this.#setEditorHtml(initialHtml, { editor })
   }
 
@@ -513,7 +511,7 @@ export class LexicalEditorElement extends HTMLElement {
   #synchronizeWithChanges() {
     this.#listeners.track(this.editor.registerUpdateListener(({ editorState }) => {
       this.#clearCachedValues()
-      this.#internalFormValue = this.value
+      this.#setInternalFormValue(this.value)
       this.#toggleEmptyStatus()
       this.#requestValidityRefresh()
       this.#dispatchAttributesChange()


### PR DESCRIPTION
- Loads the initial value by passing `#loadInitialValue` to `$initialEditorState` to build theal editor with the initial value
- Remove `valueLoaded` tracking as editor comes with value loaded
- Collapse `internalFormValue` tracking to two variables/setters from three
- Force `value` and `toString()` getters to flush updates with `editor.read`
- Move setting `#editorInitializedDispatched` to disambiguate that it's for the adapter