### PR TITLE
Make the uploads-busy validation message configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,7 @@ Editors support the following options, configurable using presets and element at
 - `multiLine`: Pass `false` to force single line editing.
 - `permittedAttachmentTypes`: Restrict the editor to a specific allowlist of attachment content types. Unset (the default) permits any content type. Example: `<lexxy-editor permitted-attachment-types="application/vnd.basecamp.mention application/vnd.basecamp.opengraph-embed"></lexxy-editor>`.
 - `richText`: Pass `false` to disable rich text editing.
+- `uploadsBusyMessage`: The form validation message shown while attachments are still uploading (the editor reports itself invalid until every upload finishes). Defaults to `"Please wait for all files to upload"`. Override it to localize the message, e.g. `<lexxy-editor uploads-busy-message="Počkejte prosím na dokončení nahrávání souborů."></lexxy-editor>`.
 
 The toolbar is considered part of the editor for `lexxy:focus` and `lexxy:blur` events. If the toolbar registers event or lexical handlers, it should expose a `dispose()` function which will be called on editor disconnect.
 

--- a/home/docs/configuration.md
+++ b/home/docs/configuration.md
@@ -71,6 +71,7 @@ Editors support the following options, configurable using presets and element at
 - `multiLine`: Pass `false` to force single line editing.
 - `permittedAttachmentTypes`: Restrict the editor to a specific allowlist of attachment content types. Unset (the default) permits any content type. Example: `<lexxy-editor permitted-attachment-types="application/vnd.basecamp.mention application/vnd.basecamp.opengraph-embed"></lexxy-editor>`.
 - `richText`: Pass `false` to disable rich text editing.
