### PR TITLE
Add text alignment (left/center/right/justify)

### DIFF
--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -3,7 +3,7 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 
 const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
 
-const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
+const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color", "text-align" ]
 
 function styleFilterHook(_currentNode, hookEvent) {
   if (hookEvent.attrName === "style" && hookEvent.attrValue) {

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -5,6 +5,7 @@ import {
   $isTextNode,
   $setSelection,
   COMMAND_PRIORITY_NORMAL,
+  FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
@@ -37,6 +38,10 @@ const COMMANDS = [
   "setFormatHeadingMedium",
   "setFormatHeadingSmall",
   "setFormatParagraph",
+  "alignLeft",
+  "alignCenter",
+  "alignRight",
+  "alignJustify",
   "clearFormatting",
   "insertUnorderedList",
   "insertOrderedList",
@@ -242,6 +247,22 @@ export class CommandDispatcher {
 
   dispatchSetFormatParagraph() {
     this.contents.applyParagraphFormat()
+  }
+
+  dispatchAlignLeft() {
+    this.editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "left")
+  }
+
+  dispatchAlignCenter() {
+    this.editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "center")
+  }
+
+  dispatchAlignRight() {
+    this.editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "right")
+  }
+
+  dispatchAlignJustify() {
+    this.editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, "justify")
   }
 
   dispatchClearFormatting() {

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -3,7 +3,7 @@ import {
   $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $setSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW, DELETE_CHARACTER_COMMAND,
   HISTORY_MERGE_TAG, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND, SELECTION_CHANGE_COMMAND, isDOMNode
 } from "lexical"
-import { $getNearestNodeOfType } from "@lexical/utils"
+import { $getNearestBlockElementAncestorOrThrow, $getNearestNodeOfType } from "@lexical/utils"
 import { $getListDepth, ListItemNode, ListNode } from "@lexical/list"
 import { $getTableCellNodeFromLexicalNode, TableCellNode } from "@lexical/table"
 import { CodeNode } from "@lexical/code"
@@ -111,7 +111,16 @@ export default class Selection {
       headingTag: headingNode?.getTag() ?? null,
       isInList: listType !== null,
       listType,
-      isInTable: $getTableCellNodeFromLexicalNode(anchorNode) !== null
+      isInTable: $getTableCellNodeFromLexicalNode(anchorNode) !== null,
+      blockAlignment: this.#getBlockAlignment(anchorNode)
+    }
+  }
+
+  #getBlockAlignment(anchorNode) {
+    try {
+      return $getNearestBlockElementAncestorOrThrow(anchorNode).getFormatType() ?? ""
+    } catch {
+      return ""
     }
   }
 

--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -223,7 +223,7 @@ export class LexicalToolbarElement extends HTMLElement {
     if (!anchorNode.getParent()) { return }
 
     const { isBold, isItalic, isStrikethrough, isUnderline, isHighlight, isInLink, isInQuote, isInHeading,
-      headingTag, isInCode, isInList, listType, isInTable } = this.selection.getFormat()
+      headingTag, isInCode, isInList, listType, isInTable, blockAlignment } = this.selection.getFormat()
 
     this.#setButtonPressed("bold", isBold)
     this.#setButtonPressed("italic", isItalic)
@@ -246,6 +246,11 @@ export class LexicalToolbarElement extends HTMLElement {
     this.#setButtonPressed("code", isInCode)
 
     this.#setButtonPressed("table", isInTable)
+
+    this.#setButtonPressed("align-left", blockAlignment === "left")
+    this.#setButtonPressed("align-center", blockAlignment === "center")
+    this.#setButtonPressed("align-right", blockAlignment === "right")
+    this.#setButtonPressed("align-justify", blockAlignment === "justify")
   }
 
   #setButtonPressed(name, isPressed) {
