### PR TITLE
Make selection w/ Arrow Keys synchronous

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -55,11 +55,6 @@ export default class Contents {
     inserter.insertNodes(nodes)
   }
 
-  insertAtCursorEnsuringLineBelow(node) {
-    this.insertAtCursor(node)
-    this.#insertLineBelowIfLastNode(node)
-  }
-
   applyParagraphFormat() {
     const selection = $getSelection()
     if (!$isRangeSelection(selection)) return
@@ -437,17 +432,6 @@ export default class Contents {
       uploader.$insertUploadNodes()
       return true
     }
-  }
-
-  #insertLineBelowIfLastNode(node) {
-    this.editor.update(() => {
-      const nextSibling = node.getNextSibling()
-      if (!nextSibling) {
-        const newParagraph = $createParagraphNode()
-        node.insertAfter(newParagraph)
-        newParagraph.selectStart()
-      }
-    })
   }
 
   #unwrap(node) {

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -469,10 +469,8 @@ export default class Selection {
 
   #withCurrentNode(fn) {
     if (this.hasNodeSelection) {
-      this.editor.update(() => {
-        fn($getSelection().getNodes()[0])
-        this.editor.focus()
-      })
+      fn($getSelection().getNodes()[0])
+      this.editor.focus()
     }
   }
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -433,8 +433,13 @@ export default class Selection {
 
   #selectPreviousNode(event) {
     if (event.shiftKey) {
-      this.#withCurrentNodeSelectionNode((currentNode) => this.#rangeSelectDecorator(currentNode, "backward"))
-      return false
+      return this.#withCurrentNodeSelectionNode((currentNode) => {
+        const selection = this.#rangeSelectDecorator(currentNode, "forward")
+
+        // Can't rely on native pass-through with Playwright on firefox
+        selection.modify("extend", true, "character")
+        return true
+      })
     } else {
       return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.selectPrevious())
         || this.#selectInLexical(this.nodeBeforeCursor)
@@ -443,8 +448,13 @@ export default class Selection {
 
   #selectNextNode(event) {
     if (event.shiftKey) {
-      this.#withCurrentNodeSelectionNode((currentNode) => this.#rangeSelectDecorator(currentNode, "forward"))
-      return false
+      return this.#withCurrentNodeSelectionNode((currentNode) => {
+        const selection = this.#rangeSelectDecorator(currentNode, "forward")
+
+        // Can't rely on native pass-through with Playwright on firefox
+        selection.modify("extend", false, "character")
+        return true
+      })
     } else {
       return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.selectNext(0, 0))
         || this.#selectInLexical(this.nodeAfterCursor)

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -7,7 +7,6 @@ import { $getNearestNodeOfType } from "@lexical/utils"
 import { $getListDepth, ListItemNode, ListNode } from "@lexical/list"
 import { $getTableCellNodeFromLexicalNode, TableCellNode } from "@lexical/table"
 import { CodeNode } from "@lexical/code"
-import { nextFrame } from "../helpers/timing_helper"
 import { isSelectionHighlighted } from "../helpers/format_helper"
 import { getNonce } from "../helpers/csp_helper"
 import { $createNodeSelectionWith, $isListItemStructurallyEmpty, getListType } from "../helpers/lexical_helper"
@@ -432,44 +431,43 @@ export default class Selection {
     }
   }
 
-  async #selectPreviousNode(event) {
+  #selectPreviousNode(event) {
     if (event?.shiftKey) return false
 
     if (this.hasNodeSelection) {
-      return await this.#withCurrentNode((currentNode) => currentNode.selectPrevious())
+      return this.#withCurrentNode((currentNode) => currentNode.selectPrevious())
     } else {
       return this.#selectInLexical(this.nodeBeforeCursor)
     }
   }
 
-  async #selectNextNode(event) {
+  #selectNextNode(event) {
     if (event?.shiftKey) return false
 
     if (this.hasNodeSelection) {
-      return await this.#withCurrentNode((currentNode) => currentNode.selectNext(0, 0))
+      return this.#withCurrentNode((currentNode) => currentNode.selectNext(0, 0))
     } else {
       return this.#selectInLexical(this.nodeAfterCursor)
     }
   }
 