+- `uploadsBusyMessage`: The form validation message shown while attachments are still uploading (the editor reports itself invalid until every upload finishes). Defaults to `"Please wait for all files to upload"`. Override it to localize the message, e.g. `<lexxy-editor uploads-busy-message="Espera a que se suban todos los archivos"></lexxy-editor>`.
 - `headings`: Pass an array of heading tags to configure which heading levels are available in the toolbar dropdown. Defaults to `["h2", "h3", "h4"]`. Pass an empty array to remove all heading options; the formatting dropdown still offers "Normal" and "Clear formatting".
 
   ```js

--- a/src/config/lexxy.js
+++ b/src/config/lexxy.js
@@ -15,6 +15,7 @@ const presets = new Configuration({
     multiLine: true,
     permittedAttachmentTypes: null,
     richText: true,
+    uploadsBusyMessage: "Please wait for all files to upload",
     toolbar: {
       upload: "both"
     },

--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -12,8 +12,6 @@ import { $isAtNodeEdge } from "../helpers/lexical_helper.js"
 const ATTACHMENT_ATTRIBUTES = [ "alt", "caption", "content", "content-type", "data-direct-upload-id",
   "data-sgid", "filename", "filesize", "height", "presentation", "previewable", "sgid", "url", "width" ]
 
-const UPLOADS_BUSY_MESSAGE = "Please wait for all files to upload"
-
 export class AttachmentsExtension extends LexxyExtension {
   #uploadsCount = 0
 
@@ -64,7 +62,7 @@ export class AttachmentsExtension extends LexxyExtension {
 
   #setUploadsValidity() {
     if (this.#uploadsCount) {
-      this.setEditorValidity({ customError: true }, UPLOADS_BUSY_MESSAGE)
+      this.setEditorValidity({ customError: true }, this.editorConfig.get("uploadsBusyMessage"))
     } else {
       this.setEditorValidity({})
     }

--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -12,8 +12,6 @@ import { $isAtNodeEdge } from "../helpers/lexical_helper.js"
 const ATTACHMENT_ATTRIBUTES = [ "alt", "caption", "content", "content-type", "data-direct-upload-id",
   "data-sgid", "filename", "filesize", "height", "presentation", "previewable", "sgid", "url", "width" ]
 
-const UPLOADS_BUSY_MESSAGE = "Please wait for all files to upload"
-
 export class AttachmentsExtension extends LexxyExtension {
   #uploadsCount = 0
 
@@ -63,7 +61,7 @@ export class AttachmentsExtension extends LexxyExtension {
 
   #setUploadsValidity() {
     if (this.#uploadsCount) {
-      this.setEditorValidity({ customError: true }, UPLOADS_BUSY_MESSAGE)
+      this.setEditorValidity({ customError: true }, this.editorConfig.get("uploadsBusyMessage"))
     } else {
       this.setEditorValidity({})
     }

--- a/test/browser/fixtures/attachments-uploads-busy-message.html
+++ b/test/browser/fixtures/attachments-uploads-busy-message.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attachments Upload (custom busy message)</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="title">
+      <input type="text" name="post[title]" placeholder="Post title" aria-label="Post title">
+    </div>
+
+    <div class="body">
+      <lexxy-editor
+        class="lexxy-content"
+        placeholder="Write something..."
+        data-direct-upload-url="/rails/active_storage/direct_uploads"
+        data-blob-url-template="/rails/active_storage/blobs/:signed_id/:filename"
+        uploads-busy-message="Počkejte prosím na dokončení nahrávání souborů."
+        required></lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/attachments/form_validity.test.js
+++ b/test/browser/tests/attachments/form_validity.test.js
@@ -50,5 +50,11 @@ test.describe("Form validity during uploads", () => {
     )
 
     await calls.releaseDirectUploadResponses()
+    await expect(page.locator("figure.attachment img")).toHaveAttribute(
+      "src",
+      /\/rails\/active_storage\/blobs\//,
+      { timeout: 10_000 },
+    )
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(true)
   })
 })

--- a/test/browser/tests/attachments/form_validity.test.js
+++ b/test/browser/tests/attachments/form_validity.test.js
@@ -32,4 +32,23 @@ test.describe("Form validity during uploads", () => {
 
     await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(true)
   })
+
+  test("uses a custom uploads-busy-message when configured", async ({ page, editor }) => {
+    await page.goto("/attachments-uploads-busy-message.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+
+    const calls = await mockActiveStorageUploads(page, { delayDirectUploadResponse: true })
+
+    await editor.send("Hello")
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await expect(page.locator("figure.attachment progress")).toBeVisible({ timeout: 10_000 })
+
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(false)
+    expect(await editor.locator.evaluate((el) => el.internals.validationMessage)).toBe(
+      "Počkejte prosím na dokončení nahrávání souborů.",
+    )
+
+    await calls.releaseDirectUploadResponses()
+  })
 })

--- a/test/browser/tests/attachments/form_validity.test.js
+++ b/test/browser/tests/attachments/form_validity.test.js
@@ -32,4 +32,29 @@ test.describe("Form validity during uploads", () => {
 
     await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(true)
   })
+
+  test("uses a custom uploads-busy-message when configured", async ({ page, editor }) => {
+    await page.goto("/attachments-uploads-busy-message.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+
+    const calls = await mockActiveStorageUploads(page, { delayDirectUploadResponse: true })
+
+    await editor.send("Hello")
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await expect(page.locator("figure.attachment progress")).toBeVisible({ timeout: 10_000 })
+
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(false)
+    expect(await editor.locator.evaluate((el) => el.internals.validationMessage)).toBe(
+      "Počkejte prosím na dokončení nahrávání souborů.",
+    )
+
+    await calls.releaseDirectUploadResponses()
+    await expect(page.locator("figure.attachment img")).toHaveAttribute(
+      "src",
+      /\/rails\/active_storage\/blobs\//,
+      { timeout: 10_000 },
+    )
+    await expect.poll(() => editor.locator.evaluate((el) => el.checkValidity())).toBe(true)
+  })
 })


### PR DESCRIPTION
## Goal

Let apps customize the native form-validation message that Lexxy shows while attachments are still uploading. The string becomes an editor option, `uploadsBusyMessage`, settable through a preset or the `uploads-busy-message` element attribute, and still defaults to the current English text so nothing changes for existing users.

## Motivation

While an upload is in flight the editor marks itself form-invalid and the browser renders a native validation bubble. Until now that bubble always read `"Please wait for all files to upload"`, hardcoded in `AttachmentsExtension`, so a non-English host app showed one untranslated string in the middle of an otherwise localized form. There was no hook to override it short of patching the bundle.

## Summary

- Add `uploadsBusyMessage` to the `default` preset in `src/config/lexxy.js`, defaulting to `"Please wait for all files to upload"`. Because it lives in the preset, it is recognized both via `Lexxy.configure({ default: { uploadsBusyMessage: "…" } })` and via the dasherised attribute `<lexxy-editor uploads-busy-message="…">`, the same mechanism as `permittedAttachmentTypes` and friends.
- Drop the module-level `UPLOADS_BUSY_MESSAGE` constant from `src/extensions/attachments_extension.js` and read `this.editorConfig.get("uploadsBusyMessage")` in `#setUploadsValidity()` instead.
- Document the option in `home/docs/configuration.md`, alongside the other editor options.
- Add a Playwright fixture `test/browser/fixtures/attachments-uploads-busy-message.html` that sets a non-English `uploads-busy-message`, and a test in `test/browser/tests/attachments/form_validity.test.js` asserting the custom message is reported while the upload is held and that the editor returns to valid once the upload settles.

## Test plan

- [ ] `yarn test:browser test/browser/tests/attachments/form_validity.test.js` — both the default-message and custom-message cases pass on chromium, firefox and webkit.
- [ ] `yarn lint` — clean.
- [ ] Manually: load an editor without the attribute, start an upload, submit the form, and confirm the bubble still reads "Please wait for all files to upload".
- [ ] Manually: set `<lexxy-editor uploads-busy-message="…">` (or configure the preset), start an upload, submit, and confirm the bubble shows the custom string and disappears once the upload completes.