@@ -425,6 +430,26 @@ export class LexicalToolbarElement extends HTMLElement {
           <div class="lexxy-editor__toolbar-separator" role="separator"></div>
           <button type="button" name="clear-formatting" data-command="clearFormatting" title="Clear formatting" role="menuitem">
             ${ToolbarIcons.clearFormatting} <span>Clear formatting</span>
+          </button>
+        </div>
+      </lexxy-toolbar-dropdown>
+
+      <lexxy-toolbar-dropdown class="lexxy-editor__toolbar-dropdown">
+        <button data-dropdown-trigger class="lexxy-editor__toolbar-button lexxy-editor__toolbar-button--chevron" type="button" name="alignment" title="Text alignment" aria-haspopup="menu" aria-expanded="false">
+          ${ToolbarIcons.alignLeft}
+        </button>
+        <div data-dropdown-panel role="menu" class="lexxy-editor__toolbar-dropdown-list" hidden>
+          <button type="button" name="align-left" data-command="alignLeft" title="Align left" role="menuitem">
+            ${ToolbarIcons.alignLeft} <span>Left</span>
+          </button>
+          <button type="button" name="align-center" data-command="alignCenter" title="Align center" role="menuitem">
+            ${ToolbarIcons.alignCenter} <span>Center</span>
+          </button>
+          <button type="button" name="align-right" data-command="alignRight" title="Align right" role="menuitem">
+            ${ToolbarIcons.alignRight} <span>Right</span>
+          </button>
+          <button type="button" name="align-justify" data-command="alignJustify" title="Justify" role="menuitem">
+            ${ToolbarIcons.alignJustify} <span>Justify</span>
           </button>
         </div>
       </lexxy-toolbar-dropdown>

--- a/src/elements/toolbar_icons.js
+++ b/src/elements/toolbar_icons.js
@@ -119,5 +119,25 @@ export default {
   "overflow":
   `<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
     <path d="M3 6.75C4.24264 6.75 5.25 7.75736 5.25 9C5.25 10.2426 4.24264 11.25 3 11.25C1.75736 11.25 0.75 10.2426 0.75 9C0.75 7.75736 1.75736 6.75 3 6.75ZM9 6.75C10.2426 6.75 11.25 7.75736 11.25 9C11.25 10.2426 10.2426 11.25 9 11.25C7.75736 11.25 6.75 10.2426 6.75 9C6.75 7.75736 7.75736 6.75 9 6.75ZM15 6.75C16.2426 6.75 17.25 7.75736 17.25 9C17.25 10.2426 16.2426 11.25 15 11.25C13.7574 11.25 12.75 10.2426 12.75 9C12.75 7.75736 13.7574 6.75 15 6.75Z"/>
+  </svg>`,
+
+  "alignLeft":
+  `<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 3.5h14v2H2zM2 7.5h10v2H2zM2 11.5h14v2H2zM2 15.5h10v2H2z" transform="translate(0,-2)"/>
+  </svg>`,
+
+  "alignCenter":
+  `<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 3.5h14v2H2zM4 7.5h10v2H4zM2 11.5h14v2H2zM4 15.5h10v2H4z" transform="translate(0,-2)"/>
+  </svg>`,
+
+  "alignRight":
+  `<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 3.5h14v2H2zM6 7.5h10v2H6zM2 11.5h14v2H2zM6 15.5h10v2H6z" transform="translate(0,-2)"/>
+  </svg>`,
+
+  "alignJustify":
+  `<svg viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 3.5h14v2H2zM2 7.5h14v2H2zM2 11.5h14v2H2zM2 15.5h14v2H2z" transform="translate(0,-2)"/>
   </svg>`
 }

--- a/test/browser/helpers/toolbar.js
+++ b/test/browser/helpers/toolbar.js
@@ -13,9 +13,19 @@ const FORMAT_DROPDOWN_COMMANDS = new Set([
   "setFormatHeadingSmall", "clearFormatting"
 ])
 
+const ALIGNMENT_DROPDOWN_COMMANDS = new Set([
+  "alignLeft", "alignCenter", "alignRight", "alignJustify"
+])
+
+export async function openAlignmentDropdown(page) {
+  await openToolbarDropdown(page, "alignment")
+}
+
 export async function clickToolbarButton(page, command) {
   if (FORMAT_DROPDOWN_COMMANDS.has(command)) {
     await openFormatDropdown(page)
+  } else if (ALIGNMENT_DROPDOWN_COMMANDS.has(command)) {
+    await openAlignmentDropdown(page)
   }
   await page.locator(`[data-command='${command}']`).click()
 }

--- a/test/browser/tests/formatting/text_alignment.test.js
+++ b/test/browser/tests/formatting/text_alignment.test.js
@@ -1,0 +1,102 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+import { clickToolbarButton, openAlignmentDropdown } from "../../helpers/toolbar.js"
+
+test.describe("Text alignment", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("aligns a paragraph to the right", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+    await editor.select("Hello")
+
+    await clickToolbarButton(page, "alignRight")
+
+    await assertEditorHtml(editor, '<p style="text-align: right;">Hello everyone</p>')
+  })
+
+  test("centers a paragraph", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+    await editor.select("Hello")
+
+    await clickToolbarButton(page, "alignCenter")
+
+    await assertEditorHtml(editor, '<p style="text-align: center;">Hello everyone</p>')
+  })
+
+  test("justifies a paragraph", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+    await editor.select("Hello")
+
+    await clickToolbarButton(page, "alignJustify")
+
+    await assertEditorHtml(editor, '<p style="text-align: justify;">Hello everyone</p>')
+  })
+
+  test("switches a right-aligned paragraph to left", async ({ page, editor }) => {
+    await editor.setValue('<p style="text-align: right;">Hello everyone</p>')
+    await editor.select("Hello")
+
+    await clickToolbarButton(page, "alignLeft")
+
+    await assertEditorHtml(editor, '<p style="text-align: left;">Hello everyone</p>')
+  })
+
+  test("aligns a heading", async ({ page, editor }) => {
+    await editor.setValue("<h2>Hello everyone</h2>")
+    await editor.select("Hello")
+
+    await clickToolbarButton(page, "alignCenter")
+
+    await assertEditorHtml(editor, '<h2 style="text-align: center;">Hello everyone</h2>')
+  })
+
+  test("aligns a list item", async ({ page, editor }) => {
+    await editor.setValue("<ul><li>Hello everyone</li></ul>")
+    await editor.select("Hello")
+
+    await clickToolbarButton(page, "alignRight")
+
+    await assertEditorHtml(editor, '<ul><li value="1" style="text-align: right;">Hello everyone</li></ul>')
+  })
+
+  test("aligns text inside a table cell", async ({ page, editor }) => {
+    const tableHtml = `<figure class="lexxy-content__table-wrapper"><table><tbody><tr><td>Hello everyone</td></tr></tbody></table></figure>`
+    await editor.setValue(tableHtml)
+    await editor.flush()
+
+    await editor.select("Hello")
+    await clickToolbarButton(page, "alignCenter")
+    await editor.flush()
+
+    await expect(editor.content.locator("td [style*='text-align: center']")).toContainText("Hello everyone")
+  })
+
+  test("alignment survives a setValue round-trip", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+    await editor.select("Hello")
+    await clickToolbarButton(page, "alignRight")
+
+    const html = await editor.value()
+    expect(html).toContain('text-align: right')
+
+    await editor.setValue(html)
+    await assertEditorHtml(editor, '<p style="text-align: right;">Hello everyone</p>')
+  })
+
+  test("dropdown reflects the active alignment", async ({ page, editor }) => {
+    await editor.setValue('<p style="text-align: center;">Hello everyone</p>')
+    await editor.select("Hello")
+
+    await openAlignmentDropdown(page)
+
+    await expect(page.locator("[name='align-center']")).toHaveAttribute("aria-pressed", "true")
+    await expect(page.locator("[name='align-left']")).toHaveAttribute("aria-pressed", "false")
+    await expect(page.locator("[name='align-right']")).toHaveAttribute("aria-pressed", "false")
+    await expect(page.locator("[name='align-justify']")).toHaveAttribute("aria-pressed", "false")
+  })
+})

