### PR TITLE
Fix @mention filtering for Cyrillic surnames

### DIFF
--- a/src/helpers/string_helper.js
+++ b/src/helpers/string_helper.js
@@ -22,7 +22,7 @@ export function filterMatchPosition(text, potentialMatch) {
 
   if (!normalizedMatch) return 0
 
-  const match = normalizedText.match(new RegExp(`(?:^|\\b)${escapeForRegExp(normalizedMatch)}`))
+  const match = normalizedText.match(new RegExp(`(?<![\\p{L}\\p{N}])${escapeForRegExp(normalizedMatch)}`, "u"))
   return match ? match.index : -1
 }
 

--- a/test/javascript/unit/helpers/string_helper.test.js
+++ b/test/javascript/unit/helpers/string_helper.test.js
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest"
+import { filterMatchPosition } from "src/helpers/string_helper"
+
+test("matches a Cyrillic surname", () => {
+  const name = "Андрій Ковальчук"
+  expect(filterMatchPosition(name, "Ковальчук")).toBe(name.indexOf("Ковальчук"))
+})
+
+test("matches a Cyrillic first name", () => {
+  expect(filterMatchPosition("Андрій Ковальчук", "Андрій")).toBe(0)
+})
+
+test("matches a Latin surname", () => {
+  const name = "Jason Fried"
+  expect(filterMatchPosition(name, "Fried")).toBe(name.indexOf("Fried"))
+})
+
+test("matches across a hyphenated name", () => {
+  const name = "Jean-Pierre Dupont"
+  expect(filterMatchPosition(name, "Pierre")).toBe(name.indexOf("Pierre"))
+})
+
+test("does not match mid-word", () => {
+  expect(filterMatchPosition("Ковальчук", "вальчук")).toBe(-1)
+  expect(filterMatchPosition("Fried", "ried")).toBe(-1)
+})
+
+test("returns 0 for an empty query", () => {
+  expect(filterMatchPosition("Андрій Ковальчук", "")).toBe(0)
+})


### PR DESCRIPTION
## Problem

A Ukrainian customer reported they cannot @mention people by surname. The @mention autocomplete (powered by Lexxy) silently filters out the surname token.

## Root cause

`filterMatchPosition` in `src/helpers/string_helper.js` used a JavaScript `\b` word boundary to anchor matches:

```js
normalizedText.match(new RegExp(`(?:^|\\b)${escapeForRegExp(normalizedMatch)}`))
```

In JavaScript, `\b` is **ASCII-only** — word characters are `[A-Za-z0-9_]`. At a `space → Cyrillic-letter` position there is no `\b`, so:

- A Cyrillic **first** name still matched via the `^` anchor.
- A Cyrillic **surname** (any non-first token) never matched at all.

Latin surnames kept working because `space → Latin-letter` *is* a real `\b` — which is why Support couldn't reproduce the bug with Latin names. This is a BC4 → BC5 regression introduced when this filter was added.

## Fix

Replace the ASCII boundary with a Unicode-aware negative lookbehind and add the `u` flag:

```js
normalizedText.match(new RegExp(`(?<![\\p{L}\\p{N}])${escapeForRegExp(normalizedMatch)}`, "u"))
```

This:
- matches Cyrillic (and other non-Latin) surnames,
- preserves Latin and hyphenated-name (`Jean-Pierre`) boundaries,
- still rejects mid-word matches,
- keeps `match.index` pointing at the start of the match (no off-by-one).

## Tests

Added `test/javascript/unit/helpers/string_helper.test.js` covering:
- a Cyrillic surname matches at the correct index (`"Андрій Ковальчук"` / `"Ковальчук"`),
- a Cyrillic first name matches at index 0,
- a Latin surname still matches,
- a hyphenated name token matches,
- mid-word queries do **not** match (Cyrillic and Latin),
- an empty query returns 0.

All 101 unit tests pass (`npx vitest run`).

## Motivating report

https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9953369922

🤖 Generated with [Claude Code](https://claude.com/claude-code)