### PR TITLE
Guard toolbar overflow refresh against absent overflow control

### DIFF
--- a/src/elements/toolbar.js
+++ b/src/elements/toolbar.js
@@ -272,6 +272,12 @@ export class LexicalToolbarElement extends HTMLElement {
   }
 
   #refreshOverflow() {
+    // The overflow control may be absent when a refresh fires: the toolbar
+    // template can be transiently detached during a Turbo/idiomorph morph, or a
+    // page server-rendered by an older Lexxy may be hydrated by newer JS. Bail
+    // out — setEditor() and the ResizeObserver re-run this once it's in the DOM.
+    if (!this.#overflowMenuButton) return
+
     this.#hideOverflowMenuButton()
     this.#resetToolbarOverflow()
     this.#reindexToolbarItems()

--- a/test/browser/tests/formatting/toolbar.test.js
+++ b/test/browser/tests/formatting/toolbar.test.js
@@ -1,6 +1,6 @@
 import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
-import { assertEditorHtml } from "../../helpers/assertions.js"
+import { assertEditorHtml, startMonitoringConsole } from "../../helpers/assertions.js"
 import { HELLO_EVERYONE } from "../../helpers/toolbar.js"
 
 test.describe("Toolbar", () => {
@@ -153,6 +153,31 @@ test.describe("Toolbar", () => {
     await expect(toolbar).not.toHaveAttribute("overflowing")
     await expect(overflowMenu.locator("button[name='async-injected']")).toHaveCount(0)
     await expect(toolbar.locator(":scope > button[name='async-injected']")).toHaveCount(1)
+  })
+
+  test("overflow refresh does not throw when the overflow control is absent from the DOM", async ({ page }) => {
+    startMonitoringConsole(page)
+
+    const toolbar = page.locator("lexxy-toolbar")
+    await expect(toolbar).toBeVisible()
+
+    // Reproduces the production rAF crash: when the overflow control is not in
+    // the DOM at the moment a refresh fires — e.g. a Turbo/idiomorph morph that
+    // transiently detaches the toolbar template, or a server/client template
+    // mismatch during a deploy — #refreshOverflow used to dereference a null
+    // overflow element inside requestAnimationFrame and throw.
+    await page.evaluate(async () => {
+      const tb = document.querySelector("lexxy-toolbar")
+      tb.querySelector(".lexxy-editor__toolbar-overflow").remove()
+      tb.requestOverflowRefresh()
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+    })
+
+    expect(page).toHaveNoErrors()
+
+    // The rest of the toolbar keeps rendering and stays interactive.
+    await expect(toolbar.locator("button[name='bold']")).toBeVisible()
   })
 
   test("overflow compaction accounts for injected buttons that cannot overflow", async ({ page }) => {


### PR DESCRIPTION
## Goal

Stop `<lexxy-toolbar>` from throwing a `TypeError` inside `requestAnimationFrame` when the overflow control (`.lexxy-editor__toolbar-overflow`) is not in the DOM at the moment an overflow refresh fires. The toolbar keeps rendering and stays interactive instead of crashing the frame.

## Motivation

`#refreshOverflow` is scheduled through `requestOverflowRefresh()` from three lifecycle points — `connectedCallback`, the `ResizeObserver`, and the `connected`-attribute reconnect path. If the overflow control is absent when the queued frame runs, `#overflowMenuButton` is `null`, `#overflowMenuDropdown` is `undefined` (its getter already uses `?.`), and the first `.children` / `.toggleAttribute` read throws:

- Chrome: `TypeError: Cannot read properties of undefined (reading 'children')`
- Safari: `TypeError: null is not an object (evaluating 'this.#overflowMenu.children')` (reported against an older Lexxy; the field is now `#overflowMenuDropdown`)

tagged `auto.browser.browserapierrors.requestAnimationFrame`. It is the single biggest client-side error in a production app embedding Lexxy. Two situations produce it:

- A **Turbo/idiomorph DOM morph** keeps the `<lexxy-toolbar>` element connected while its inner template is transiently detached, so the overflow child is missing when the already-queued frame fires.
- A page **server-rendered by an older Lexxy** (toolbar markup without the overflow control) hydrated by **newer JS** leaves `#overflowMenuButton` permanently `null`, crashing on the first refresh.

The optional chaining in `get #overflowMenuDropdown()` only defers the throw to the first property read; it does not prevent it. The existing `disconnectedCallback → dispose() → cancelAnimationFrame` narrows the disconnect race but covers neither case above.

## Summary

- `src/elements/toolbar.js`: `#refreshOverflow()` returns early when `#overflowMenuButton` is absent, with a comment explaining the two scenarios that produce it. No state is mutated on that path — `setEditor()` and the next `ResizeObserver` tick re-run the refresh once the template is back in the DOM, so overflow behavior is unchanged.
- `test/browser/tests/formatting/toolbar.test.js`: adds a regression test that removes the overflow control, calls `requestOverflowRefresh()`, advances two animation frames, and asserts the page logged no errors (`startMonitoringConsole` / `toHaveNoErrors`) and that `button[name='bold']` is still visible.

## Test plan

- [x] `yarn test:browser test/browser/tests/formatting/toolbar.test.js` — 33 passed across chromium, firefox, and webkit.
- [x] Reverted `src/elements/toolbar.js` to `main` and re-ran the new test: it fails on `toHaveNoErrors()`, confirming it reproduces the crash.
- [x] `yarn lint` — clean.
- [ ] Resize a toolbar that does have the overflow control and confirm buttons still compact into the overflow menu as before.