--- a/test/browser/tests/formatting/toolbar.test.js
+++ b/test/browser/tests/formatting/toolbar.test.js
@@ -160,7 +160,7 @@ test.describe("Toolbar", () => {
     const overflowMenu = toolbar.locator(".lexxy-editor__toolbar-overflow-menu")
 
     const originalSize = page.viewportSize()
-    await page.setViewportSize({ width: 360, height: originalSize.height })
+    await page.setViewportSize({ width: 400, height: originalSize.height })
 
     await page.evaluate(async () => {
       const tb = document.querySelector("lexxy-toolbar")

--- a/test/system/text_alignment_test.rb
+++ b/test/system/text_alignment_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class TextAlignmentTest < ApplicationSystemTestCase
+  setup do
+    visit edit_post_path(posts(:hello_world))
+  end
+
+  test "right alignment is preserved after saving" do
+    find_editor.select "everyone"
+    apply_alignment "right"
+
+    click_on "Update Post"
+
+    assert_selector "p[style='text-align:right;']", text: "Hello everyone"
+  end
+
+  test "center alignment survives an edit round-trip" do
+    find_editor.select "everyone"
+    apply_alignment "center"
+
+    click_on "Update Post"
+    click_on "Edit this post"
+
+    assert_equal_html '<p style="text-align: center;">Hello everyone</p>', find_editor.value
+  end
+end

--- a/test/test_helpers/toolbar_helper.rb
+++ b/test/test_helpers/toolbar_helper.rb
@@ -6,4 +6,9 @@ module ToolbarHelper
       all(".lexxy-highlight-button[data-style='#{attribute}']")[button_index - 1].click
     end
   end
+
+  def apply_alignment(direction)
+    find("[name='alignment']").click
+    find("[name='align-#{direction}']").click
+  end
 end


### PR DESCRIPTION
Implements text alignment as a toolbar dropdown by dispatching Lexical's `FORMAT_ELEMENT_COMMAND`. Works on paragraphs, headings, list items, and table cells. Adds state-driven active-button highlighting in the dropdown.

- Add "text-align" to DOMPurify's allowed style properties so the inline style survives sanitization.
- Surface blockAlignment from Selection#getFormat for toolbar state reads.
- Register the four align commands in the command dispatcher.
- Add the alignment dropdown to the default toolbar template, after the format dropdown and before highlight.
- Add 4 alignment SVG icons.

Bumps the viewport in the existing overflow-compaction test from 360px to 400px to accommodate one more non-overflowable toolbar item.

Closes #1067

<img width="645" height="274" alt="image" src="https://github.com/user-attachments/assets/53a42a95-82c8-4088-8ff4-82800a6d6afd" />