-  async #selectPreviousTopLevelNode() {
+  #selectPreviousTopLevelNode() {
     if (this.hasNodeSelection) {
-      return await this.#withCurrentNode((currentNode) => currentNode.getTopLevelElement().selectPrevious())
+      return this.#withCurrentNode((currentNode) => currentNode.getTopLevelElement().selectPrevious())
     } else {
       return this.#selectInLexical(this.topLevelNodeBeforeCursor)
     }
   }
 
-  async #selectNextTopLevelNode() {
+  #selectNextTopLevelNode() {
     if (this.hasNodeSelection) {
-      return await this.#withCurrentNode((currentNode) => currentNode.getTopLevelElement().selectNext(0, 0))
+      return this.#withCurrentNode((currentNode) => currentNode.getTopLevelElement().selectNext(0, 0))
     } else {
       return this.#selectInLexical(this.topLevelNodeAfterCursor)
     }
   }
 
-  async #withCurrentNode(fn) {
-    await nextFrame()
+  #withCurrentNode(fn) {
     if (this.hasNodeSelection) {
       this.editor.update(() => {
         fn($getSelection().getNodes()[0])

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -13,7 +13,7 @@ import { $createNodeSelectionWith, $isListItemStructurallyEmpty, getListType } f
 import { LinkNode } from "@lexical/link"
 import { $isHeadingNode, $isQuoteNode } from "@lexical/rich-text"
 import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
-import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
+import { ListenerBin, handlingDefault, registerEventListener } from "../helpers/listener_helper"
 
 export default class Selection {
   #listeners = new ListenerBin()
@@ -329,10 +329,10 @@ export default class Selection {
 
   #processSelectionChangeCommands() {
     this.#listeners.track(
-      this.editor.registerCommand(KEY_ARROW_LEFT_COMMAND, this.#selectPreviousNode.bind(this), COMMAND_PRIORITY_LOW),
-      this.editor.registerCommand(KEY_ARROW_RIGHT_COMMAND, this.#selectNextNode.bind(this), COMMAND_PRIORITY_LOW),
-      this.editor.registerCommand(KEY_ARROW_UP_COMMAND, this.#selectPreviousTopLevelNode.bind(this), COMMAND_PRIORITY_LOW),
-      this.editor.registerCommand(KEY_ARROW_DOWN_COMMAND, this.#selectNextTopLevelNode.bind(this), COMMAND_PRIORITY_LOW),
+      this.editor.registerCommand(KEY_ARROW_LEFT_COMMAND, handlingDefault(this.#selectPreviousNode.bind(this)), COMMAND_PRIORITY_LOW),
+      this.editor.registerCommand(KEY_ARROW_RIGHT_COMMAND, handlingDefault(this.#selectNextNode.bind(this)), COMMAND_PRIORITY_LOW),
+      this.editor.registerCommand(KEY_ARROW_UP_COMMAND, handlingDefault(this.#selectPreviousTopLevelNode.bind(this)), COMMAND_PRIORITY_LOW),
+      this.editor.registerCommand(KEY_ARROW_DOWN_COMMAND, handlingDefault(this.#selectNextTopLevelNode.bind(this)), COMMAND_PRIORITY_LOW),
 
       this.editor.registerCommand(DELETE_CHARACTER_COMMAND, this.#selectDecoratorNodeBeforeDeletion.bind(this), COMMAND_PRIORITY_LOW),
 
@@ -432,45 +432,32 @@ export default class Selection {
   }
 
   #selectPreviousNode(event) {
-    if (event?.shiftKey) return false
-
-    if (this.hasNodeSelection) {
-      return this.#withCurrentNode((currentNode) => currentNode.selectPrevious())
-    } else {
-      return this.#selectInLexical(this.nodeBeforeCursor)
+    if (!event.shiftKey) {
+      return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.selectPrevious())
+        || this.#selectInLexical(this.nodeBeforeCursor)
     }
   }
 
   #selectNextNode(event) {
-    if (event?.shiftKey) return false
-
-    if (this.hasNodeSelection) {
-      return this.#withCurrentNode((currentNode) => currentNode.selectNext(0, 0))
-    } else {
-      return this.#selectInLexical(this.nodeAfterCursor)
+    if (!event.shiftKey) {
+      return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.selectNext(0, 0))
+        || this.#selectInLexical(this.nodeAfterCursor)
     }
   }
 
   #selectPreviousTopLevelNode() {
-    if (this.hasNodeSelection) {
-      return this.#withCurrentNode((currentNode) => currentNode.getTopLevelElement().selectPrevious())
-    } else {
-      return this.#selectInLexical(this.topLevelNodeBeforeCursor)
-    }
+    return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.getTopLevelElement().selectPrevious())
+      || this.#selectInLexical(this.topLevelNodeBeforeCursor)
   }
 
   #selectNextTopLevelNode() {
-    if (this.hasNodeSelection) {
-      return this.#withCurrentNode((currentNode) => currentNode.getTopLevelElement().selectNext(0, 0))
-    } else {
-      return this.#selectInLexical(this.topLevelNodeAfterCursor)
-    }
+    return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.getTopLevelElement().selectNext(0, 0))
+      || this.#selectInLexical(this.topLevelNodeAfterCursor)
   }
 
-  #withCurrentNode(fn) {
+  #withCurrentNodeSelectionNode(fn) {
     if (this.hasNodeSelection) {
-      fn($getSelection().getNodes()[0])
-      this.editor.focus()
+      return fn($getSelection().getNodes()[0])
     }
   }
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -432,14 +432,20 @@ export default class Selection {
   }
 
   #selectPreviousNode(event) {
-    if (!event.shiftKey) {
+    if (event.shiftKey) {
+      this.#withCurrentNodeSelectionNode((currentNode) => this.#rangeSelectDecorator(currentNode, "backward"))
+      return false
+    } else {
       return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.selectPrevious())
         || this.#selectInLexical(this.nodeBeforeCursor)
     }
   }
 
   #selectNextNode(event) {
-    if (!event.shiftKey) {
+    if (event.shiftKey) {
+      this.#withCurrentNodeSelectionNode((currentNode) => this.#rangeSelectDecorator(currentNode, "forward"))
+      return false
+    } else {
       return this.#withCurrentNodeSelectionNode((currentNode) => currentNode.selectNext(0, 0))
         || this.#selectInLexical(this.nodeAfterCursor)
     }
@@ -458,6 +464,15 @@ export default class Selection {
   #withCurrentNodeSelectionNode(fn) {
     if (this.hasNodeSelection) {
       return fn($getSelection().getNodes()[0])
+    }
+  }
+
+  #rangeSelectDecorator(node, direction = "forward") {
+    if ($isDecoratorNode(node)) {
+        const [ anchorOffset, focusOffset ] = direction === "forward" ? [ 0, 1 ] : [ 1, 0 ]
+        const indexAtNode = node.getIndexWithinParent()
+
+        return node.getParent().select(indexAtNode + anchorOffset, indexAtNode + focusOffset)
     }
   }
 

--- a/src/helpers/listener_helper.js
+++ b/src/helpers/listener_helper.js
@@ -25,3 +25,12 @@ export class ListenerBin {
     }
   }
 }
+
+export function handlingDefault(handler) {
+  return event => {
+    const handled = handler(event)
+    if (handled) event.preventDefault()
+    return handled
+  }
+}
+

--- a/test/browser/tests/prompts/mention_deletion.test.js
+++ b/test/browser/tests/prompts/mention_deletion.test.js
@@ -135,10 +135,10 @@ test.describe("Mention deletion cursor position", () => {
     await page.keyboard.press("X")
     await editor.flush()
 
-    // The marker should appear where the mention was, between "Before" and "after"
+    // The marker should appear where the mention was, between "Before" and "after", consuming the adjacent space
     const text = await editor.content.evaluate((el) => el.textContent)
     expect(text).not.toContain("Alice")
-    expect(text).toMatch(/Before[\s]*X[\s]*after/)
+    expect(text).toMatch(/Before[\s]*Xafter/)
   })
 
   test("with multiple mentions, deleting first via click+backspace does not jump to second", async ({ page, editor }) => {


### PR DESCRIPTION
- remove `await nextFrame` resulting in inconsistent selection state from stale `hasNodeSelection` read
- unwrap `editor.update` from `withCurrentNode` always used in a command context
-  `withCurrentNode` => `withCurrentNodeSelectionNode`
- `return true` from ArrowKey handlers which do handle the command 
- ensure handled events get `preventDefault()` (this was being done by loose handlers down the chain)

https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9959684586