### PR TITLE
Preserve whitespace around custom attachment.

### DIFF
--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -27,10 +27,11 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
 
         return {
           conversion: (attachment) => {
-            // Preserve initial space if present since Lexical removes it
+            // Preserve the space Lexical strips next to the attachment. ASCII only:
+            // \s also matches NBSP, which Lexical keeps, so it would add a phantom space.
             const nodes = []
             const previousSibling = attachment.previousSibling
-            if (previousSibling && previousSibling.nodeType === Node.TEXT_NODE && /\s$/.test(previousSibling.textContent)) {
+            if (previousSibling && /[ \t\r\n]$/.test(previousSibling.textContent)) {
               nodes.push($createTextNode(" "))
             }
 
@@ -44,7 +45,7 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
             }))
 
             const nextSibling = attachment.nextSibling
-            if (nextSibling && nextSibling.nodeType === Node.TEXT_NODE && /^\s/.test(nextSibling.textContent)) {
+            if (nextSibling && /^[ \t\r\n]/.test(nextSibling.textContent)) {
               nodes.push($createTextNode(" "))
             }
 

--- a/test/browser/tests/attachments/custom_attachment_whitespace.test.js
+++ b/test/browser/tests/attachments/custom_attachment_whitespace.test.js
@@ -1,0 +1,34 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const mention = `<bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment>`
+
+const NBSP = "\u00a0"
+
+test.describe("Whitespace around custom attachments", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("preserves the space between a bold run and a following attachment", async ({ editor }) => {
+    await editor.setValue(`<p><strong>Link: </strong>${mention}<strong>.</strong></p>`)
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe("Link: Alice.")
+  })
+
+  test("preserves the space between an attachment and a following bold run", async ({ editor }) => {
+    await editor.setValue(`<p>${mention}<strong> end</strong></p>`)
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe("Alice end")
+  })
+
+  test("keeps non-breaking spaces inside a format intact without adding a space", async ({ editor }) => {
+    await editor.setValue(`<p><strong>Link:&nbsp;&nbsp;</strong>${mention}</p>`)
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toBe(`Link:${NBSP}${NBSP}Alice`)
+  })
+})

--- a/test/browser/tests/attachments/custom_attachment_whitespace.test.js
+++ b/test/browser/tests/attachments/custom_attachment_whitespace.test.js
@@ -3,8 +3,6 @@ import { expect } from "@playwright/test"
 
 const mention = `<bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment>`
 
-const NBSP = "\u00a0"
-
 test.describe("Whitespace around custom attachments", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/mentions-custom-element.html")
@@ -15,20 +13,20 @@ test.describe("Whitespace around custom attachments", () => {
     await editor.setValue(`<p><strong>Link: </strong>${mention}<strong>.</strong></p>`)
     await editor.flush()
 
-    expect(await editor.plainTextValue()).toBe("Link: Alice.")
+    expect(await editor.value()).toContain("<strong>Link:</strong> <bc-attachment")
   })
 
   test("preserves the space between an attachment and a following bold run", async ({ editor }) => {
     await editor.setValue(`<p>${mention}<strong> end</strong></p>`)
     await editor.flush()
 
-    expect(await editor.plainTextValue()).toBe("Alice end")
+    expect(await editor.value()).toContain("</bc-attachment> <strong>end</strong>")
   })
 
   test("keeps non-breaking spaces inside a format intact without adding a space", async ({ editor }) => {
     await editor.setValue(`<p><strong>Link:&nbsp;&nbsp;</strong>${mention}</p>`)
     await editor.flush()
 
-    expect(await editor.plainTextValue()).toBe(`Link:${NBSP}${NBSP}Alice`)
+    expect(await editor.value()).toContain("<strong>Link:&nbsp;&nbsp;</strong><bc-attachment")
   })
 })


### PR DESCRIPTION
## Summary

Importing HTML into the editor dropped the space between formatted text and an inline custom attachment (mention, placeholder): `<strong>Link: </strong><action-text-attachment>` came back as `Link:` glued to the attachment. The space survived in the saved value but vanished on re-edit.

Lexical strips the ASCII whitespace bordering an inline decorator on import, and `CustomActionTextAttachmentNode` re-adds it from the neighbouring sibling. That restore only ran for bare text nodes, so when the bordering text was wrapped in an inline format (`<strong>`, `<mark>`, etc) the sibling was an element and the space was lost.

## Changes

`src/nodes/custom_action_text_attachment_node.js` - read the sibling's  `textContent` instead of requiring a bare text node, so the space counts inside inline formats. Match ASCII whitespace (`[ \t\r\n]`) rather than `\s`, which also matches NBSP - whitespace Lexical keeps - and would inject a phantom space.
