### PR TITLE
Fire paste nodes command on insertHtml/insertDOM during paste

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -3,7 +3,7 @@ import { isAutolinkableURL } from "../helpers/string_helper"
 import { nextFrame } from "../helpers/timing_helper"
 import { addBlockSpacing, dispatch, parseHtml } from "../helpers/html_helper"
 import { $isCodeNode } from "@lexical/code"
-import { $createTextNode, $getSelection, $isParagraphNode, $isRangeSelection, COMMAND_PRIORITY_NORMAL, PASTE_COMMAND, PASTE_TAG, SELECTION_INSERT_CLIPBOARD_NODES_COMMAND } from "lexical"
+import { $createTextNode, $getSelection, $isParagraphNode, $isRangeSelection, $onUpdate, COMMAND_PRIORITY_NORMAL, PASTE_COMMAND, PASTE_TAG, SELECTION_INSERT_CLIPBOARD_NODES_COMMAND } from "lexical"
 import { $insertDataTransferForRichText } from "@lexical/clipboard"
 import { $createLinkNode, $isLinkNode, $toggleLink } from "@lexical/link"
 import { ListenerBin } from "../helpers/listener_helper"
@@ -146,10 +146,7 @@ export default class Clipboard {
     const linkNode = $createLinkNode(url).append($createTextNode(url))
     selection.insertNodes([ linkNode ])
 
-    // Defer the lexxy:insert-link event until after the active update commits;
-    // listeners may run editor mutations of their own.
-    const nodeKey = linkNode.getKey()
-    Promise.resolve().then(() => this.#dispatchLinkInsertEvent(nodeKey, { url }))
+    $onUpdate(() => this.#dispatchLinkInsertEvent(linkNode.getKey(), { url }))
   }
 
   #dispatchLinkInsertEvent(nodeKey, payload) {

--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -62,10 +62,10 @@ export default class Clipboard {
 
   #handleParsedClipboardNodes({ nodes, selection }) {
     const url = $bareUrlFromSingleLink(nodes)
-    if (!url) return false
-
-    this.#insertSingleLinkAt(selection, url)
-    return true
+    if (url && $isRangeSelection(selection)) {
+      this.#insertSingleLinkAt(selection, url)
+      return true
+    }
   }
 
   #isPlainTextOrURLPasted(clipboardData) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -1,7 +1,8 @@
 import {
   $createLineBreakNode, $createParagraphNode, $createTextNode, $getNodeByKey, $getRoot, $getSelection, $hasUpdateTag,
   $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootOrShadowRoot, $isTextNode, $setSelection,
-  HISTORY_MERGE_TAG, PASTE_TAG
+  HISTORY_MERGE_TAG, PASTE_TAG,
+  SELECTION_INSERT_CLIPBOARD_NODES_COMMAND
 } from "lexical"
 
 import { $createCodeNode, $isCodeNode } from "@lexical/code"
@@ -36,14 +37,13 @@ export default class Contents {
   }
 
   insertDOM(doc, { tag } = {}) {
-    this.#unwrapPlaceholderAnchors(doc)
-
     this.editor.update(() => {
-      if ($hasUpdateTag(PASTE_TAG)) this.#stripTableCellColorStyles(doc)
+      if ($hasUpdateTag(PASTE_TAG)) this.#formatPastedDOM(doc)
 
       const nodes = this.editorElement.$generateNodesFromDOM(doc)
-      if (!this.#insertUploadNodes(nodes)) {
-        this.insertAtCursor(...nodes)
+
+      if (!$hasUpdateTag(PASTE_TAG) || !this.#dispatchPastedNodesCommand(nodes)) {
+        this.#insertUploadNodes(nodes) || this.insertAtCursor(...nodes)
       }
     }, { tag })
   }
@@ -360,6 +360,17 @@ export default class Contents {
 
       const newNode = options.attachment ? this.#createCustomAttachmentNodeWithHtml(html, options.attachment) : this.#createHtmlNodeWith(html)
       previousNode.insertAfter(newNode)
+    })
+  }
+
+  #formatPastedDOM(doc) {
+    this.#unwrapPlaceholderAnchors(doc)
+    this.#stripTableCellColorStyles(doc)
+  }
+
+  #dispatchPastedNodesCommand(nodes) {
+    return this.editor.dispatchCommand(SELECTION_INSERT_CLIPBOARD_NODES_COMMAND, {
+      nodes, selection: $getSelection()
     })
   }
 

--- a/test/browser/fixtures/paste-command-dispatch.html
+++ b/test/browser/fixtures/paste-command-dispatch.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Paste Command Dispatch</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import { SELECTION_INSERT_CLIPBOARD_NODES_COMMAND, COMMAND_PRIORITY_HIGH } from "lexical"
+    window.__lex = { SELECTION_INSERT_CLIPBOARD_NODES_COMMAND, COMMAND_PRIORITY_HIGH }
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..."></lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/paste/paste_nodes_command.test.js
+++ b/test/browser/tests/paste/paste_nodes_command.test.js
@@ -1,0 +1,67 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+async function installListener(editor, { returnValue }) {
+  await editor.locator.evaluate((el, value) => {
+    const { SELECTION_INSERT_CLIPBOARD_NODES_COMMAND, COMMAND_PRIORITY_HIGH } = window.__lex
+    window.__pasteCommandCalls = []
+    el.editor.registerCommand(
+      SELECTION_INSERT_CLIPBOARD_NODES_COMMAND,
+      (payload) => {
+        window.__pasteCommandCalls.push({
+          nodesLength: payload.nodes.length,
+          hasSelection: !!payload.selection,
+        })
+        return value
+      },
+      COMMAND_PRIORITY_HIGH,
+    )
+  }, returnValue)
+}
+
+test.describe("Paste — SELECTION_INSERT_CLIPBOARD_NODES_COMMAND dispatch", () => {
+  test("fires on HTML paste with nodes and a selection", async ({ page, editor }) => {
+    await page.goto("/paste-command-dispatch.html")
+    await editor.waitForConnected()
+
+    await installListener(editor, { returnValue: false })
+
+    await editor.paste("hello", { html: "<p>hello</p>" })
+    await editor.flush()
+
+    const calls = await page.evaluate(() => window.__pasteCommandCalls)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].nodesLength).toBeGreaterThan(0)
+    expect(calls[0].hasSelection).toBe(true)
+  })
+
+  test("returning false does not stop the default paste", async ({ page, editor }) => {
+    await page.goto("/paste-command-dispatch.html")
+    await editor.waitForConnected()
+
+    await installListener(editor, { returnValue: false })
+
+    await editor.paste("hello", { html: "<p>hello pasted</p>" })
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content).toContainText("hello pasted")
+    })
+  })
+
+  test("returning true prevents the default insertion path", async ({ page, editor }) => {
+    await page.goto("/paste-command-dispatch.html")
+    await editor.waitForConnected()
+
+    await installListener(editor, { returnValue: true })
+
+    await editor.paste("blocked", { html: "<p>blocked content</p>" })
+    await editor.flush()
+
+    const calls = await page.evaluate(() => window.__pasteCommandCalls)
+    expect(calls).toHaveLength(1)
+
+    await expect(editor.content).not.toContainText("blocked content")
+    await expect.poll(() => editor.isEmpty()).toBe(true)
+  })
+})


### PR DESCRIPTION
Dispatch `SELECTION_INSERT_CLIPBOARD_NODES_COMMAND` within `Contents.insertDOM` for a paste operation to allow a post-node-generation hook to modify the nodes or handle the node insertion.

> There's more paste logic creeping into `Contents` making `Clipboard` look ready for a refactor.