### PR TITLE
Fix Dragon NaturallySpeaking corrections breaking the editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/lexxy.esm.js",
-    "./helpers": "./dist/lexxy_helpers.esm.js"
+    "./helpers": "./dist/lexxy_helpers.esm.js",
+    "./dragon": "./dist/lexxy_dragon.esm.js"
   },
   "files": [
     "dist"

--- a/rollup.config.npm.mjs
+++ b/rollup.config.npm.mjs
@@ -6,7 +6,7 @@ const helperChunks = [
 ]
 
 export default {
-  input: { lexxy: "src/index.js" },
+  input: { lexxy: "src/index.js", lexxy_dragon: "src/editor/vendor/dragon/support.js" },
   output: {
     dir: "./dist",
     format: "esm",

--- a/scripts/benchmarks/run-browser-benchmarks.js
+++ b/scripts/benchmarks/run-browser-benchmarks.js
@@ -61,6 +61,17 @@ const SCENARIOS = [
     },
     title: "Load many attachments",
   },
+  {
+    description: "Move the caret across a large document to measure selection-only update cost",
+    kind: "caret",
+    name: "move-caret-large-document",
+    payload: {
+      kind: "paragraphs",
+      paragraphs: 200,
+      wordsPerParagraph: 40,
+    },
+    title: "Move caret on large document",
+  },
 ]
 
 main().catch((error) => {

--- a/src/editor/vendor/dragon/make_changes.js
+++ b/src/editor/vendor/dragon/make_changes.js
@@ -1,5 +1,14 @@
 import { $getSelection, $isRangeSelection, $isTextNode } from "lexical"
 
+const TEXT_FORMAT_BY_EXEC_COMMAND = new Map([
+  [ "bold", "bold" ],
+  [ "italic", "italic" ],
+  [ "strikeThrough", "strikethrough" ],
+  [ "subscript", "subscript" ],
+  [ "superscript", "superscript" ],
+  [ "underline", "underline" ]
+])
+
 document.addEventListener("lexxy:dragon-make-changes", (event) => {
   const editor = document.activeElement?.closest("lexxy-editor")?.editor
   if (editor) applyMakeChanges(editor, event.detail)
@@ -27,12 +36,13 @@ function isWellFormed(args) {
 // Offsets are relative to the text node at the selection anchor. A text of -1
 // (a number, not a string) means "change the selection without touching the text".
 class MakeChangesMessage {
-  constructor([ elementStart, elementLength, text, selStart, selLength ]) {
+  constructor([ elementStart, elementLength, text, selStart, selLength, formatCommand ]) {
     this.elementStart = elementStart
     this.elementLength = elementLength
     this.text = text
     this.selStart = selStart
     this.selLength = selLength
+    this.formatCommand = formatCommand
   }
 
   applyTo(selection) {
@@ -40,6 +50,7 @@ class MakeChangesMessage {
     this.#setAddressedRange()
     this.#insertText()
     this.#setFinalSelection()
+    this.#applyFormatCommand()
   }
 
   #setAddressedRange() {
@@ -81,5 +92,17 @@ class MakeChangesMessage {
 
   get #hasFinalRange() {
     return this.selStart >= 0 && this.selLength >= 0
+  }
+
+  // Voice commands like "bold that" arrive as execCommand names. A collapsed
+  // selection would toggle the pending format instead of formatting a range.
+  #applyFormatCommand() {
+    if (this.#format && this.selLength > 0 && !this.selection.isCollapsed()) {
+      this.selection.formatText(this.#format)
+    }
+  }
+
+  get #format() {
+    return TEXT_FORMAT_BY_EXEC_COMMAND.get(this.formatCommand)
   }
 }

--- a/src/editor/vendor/dragon/make_changes.js
+++ b/src/editor/vendor/dragon/make_changes.js
@@ -1,0 +1,85 @@
+import { $getSelection, $isRangeSelection, $isTextNode } from "lexical"
+
+document.addEventListener("lexxy:dragon-make-changes", (event) => {
+  const editor = document.activeElement?.closest("lexxy-editor")?.editor
+  if (editor) applyMakeChanges(editor, event.detail)
+})
+
+function applyMakeChanges(editor, args) {
+  if (isWellFormed(args)) {
+    editor.update(() => {
+      const selection = $getSelection()
+      if ($isRangeSelection(selection)) {
+        new MakeChangesMessage(args).applyTo(selection)
+      }
+    })
+  }
+}
+
+function isWellFormed(args) {
+  if (!Array.isArray(args)) return false
+
+  const [ elementStart, elementLength, text, selStart, selLength ] = args
+  return [ elementStart, elementLength, selStart, selLength ].every(Number.isFinite) &&
+    (typeof text === "string" || text === -1)
+}
+
+// Offsets are relative to the text node at the selection anchor. A text of -1
+// (a number, not a string) means "change the selection without touching the text".
+class MakeChangesMessage {
+  constructor([ elementStart, elementLength, text, selStart, selLength ]) {
+    this.elementStart = elementStart
+    this.elementLength = elementLength
+    this.text = text
+    this.selStart = selStart
+    this.selLength = selLength
+  }
+
+  applyTo(selection) {
+    this.selection = selection
+    this.#setAddressedRange()
+    this.#insertText()
+    this.#setFinalSelection()
+  }
+
+  #setAddressedRange() {
+    if ($isTextNode(this.#anchorNode) && this.elementStart >= 0 && this.elementLength >= 0) {
+      const end = this.elementStart + this.elementLength
+      this.selection.setTextNodeRange(this.#anchorNode, this.elementStart, this.#anchorNode, end)
+    }
+  }
+
+  get #anchorNode() {
+    return this.selection.anchor.getNode()
+  }
+
+  #insertText() {
+    if (typeof this.text === "string" && (this.text !== "" || this.#hasTextToReplace)) {
+      this.selection.insertRawText(this.text)
+    }
+  }
+
+  get #hasTextToReplace() {
+    return $isTextNode(this.#anchorNode) && this.elementStart >= 0 && this.elementLength > 0
+  }
+
+  #setFinalSelection() {
+    if ($isTextNode(this.#anchorNode)) {
+      this.selection.setTextNodeRange(this.#anchorNode, this.#finalStart, this.#anchorNode, this.#finalEnd)
+    }
+  }
+
+  get #finalStart() {
+    return Math.min(Math.max(this.selStart, 0), this.#anchorNode.getTextContentSize())
+  }
+
+  // Negative offsets collapse the selection instead of leaving a backward range
+  // that the next input would replace
+  get #finalEnd() {
+    return this.#hasFinalRange ? Math.min(this.selStart + this.selLength, this.#anchorNode.getTextContentSize()) : this.#finalStart
+  }
+
+  get #hasFinalRange() {
+    return this.selStart >= 0 && this.selLength >= 0
+  }
+}

--- a/src/editor/vendor/dragon/make_changes.js
+++ b/src/editor/vendor/dragon/make_changes.js
@@ -1,4 +1,4 @@
-import { $getSelection, $isRangeSelection, $isTextNode } from "lexical"
+import { $getRoot, $getSelection, $isElementNode, $isRangeSelection } from "lexical"
 
 const TEXT_FORMAT_BY_EXEC_COMMAND = new Map([
   [ "bold", "bold" ],
@@ -33,7 +33,8 @@ function isWellFormed(args) {
     (typeof text === "string" || text === -1)
 }
 
-// Offsets are relative to the text node at the selection anchor. A text of -1
+// Dragon addresses positions by their offset in the whole field, counting a
+// newline between blocks, not relative to the node at the caret. A text of -1
 // (a number, not a string) means "change the selection without touching the text".
 class MakeChangesMessage {
   constructor([ elementStart, elementLength, text, selStart, selLength, formatCommand ]) {
@@ -47,51 +48,40 @@ class MakeChangesMessage {
 
   applyTo(selection) {
     this.selection = selection
-    this.#setAddressedRange()
+    this.#selectAddressedRange()
     this.#insertText()
-    this.#setFinalSelection()
+    this.#selectFinalRange()
     this.#applyFormatCommand()
   }
 
-  #setAddressedRange() {
-    if ($isTextNode(this.#anchorNode) && this.elementStart >= 0 && this.elementLength >= 0) {
-      const end = this.elementStart + this.elementLength
-      this.selection.setTextNodeRange(this.#anchorNode, this.elementStart, this.#anchorNode, end)
+  #selectAddressedRange() {
+    if (this.elementStart >= 0 && this.elementLength >= 0) {
+      this.#select(this.elementStart, this.elementStart + this.elementLength)
     }
   }
 
-  get #anchorNode() {
-    return this.selection.anchor.getNode()
-  }
-
   #insertText() {
-    if (typeof this.text === "string" && (this.text !== "" || this.#hasTextToReplace)) {
+    if (typeof this.text === "string" && (this.text !== "" || this.elementLength > 0)) {
       this.selection.insertRawText(this.text)
     }
   }
 
-  get #hasTextToReplace() {
-    return $isTextNode(this.#anchorNode) && this.elementStart >= 0 && this.elementLength > 0
-  }
-
-  #setFinalSelection() {
-    if ($isTextNode(this.#anchorNode)) {
-      this.selection.setTextNodeRange(this.#anchorNode, this.#finalStart, this.#anchorNode, this.#finalEnd)
+  // Negative offsets collapse the selection instead of leaving a backward range
+  // that the next input would replace
+  #selectFinalRange() {
+    if (this.selStart >= 0 && this.selLength >= 0) {
+      this.#select(this.selStart, this.selStart + this.selLength)
+    } else {
+      this.#select(this.selStart, this.selStart)
     }
   }
 
-  get #finalStart() {
-    return Math.min(Math.max(this.selStart, 0), this.#anchorNode.getTextContentSize())
-  }
-
-  // Negative offsets collapse the selection instead of leaving a backward range
-  // that the next input would replace
-  get #finalEnd() {
-    return this.#hasFinalRange ? Math.min(this.selStart + this.selLength, this.#anchorNode.getTextContentSize()) : this.#finalStart
-  }
-
-  get #hasFinalRange() {
-    return this.selStart >= 0 && this.selLength >= 0
+  #select(from, to) {
+    const start = $pointAtGlobalOffset(from)
+    const end = $pointAtGlobalOffset(to)
+    if (start && end) {
+      this.selection.setTextNodeRange(start.node, start.offset, end.node, end.offset)
+    }
   }
 
   // Voice commands like "bold that" arrive as execCommand names. A collapsed
@@ -105,4 +95,32 @@ class MakeChangesMessage {
   get #format() {
     return TEXT_FORMAT_BY_EXEC_COMMAND.get(this.formatCommand)
   }
+}
+
+// Walk the text nodes in document order, counting a newline between top-level
+// blocks the way Dragon does, and return the text node and local offset that the
+// global offset lands in. Offsets past the end clamp to the last text node.
+function $pointAtGlobalOffset(offset) {
+  let consumed = 0
+  let lastNode = null
+
+  for (const [ index, block ] of $getRoot().getChildren().entries()) {
+    if (index > 0) consumed += 1
+
+    if ($isElementNode(block)) {
+      for (const node of block.getAllTextNodes()) {
+        const size = node.getTextContentSize()
+        if (offset <= consumed + size) {
+          return { node, offset: Math.max(offset - consumed, 0) }
+        }
+        consumed += size
+        lastNode = node
+      }
+    }
+  }
+
+  if (lastNode) {
+    return { node: lastNode, offset: lastNode.getTextContentSize() }
+  }
+  return null
 }

--- a/src/editor/vendor/dragon/support.js
+++ b/src/editor/vendor/dragon/support.js
@@ -1,0 +1,39 @@
+// Registered from the app's eager bundle so it runs before Dragon's content
+// script (which registers at document_end) and can stop the extension from
+// editing the DOM directly. It holds no Lexical to keep that bundle light, and
+// make_changes.js handles the edit lazily. The flag keeps a single registration
+// when this module loads from both the app's bundle and Lexxy's.
+if (!window.lexxyDragonInstalled) {
+  window.lexxyDragonInstalled = true
+  window.addEventListener("message", handleMessage, { capture: true })
+}
+
+function handleMessage(event) {
+  if (event.origin !== window.location.origin) return
+
+  const args = makeChangesArgumentsFrom(event.data)
+  const editor = args && document.activeElement?.closest("lexxy-editor")
+
+  if (editor) {
+    event.stopImmediatePropagation()
+    document.dispatchEvent(new CustomEvent("lexxy:dragon-make-changes", { detail: args }))
+  }
+}
+
+function makeChangesArgumentsFrom(data) {
+  if (typeof data !== "string" || !data.includes("nuanria_messaging")) return null
+
+  const message = parsedJson(data)
+  const isMakeChanges = message?.protocol === "nuanria_messaging" &&
+    message?.type === "request" && message.payload?.functionId === "makeChanges"
+
+  return isMakeChanges ? message.payload.args : null
+}
+
+function parsedJson(data) {
+  try {
+    return JSON.parse(data)
+  } catch {
+    return null
+  }
+}

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -515,8 +515,11 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #synchronizeWithChanges() {
-    this.#listeners.track(this.editor.registerUpdateListener(({ editorState }) => {
-      this.#clearCachedValues()
+    this.#listeners.track(this.editor.registerUpdateListener(({ dirtyElements, dirtyLeaves }) => {
+      // Reading the value serializes and sanitizes the whole document. Only
+      // invalidate the cache when a node actually changed, so an update that
+      // just moved the selection reuses it instead of re-serializing.
+      if (dirtyElements.size > 0 || dirtyLeaves.size > 0) this.#clearCachedValues()
       this.#setInternalFormValue(this.value)
       this.#toggleEmptyStatus()
       this.#requestValidityRefresh()

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import "./config/prism"
 import "./config/dom_purify"
 
 import { defineElements } from "./elements/index"
+import "./editor/vendor/dragon/support"
+import "./editor/vendor/dragon/make_changes"
 
 import Lexxy from "./config/lexxy"
 

--- a/test/browser/fixtures/benchmarks.js
+++ b/test/browser/fixtures/benchmarks.js
@@ -1,4 +1,5 @@
 import "lexxy"
+import { $createRangeSelection, $getRoot, $setSelection } from "lexical"
 
 const root = document.getElementById("benchmark-root")
 const READY_TIMEOUT_MS = 5_000
@@ -31,8 +32,63 @@ window.lexxyBenchmarks = {
       return measureLoad(scenario.payload, scenario.editorAttributes, scenario.options)
     }
 
+    if (scenario.kind === "caret") {
+      return measureCaret(scenario.payload, scenario.editorAttributes, scenario.options)
+    }
+
     throw new Error(`Unknown benchmark kind: ${scenario.kind}`)
   },
+}
+
+// Moving the caret runs the editor's update listener without changing any node,
+// which exercises the value-serialization caching on a large document.
+async function measureCaret(payload, editorAttributes = {}, options = {}) {
+  await clearRoot()
+
+  const editorElement = await createReadyEditor(editorAttributes)
+  const { details, html } = buildPayload(payload)
+  editorElement.value = html
+  await settleEditor(editorElement)
+
+  const timeBudgetMs = options.timeBudgetMs ?? 5_000
+
+  let opCount = 0
+  const startTime = performance.now()
+
+  do {
+    await moveCaret(editorElement, opCount)
+    opCount += 1
+  } while (performance.now() - startTime < timeBudgetMs)
+
+  const durationMs = performance.now() - startTime
+
+  return {
+    details: {
+      ...details,
+      opCount,
+      perOpDurationMs: durationMs / opCount,
+      renderedNodeCount: editorElement.querySelectorAll("*").length,
+      serializedHtmlLength: editorElement.value.length,
+      timeBudgetMs,
+    },
+    durationMs,
+  }
+}
+
+function moveCaret(editorElement, step) {
+  return new Promise((resolve) => {
+    editorElement.editor.update(() => {
+      const textNodes = $getRoot().getAllTextNodes()
+      if (textNodes.length === 0) return
+
+      const node = textNodes[step % textNodes.length]
+      const offset = step % (node.getTextContentSize() + 1)
+      const selection = $createRangeSelection()
+      selection.anchor.set(node.getKey(), offset, "text")
+      selection.focus.set(node.getKey(), offset, "text")
+      $setSelection(selection)
+    }, { onUpdate: resolve })
+  })
 }
 
 async function measureBootstrap(options = {}) {
@@ -116,6 +172,10 @@ function buildPayload(payload) {
     return buildLargeContentPayload(payload)
   }
 
+  if (payload.kind === "paragraphs") {
+    return buildParagraphsPayload(payload)
+  }
+
   if (payload.kind === "table") {
     return buildTablePayload(payload)
   }
@@ -125,6 +185,17 @@ function buildPayload(payload) {
   }
 
   throw new Error(`Unknown payload kind: ${payload.kind}`)
+}
+
+function buildParagraphsPayload({ paragraphs, wordsPerParagraph }) {
+  const html = Array.from({ length: paragraphs }, (_item, index) => {
+    return `<p>${buildPlainSentence(index, wordsPerParagraph)}</p>`
+  }).join("")
+
+  return {
+    details: { paragraphs, wordsPerParagraph },
+    html,
+  }
 }
 
 function buildLargeContentPayload({ listItemsPerSection, paragraphsPerSection, sections, wordsPerParagraph }) {

--- a/test/browser/fixtures/editor.js
+++ b/test/browser/fixtures/editor.js
@@ -1,2 +1,3 @@
 import "lexxy"
+import "lexxy/dragon"
 import "./events_logger.js"

--- a/test/browser/tests/vendor/dragon.test.js
+++ b/test/browser/tests/vendor/dragon.test.js
@@ -97,14 +97,53 @@ test.describe("Dragon NaturallySpeaking support", () => {
     expect(await editor.plainTextValue()).toBe("I'm dictating in the main content section")
     expect(pageErrors).toEqual([])
   })
+
+  // Dragon counts offsets over the whole field, with a newline between blocks,
+  // not relative to the node at the caret. In "First paragraph\nI'm dictating
+  // here", "dictating" sits at global offset 20, four characters into its own
+  // paragraph.
+  test("selects a word addressed by a global offset across paragraphs", async ({ editor }) => {
+    await editor.setValue("<p>First paragraph</p><p>I'm dictating here</p>")
+    await editor.select("here")
+    await postMakeChanges(editor, [ 20, 9, -1, 20, 9 ])
+    await editor.flush()
+
+    expect(await editor.content.evaluate(() => window.getSelection().toString())).toBe("dictating")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("replaces a word addressed by a global offset across paragraphs", async ({ editor }) => {
+    await editor.setValue("<p>First paragraph</p><p>I'm dictating here</p>")
+    await editor.select("here")
+    await postMakeChanges(editor, [ 20, 9, "speaking", 28, 0 ])
+    await editor.flush()
+
+    expect(await editor.value()).toContain("I'm speaking here")
+    expect(await editor.value()).toContain("First paragraph")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("addresses text after a decorator block without breaking", async ({ editor }) => {
+    await editor.setValue("<p>Before</p><hr><p>Dictating here</p>")
+    await editor.select("here")
+    await postMakeChanges(editor, [ 8, 9, -1, 8, 9 ])
+    await editor.flush()
+
+    expect(await editor.content.evaluate(() => window.getSelection().toString())).toBe("Dictating")
+    expect(pageErrors).toEqual([])
+  })
 })
 
 async function postMakeChanges(editor, args) {
   await editor.content.evaluate((_element, args) => {
-    window.postMessage(JSON.stringify({
-      protocol: "nuanria_messaging",
-      type: "request",
-      payload: { functionId: "makeChanges", args },
-    }), "*")
+    return new Promise((resolve) => {
+      window.postMessage(JSON.stringify({
+        protocol: "nuanria_messaging",
+        type: "request",
+        payload: { functionId: "makeChanges", args },
+      }), "*")
+      // Let the posted message reach the capture listener before the test reads back state.
+      setTimeout(resolve, 0)
+    })
   }, args)
 }

--- a/test/browser/tests/vendor/dragon.test.js
+++ b/test/browser/tests/vendor/dragon.test.js
@@ -1,0 +1,80 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+// Dragon NaturallySpeaking's web extension drives the editor through window
+// messages: protocol "nuanria_messaging", functionId "makeChanges", args
+// [elementStart, elementLength, text, selStart, selLength]. A text of -1 (a
+// number) means "change the selection without touching the text", which is how
+// Select-and-Say corrections and cursor moves by voice arrive.
+test.describe("Dragon NaturallySpeaking support", () => {
+  let pageErrors
+
+  test.beforeEach(async ({ page, editor }) => {
+    pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await editor.focus()
+    await editor.send("I'm dictating in the main content section")
+  })
+
+  test("replaces a word through a makeChanges message", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 9, "Dictating", 13, 0 ])
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe("I'm Dictating in the main content section")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("selection-only makeChanges selects the range without touching the text", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 9, -1, 4, 9 ])
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe("I'm dictating in the main content section")
+    expect(await editor.content.evaluate(() => window.getSelection().toString())).toBe("dictating")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("corrects a word after a selection-only makeChanges", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 9, -1, 4, 9 ])
+    await postMakeChanges(editor, [ 4, 9, "Dictating", 13, 0 ])
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe("I'm Dictating in the main content section")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("survives malformed makeChanges payloads", async ({ editor }) => {
+    await postMakeChanges(editor, "garbage")
+    await postMakeChanges(editor, { blockStart: 4 })
+    await postMakeChanges(editor, [])
+    await postMakeChanges(editor, [ "4", "9", "Hi", 0, 0 ])
+    await postMakeChanges(editor, [ 4, 9, 5, 0, 0 ])
+    await editor.send("!")
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe("I'm dictating in the main content section!")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("survives out-of-range offsets", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 900, -1, -5, 100 ])
+    await postMakeChanges(editor, [ 4, 9, -1, 8, -3 ])
+    await editor.send("!")
+    await editor.flush()
+
+    expect((await editor.plainTextValue()).replace("!", "")).toBe("I'm dictating in the main content section")
+    expect(pageErrors).toEqual([])
+  })
+})
+
+async function postMakeChanges(editor, args) {
+  await editor.content.evaluate((_element, args) => {
+    window.postMessage(JSON.stringify({
+      protocol: "nuanria_messaging",
+      type: "request",
+      payload: { functionId: "makeChanges", args },
+    }), "*")
+  }, args)
+}

--- a/test/browser/tests/vendor/dragon.test.js
+++ b/test/browser/tests/vendor/dragon.test.js
@@ -3,9 +3,11 @@ import { expect } from "@playwright/test"
 
 // Dragon NaturallySpeaking's web extension drives the editor through window
 // messages: protocol "nuanria_messaging", functionId "makeChanges", args
-// [elementStart, elementLength, text, selStart, selLength]. A text of -1 (a
-// number) means "change the selection without touching the text", which is how
-// Select-and-Say corrections and cursor moves by voice arrive.
+// [elementStart, elementLength, text, selStart, selLength, formatCommand]. A
+// text of -1 (a number) means "change the selection without touching the
+// text", which is how Select-and-Say corrections and cursor moves by voice
+// arrive. The optional sixth argument carries an execCommand name (bold,
+// italic, underline, ...) for voice commands such as "bold that".
 test.describe("Dragon NaturallySpeaking support", () => {
   let pageErrors
 
@@ -65,6 +67,34 @@ test.describe("Dragon NaturallySpeaking support", () => {
     await editor.flush()
 
     expect((await editor.plainTextValue()).replace("!", "")).toBe("I'm dictating in the main content section")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("formats the selection when makeChanges carries a format command", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 9, -1, 4, 9, "bold" ])
+    await editor.flush()
+
+    expect(await editor.value()).toContain("<strong>dictating</strong>")
+    expect(await editor.plainTextValue()).toBe("I'm dictating in the main content section")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("does not toggle format when the final selection is collapsed", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 9, -1, 100, 5, "bold" ])
+    await editor.send("!")
+    await editor.flush()
+
+    expect(await editor.value()).not.toContain("<strong>")
+    expect(pageErrors).toEqual([])
+  })
+
+  test("ignores unknown format commands", async ({ editor }) => {
+    await postMakeChanges(editor, [ 4, 9, -1, 4, 9, "fontName" ])
+    await postMakeChanges(editor, [ 4, 9, -1, 4, 9, "toString" ])
+    await editor.flush()
+
+    expect(await editor.value()).not.toContain("<strong>")
+    expect(await editor.plainTextValue()).toBe("I'm dictating in the main content section")
     expect(pageErrors).toEqual([])
   })
 })

--- a/test/browser/tests/vendor/dragon.test.js
+++ b/test/browser/tests/vendor/dragon.test.js
@@ -29,6 +29,17 @@ test.describe("Dragon NaturallySpeaking support", () => {
     expect(pageErrors).toEqual([])
   })
 
+  test("a selection-only makeChanges keeps the serialized value cache instead of recomputing it", async ({ editor }) => {
+    // A selection-only change dirties no node, so the value cache should survive
+    // untouched. A sentinel tells "kept" apart from "recomputed to the same string".
+    await editor.locator.evaluate((element) => { element.cachedValue = "sentinel" })
+
+    await postMakeChanges(editor, [ 4, 9, -1, 4, 9 ])
+    await editor.flush()
+
+    expect(await editor.locator.evaluate((element) => element.cachedValue)).toBe("sentinel")
+  })
+
   test("selection-only makeChanges selects the range without touching the text", async ({ editor }) => {
     await postMakeChanges(editor, [ 4, 9, -1, 4, 9 ])
     await editor.flush()

--- a/test/browser/vite.config.js
+++ b/test/browser/vite.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   root: path.resolve(import.meta.dirname, "fixtures"),
   resolve: {
     alias: {
+      "lexxy/dragon": path.resolve(import.meta.dirname, "../../src/editor/vendor/dragon/support.js"),
       lexxy: path.resolve(import.meta.dirname, "../../src/index.js"),
     },
   },


### PR DESCRIPTION
A customer who dictates with Dragon NaturallySpeaking reported that correcting a word by voice in any rich text field destroys everything after the corrected word ([Basecamp card](https://app.basecamp.com/2914079/buckets/47229151/card_tables/cards/9966179255)). The cause is in the handler Lexical ships for Dragon's web extension messages, which Lexxy picks up through the RichTextExtension dependency chain: Dragon sends the number -1 as the text argument to mean "change the selection without touching the text", the handler passes it straight to `insertRawText`, and the resulting exception inside `editor.update` leaves the editor permanently broken. From then on the extension edits the DOM behind Lexical's back and content disappears when the two diverge.

Blocking the extension means catching its window message before it acts, and its content script registers at `document_end`. A handler that loads with the editor can't win that race when the editor loads lazily, well after `document_end`.

So this PR:

- Handles the protocol from a listener registered as Lexxy loads, early enough to beat the extension's content script and stop it from editing the DOM directly. The listener carries no Lexical, so it stays light, and dispatches a document event to the editor-side code that applies the change once Lexxy has loaded.
- Honors the -1 sentinel, so corrections and cursor moves by voice work without breaking the editor.
- Validates every makeChanges payload before `editor.update`, malformed ones included, since both the extension's raw DOM edits and the broken stock handler behind us would corrupt the editor otherwise.
- Applies Dragon's format commands ("bold that"), mapping the execCommand names the extension sends to Lexical text formats.
- Adds Playwright coverage for the protocol: replacement, selection-only, the full correction flow, malformed and out-of-range payloads, format commands, unknown commands, and clamped selections not toggling the pending format.

Apps that load Lexxy from their eager bundle get this with no extra step. Apps that load it lazily add `import "@37signals/lexxy/dragon"` to their eager bundle so the listener still wins the race.

The protocol fix and the format mapping also went upstream in facebook/lexical#8665, which adds an `installDragonSupport()` entrypoint API for the race. Once a release we adopt ships, we can hand the editor-side processing to Lexical's handler. The lightweight listener that wins the race for lazy-loaded apps is still ours for now, and if it's worth bringing upstream too, we'll follow up with another PR.

I validated the handler against the real extension's unpacked content scripts in both registration orders, but final confirmation with Dragon itself will have to come through the customer, since it needs their setup.
