### PR TITLE
Arrow-key navigation crashes when the selected node is removed before the deferred update runs

### DIFF
--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -470,12 +470,16 @@ export default class Selection {
 
   async #withCurrentNode(fn) {
     await nextFrame()
-    if (this.hasNodeSelection) {
-      this.editor.update(() => {
-        fn($getSelection().getNodes()[0])
-        this.editor.focus()
-      })
-    }
+    if (!this.hasNodeSelection) return
+
+    this.editor.update(() => {
+      const selection = $getSelection()
+      const currentNode = $isNodeSelection(selection) ? selection.getNodes()[0] : null
+      if (!currentNode) return
+
+      fn(currentNode)
+      this.editor.focus()
+    })
   }
 
   async #selectOrAppendNextLine() {

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -470,16 +470,16 @@ export default class Selection {
 
   async #withCurrentNode(fn) {
     await nextFrame()
-    if (!this.hasNodeSelection) return
-
-    this.editor.update(() => {
-      const selection = $getSelection()
-      const currentNode = $isNodeSelection(selection) ? selection.getNodes()[0] : null
-      if (!currentNode) return
-
-      fn(currentNode)
-      this.editor.focus()
-    })
+    if (this.hasNodeSelection) {
+      this.editor.update(() => {
+        const selection = $getSelection()
+        const currentNode = $isNodeSelection(selection) ? selection.getNodes()[0] : null
+        if (currentNode) {
+          fn(currentNode)
+          this.editor.focus()
+        }
+      })
+    }
   }
 
   async #selectOrAppendNextLine() {

--- a/test/browser/tests/attachments/arrow_navigation_attachment.test.js
+++ b/test/browser/tests/attachments/arrow_navigation_attachment.test.js
@@ -199,4 +199,43 @@ test.describe("Arrow key navigation near attachments", () => {
       .count()
     expect(attachmentSelected).toBe(1)
   })
+
+  test("arrow key on a selected attachment that is replaced before navigation runs does not throw", async ({ page, editor }) => {
+    await editor.setValue(
+      "<p>First paragraph</p>" +
+        '<action-text-attachment content-type="image/png" url="/test.png" filename="test.png" filesize="1024" width="100" height="100"></action-text-attachment>',
+    )
+    await editor.flush()
+
+    // Click the attachment to create a node selection
+    await page.locator("figure.attachment").click()
+    await expect(page.locator("figure.attachment.node--selected")).toHaveCount(1)
+
+    const pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    // Arrow navigation on a node selection defers one frame before acting.
+    // Replace the selected node during that frame — like an upload finishing —
+    // so the node selection's key goes stale before the deferred update runs.
+    await editor.content.evaluate((el) => {
+      const editorElement = el.closest("lexxy-editor")
+      const lexicalEditor = editorElement.editor
+
+      el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", code: "ArrowUp", keyCode: 38, bubbles: true, cancelable: true }))
+
+      lexicalEditor.update(() => {
+        const editorState = lexicalEditor.getEditorState()
+        const selectedKey = Array.from(editorState._selection._nodes)[0]
+        const attachmentNode = editorState._nodeMap.get(selectedKey)
+        const paragraphNode = Array.from(editorState._nodeMap.values()).find((node) => node.getType() === "paragraph")
+        attachmentNode.replace(paragraphNode)
+      })
+    })
+
+    // Give the deferred navigation time to run and any page error to reach the test
+    await editor.flush()
+    await page.waitForTimeout(250)
+
+    expect(pageErrors).toEqual([])
+  })
 })


### PR DESCRIPTION
Arrow-key navigation on a node selection crashes with `TypeError: Cannot read properties of undefined (reading 'getTopLevelElement')` (also `selectPrevious` / `selectNext`) when the selected node disappears before the deferred navigation runs. [Fixes BC3-JS-N7TF](https://basecamp.sentry.io/issues/7513049864/) — 3,101 events / 1,647 users in BC3 since May 29.

Basecamp card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9982065995

## Root cause

`Selection#withCurrentNode` awaits `nextFrame()` before acting on the current node selection. If the selected node is removed or replaced during that frame — for example, a direct upload finishing replaces the upload node via `replaceAndRewriteHistory`, which uses Lexical's `replace()` and does not restore node selections — the selection keeps the stale node key. `hasNodeSelection` still reports true, but `$getSelection().getNodes()` comes back empty, so the handler calls `fn(undefined)` and throws.

## Fix

Re-resolve the selection inside the deferred `editor.update()` and bail cleanly when it is no longer a node selection or the node is gone.

The regression test reproduces the race: select an attachment, press an arrow key, and replace the attachment node before the deferred frame runs — it fails with the exact production TypeError without the fix.
