### PR TITLE
Prevent spurious lexxy:change event

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -309,9 +309,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   get value() {
-    return this.cachedValue ??= this.editor?.read(() => {
-      return sanitize($generateHtmlFromNodes(this.editor, null))
-    }) ?? null
+    return this.cachedValue ??= this.#readSanitizedEditorValue()
   }
 
   set value(html) {
@@ -338,6 +336,12 @@ export class LexicalEditorElement extends HTMLElement {
 
   get canRedo() {
     return this.#historyState.redo
+  }
+
+  #readSanitizedEditorValue(editor = this.editor) {
+    return editor?.read(() => {
+      return sanitize($generateHtmlFromNodes(this.editor, null))
+    }) ?? null
   }
 
   #parseHtmlIntoLexicalNodes(html, { editor = this.editor } = {}) {
@@ -377,7 +381,6 @@ export class LexicalEditorElement extends HTMLElement {
     this.#registerFileAcceptFilter()
     this.#attachDebugHooks()
     this.#attachToolbar()
-    this.#configureSanitizer()
     this.#resetBeforeTurboCaches()
   }
 
@@ -403,7 +406,11 @@ export class LexicalEditorElement extends HTMLElement {
       html: {
         export: new Map([ [ TextNode, exportTextNodeDOM ], [ CodeHighlightNode, exportTextNodeDOM ] ])
       },
-      $initialEditorState: (editor) => this.#loadInitialValue(editor)
+      $initialEditorState: (editor) => {
+        this.#configureSanitizer(editor)
+        this.#loadInitialValue(editor)
+        this.#setInternalFormValue(this.#readSanitizedEditorValue(editor))
+      },
     },
       ...this.extensions.lexicalExtensions
     )
@@ -485,7 +492,6 @@ export class LexicalEditorElement extends HTMLElement {
     const initialHtml = this.valueBeforeDisconnect || this.getAttribute("value") || "<p><br></p>"
 
     this.#initialValue = initialHtml
-    this.#setInternalFormValue(initialHtml)
     this.#setEditorHtml(initialHtml, { editor })
   }
 
@@ -719,16 +725,16 @@ export class LexicalEditorElement extends HTMLElement {
     this.classList.toggle("lexxy-editor--empty", this.isEmpty)
   }
 
-  #configureSanitizer() {
-    setSanitizerConfig(this.#allowedElements)
+  #configureSanitizer(editor) {
+    setSanitizerConfig(this.#getAllowedElements(editor))
   }
 
-  get #allowedElements() {
-    return this.#importableTags.concat(this.extensions.allowedElements)
+  #getAllowedElements(editor) {
+    return this.#getImportableTags(editor).concat(this.extensions.allowedElements)
   }
 
-  get #importableTags() {
-    const tags = Array.from(this.editor._htmlConversions.keys())
+  #getImportableTags(editor) {
+    const tags = Array.from(editor._htmlConversions.keys())
     return tags.filter(tag => !tag.startsWith("#"))
   }
 

--- a/test/browser/fixtures/initial-value-renormalized.html
+++ b/test/browser/fixtures/initial-value-renormalized.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Initial Value Renormalized</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="title">
+      <input type="text" name="post[title]" placeholder="Post title" aria-label="Post title">
+    </div>
+
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..." value="<p><del>renormalized</del></p>" required></lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/initial-value-sanitized.html
+++ b/test/browser/fixtures/initial-value-sanitized.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Initial Value Sanitized</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="title">
+      <input type="text" name="post[title]" placeholder="Post title" aria-label="Post title">
+    </div>
+
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..." value="<p>hello<script>alert(1)</script></p>" required></lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/events.test.js
+++ b/test/browser/tests/events.test.js
@@ -10,6 +10,28 @@ test.describe("Events", () => {
     await expect(page.locator("[data-event='lexxy:change']")).toHaveCount(0)
   })
 
+  test("no lexxy:change event on initial load when value re-serializes differently", async ({ page, editor }) => {
+    await page.goto("/initial-value-renormalized.html")
+    await editor.waitForConnected()
+    await editor.flush()
+
+    // Initial value has <del> elements
+    await assertEditorHtml(editor, "<p><s>renormalized</s></p>")
+
+    await expect(page.locator("[data-event='lexxy:change']")).toHaveCount(0)
+  })
+
+  test("no lexxy:change event on initial load when value has a sanitized tag stripped", async ({ page, editor }) => {
+    await page.goto("/initial-value-sanitized.html")
+    await editor.waitForConnected()
+    await editor.flush()
+
+    // Initial value contains a <script> tag stripped by the sanitizer
+    await assertEditorHtml(editor, "<p>hello</p>")
+
+    await expect(page.locator("[data-event='lexxy:change']")).toHaveCount(0)
+  })
+
   test("dispatch lexxy:focus and lexxy:blur events on focus gain and loss", async ({
     page,
     editor,


### PR DESCRIPTION
Use the serialized editor value as the initial internal form value to prevent firing `lexxy:change` as a consequence of the serialization.

This requires configuration of the sanitizer at editor load time in the `$InitialEditorState` callback. Any earlier and the required `_htmlImports` is not available; any later and it will not apply correctly to the value.

- Added test