### PR TITLE
Fix file drop/paste crashes on node selections and code-block carets

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -251,6 +251,8 @@ export default class Contents {
   }
 
   uploadFiles(files, { selectLast } = {}) {
+    if (!this.editorElement) return // Disposed (e.g. on turbo:before-cache); a late drop can still land here
+
     if (!this.editorElement.supportsAttachments) {
       console.warn("This editor does not supports attachments (it's configured with [attachments=false])")
       return

--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -1,4 +1,4 @@
-import { $createLineBreakNode, $createParagraphNode, $createTextNode, $getChildCaretAtIndex, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isNodeSelection, $isRangeSelection, $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
+import { $createLineBreakNode, $createParagraphNode, $createTextNode, $getChildCaretAtIndex, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
 import { CodeNode } from "@lexical/code"
 import { $ensureForwardRangeSelection } from "@lexical/selection"
 import { $getNearestNodeOfType } from "@lexical/utils"
@@ -36,14 +36,40 @@ class CodeNodeInserter extends NodeInserter {
 
     const caret = $getChildCaretAtIndex(codeNode, insertionIndex + 1, "previous")
 
-    for (const node of nodes) {
-      if (!node.isAttached()) continue
-      if (caret.getNodeAtCaret() && $isElementNode(node)) { caret.insert($createLineBreakNode()) }
+    // Nodes that are already in the document come from the format-toggle path (existing
+    // content converted into this code block). Brand-new nodes (dropped/pasted content)
+    // were never attached.
+    const existingNodes = new Set(nodes.filter(node => node.isAttached()))
+    const trailingNodes = []
 
+    for (const node of nodes) {
+      if (existingNodes.has(node)) {
+        if (!node.isAttached()) continue // already pulled in when a converted ancestor was removed
+      } else if (!this.#canJoinCodeBlock(node)) {
+        trailingNodes.push(node) // e.g. a dropped attachment, which a code block can't hold
+        continue
+      }
+
+      if (caret.getNodeAtCaret() && $isElementNode(node)) { caret.insert($createLineBreakNode()) }
       caret.insert(this.#convertNodeToCodeChild(node))
     }
 
-    caret.getNodeAtCaret().selectEnd()
+    const lastTrailingNode = this.#insertAfterCodeBlock(codeNode, trailingNodes)
+    const nodeToSelect = lastTrailingNode ?? caret.getNodeAtCaret()
+    nodeToSelect?.selectEnd()
+  }
+
+  #canJoinCodeBlock(node) {
+    return $isTextNode(node) || $isLineBreakNode(node)
+  }
+
+  #insertAfterCodeBlock(codeNode, nodes) {
+    let previousNode = codeNode
+    for (const node of nodes) {
+      previousNode.insertAfter(node)
+      previousNode = node
+    }
+    return nodes.at(-1)
   }
 
   #convertNodeToCodeChild(node) {

--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -59,7 +59,7 @@ class CodeNodeInserter extends NodeInserter {
 
 class ShadowRootNodeInserter extends NodeInserter {
   static handles(selection) {
-    return $isShadowRoot(selection?.anchor.getNode())
+    return $isShadowRoot(selection?.anchor?.getNode())
   }
 
   insertNodes(nodes) {

--- a/src/editor/contents/uploader.js
+++ b/src/editor/contents/uploader.js
@@ -69,7 +69,10 @@ class GalleryUploader extends Uploader {
 
   #findOrCreateGallery() {
     if (this.selection.isOnPreviewableImage) {
-      this.#gallery = $findOrCreateGalleryForImage(this.#selectedNode)
+      // Resolve from the previewable image itself (the selection's first node), not from
+      // #selectedNode (the anchor) — those differ when the selection runs from an image
+      // into following text, and the anchor text node can't join a gallery (returns null).
+      this.#gallery = $findOrCreateGalleryForImage(this.selection.previewableImageNode)
     } else if (this.#selectionIsAfterGalleryEdge) {
       this.#gallery = $findOrCreateGalleryForImage(this.selection.nodeBeforeCursor)
     } else {

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -177,9 +177,12 @@ export default class Selection {
   }
 
   get isOnPreviewableImage() {
-    const selection = $getSelection()
-    const firstNode = selection?.getNodes().at(0)
-    return $isActionTextAttachmentNode(firstNode) && firstNode.isPreviewableImage
+    return this.previewableImageNode != null
+  }
+
+  get previewableImageNode() {
+    const firstNode = $getSelection()?.getNodes().at(0)
+    return $isActionTextAttachmentNode(firstNode) && firstNode.isPreviewableImage ? firstNode : null
   }
 
   get isAtNodeStart() {

--- a/test/browser/tests/attachments/upload_after_editor_disposed.test.js
+++ b/test/browser/tests/attachments/upload_after_editor_disposed.test.js
@@ -1,0 +1,38 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+test.describe("Uploading after the editor is disposed", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+    await mockActiveStorageUploads(page)
+  })
+
+  // "Cannot read properties of null (reading 'supportsAttachments')":
+  // turbo:before-cache disposes the editor in place (Contents#editorElement becomes null)
+  // while the element stays in the DOM, so a late drop relayed by a document-level drop zone
+  // still calls Contents#uploadFiles on the disposed instance. It must be a no-op, not a crash.
+  test("uploading after turbo:before-cache disposes the editor is a no-op", async ({ page, editor }) => {
+    await editor.setValue("<p>hello</p>")
+    await editor.flush()
+
+    const errorMessage = await page.evaluate(() => {
+      const editorElement = document.querySelector("lexxy-editor")
+
+      // Turbo caches the page on every navigation; lexxy resets the editor in place.
+      document.dispatchEvent(new Event("turbo:before-cache"))
+
+      const file = new File([ "x" ], "late-drop.png", { type: "image/png" })
+      try {
+        editorElement.contents.uploadFiles([ file ])
+        return null
+      } catch (error) {
+        return error.message
+      }
+    })
+
+    expect(errorMessage).toBeNull()
+  })
+})

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -35,4 +35,34 @@ test.describe("Uploading into an unsupported selection", () => {
 
     await expect(editor.content.locator("figure.attachment")).toHaveCount(2, { timeout: 10_000 })
   })
+
+  // "Cannot read properties of null (reading 'selectEnd')":
+  // uploading a file while the caret sits in an empty code block leaves no node
+  // at the caret, and CodeNodeInserter crashed trying to select it. Driven through
+  // Contents#uploadFiles directly, the same entry point document-level drop zones use.
+  // A <code> block can't hold an attachment, so the file lands after the block rather
+  // than being silently discarded.
+  test("uploading a file with the caret in a code block lands it after the block", async ({ page, editor }) => {
+    await editor.setValue('<pre data-language="plain"><code>keep me</code></pre>')
+    await editor.flush()
+
+    await editor.click()
+
+    const errorMessage = await page.evaluate(() => {
+      const editorElement = document.querySelector("lexxy-editor")
+      const file = new File([ "%PDF-1.4 dummy" ], "dropped.pdf", { type: "application/pdf" })
+      try {
+        editorElement.contents.uploadFiles([ file ])
+        return null
+      } catch (error) {
+        return error.message
+      }
+    })
+
+    expect(errorMessage).toBeNull()
+
+    // The file is uploaded (not silently dropped) and the code block keeps its contents.
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(1, { timeout: 10_000 })
+    await expect(editor.content.locator("code")).toContainText("keep me")
+  })
 })

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -8,6 +8,10 @@ const pdfAttachment =
   '<action-text-attachment sgid="test-sgid-123" content-type="application/pdf" filename="report.pdf" ' +
   'filesize="12345" previewable="false" url="http://example.com/report.pdf"></action-text-attachment>'
 
+const imageAttachment =
+  '<action-text-attachment sgid="img-sgid-1" content-type="image/png" filename="a.png" ' +
+  'filesize="100" width="10" height="10" previewable="true" url="http://example.com/a.png"></action-text-attachment>'
+
 test.describe("Uploading into an unsupported selection", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/attachments.html")
@@ -64,5 +68,39 @@ test.describe("Uploading into an unsupported selection", () => {
     // The file is uploaded (not silently dropped) and the code block keeps its contents.
     await expect(editor.content.locator("figure.attachment")).toHaveCount(1, { timeout: 10_000 })
     await expect(editor.content.locator("code")).toContainText("keep me")
+  })
+
+  // "Cannot read properties of null (reading 'splice')":
+  // isOnPreviewableImage looks at the selection's first node (the image), but the gallery
+  // was resolved from the anchor — the trailing text node, which can't join a gallery. The
+  // lookup returned null and GalleryUploader crashed on `gallery.splice(...)`. Resolving from
+  // the image node itself makes the existing image and the uploaded one form a gallery.
+  test("uploading an image with the selection spanning from an image into text forms a gallery", async ({ page, editor }) => {
+    await editor.setValue(`${imageAttachment}<p>hello world</p>`)
+    await editor.flush()
+
+    // Select from the image down into the trailing text: anchor at the end of the text,
+    // focus on the root just before the image. This is what dragging from the image into
+    // the text below produces — the image is the first selected node, the anchor is text.
+    await page.evaluate(() => {
+      const editorElement = document.querySelector("lexxy-editor")
+      editorElement.editor.update(() => {
+        const root = editorElement.editor.getEditorState()._nodeMap.get("root")
+        const image = root.getChildren().find((child) => child.getType() === "action_text_attachment")
+        const lastText = root.getLastDescendant()
+        const selection = lastText.select(lastText.getTextContentSize(), lastText.getTextContentSize())
+        selection.focus.set(root.getKey(), image.getIndexWithinParent(), "element")
+      })
+    })
+
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await editor.flush()
+
+    // The dropped image lands (standalone image + new gallery = 2 figures) and nothing throws.
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(2, { timeout: 10_000 })
+    expect(errors).toEqual([])
   })
 })

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -1,0 +1,38 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+const PDF_BASE64 = Buffer.from("%PDF-1.4 dummy", "utf8").toString("base64")
+
+const pdfAttachment =
+  '<action-text-attachment sgid="test-sgid-123" content-type="application/pdf" filename="report.pdf" ' +
+  'filesize="12345" previewable="false" url="http://example.com/report.pdf"></action-text-attachment>'
+
+test.describe("Uploading into an unsupported selection", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+    await mockActiveStorageUploads(page)
+  })
+
+  // "Cannot read properties of undefined (reading 'getNode')":
+  // node selections have no anchor, so ShadowRootNodeInserter.handles crashed
+  // instead of letting NodeSelectionNodeInserter handle the insertion.
+  test("pasting a file while an attachment is node-selected inserts after it", async ({ page, editor }) => {
+    await editor.setValue(pdfAttachment)
+    await editor.flush()
+
+    const figure = editor.content.locator("figure.attachment")
+    await expect(figure).toBeVisible()
+
+    await figure.click()
+    await expect(figure).toHaveClass(/node--selected/)
+
+    await editor.paste("", {
+      files: [ { base64: PDF_BASE64, name: "pasted.pdf", type: "application/pdf" } ],
+    })
+
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(2, { timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
Fixes the four file-drop/paste crashes grouped under [Sentry BC3-JS-N7D5](https://basecamp.sentry.io/issues/7507327343/). Bug card: [9982374185](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9982374185).

Uploads funnel through `Contents#uploadFiles` → `insertAtCursor()` → `NodeInserter.for(selection)` (and `Uploader.for(...)` for images). The **same path runs for dropping a file and for pasting one**, so none of these is drag-specific.

## 1. Node-selected attachment — `Cannot read properties of undefined (reading 'getNode')`

`ShadowRootNodeInserter.handles` read `selection?.anchor.getNode()`. A **NodeSelection** has no `.anchor`, so `undefined.getNode()` threw before `NodeSelectionNodeInserter` could handle it. Fixed the optional chaining.

**How a real user hits it:** click an attachment (PDF chip, file card, image) so it's selected as a whole node, then **paste or drop another file**.

## 2. Caret in a code block — `Cannot read properties of null (reading 'selectEnd')`

`CodeNodeInserter` filters with `!node.isAttached()`; a freshly-created upload node isn't attached, so nothing was inserted and `caret.getNodeAtCaret()` was `null`. A `<code>` block can't hold an attachment, so fresh non-code nodes are now inserted **after** the block.

**How a real user hits it:** put the cursor **inside a code block**, then **drop or paste a file/image**.

## 3. Selection spanning an image into text — `Cannot read properties of null (reading 'splice')`

`GalleryUploader` engages when `isOnPreviewableImage` (the selection's **first node** is an image) but resolved the gallery from `#selectedNode` (the **anchor**). When the selection runs from an image into following text, the anchor is the text node, which can't join a gallery — the lookup returned `null` and `gallery.splice(...)` threw. Now resolves from the previewable image node itself.

**How a real user hits it:** with an image followed by text, select from the image down into the text below (or shift-select upward from the text onto the image), then **drop or paste an image**. Most frequent variant (~2,000 users).

## 4. Disposed editor — `Cannot read properties of null (reading 'supportsAttachments')`

`turbo:before-cache` (which fires on **every Turbo Drive navigation** to cache the page, not just morph refreshes) disposes the editor **in place** — `Contents#editorElement` becomes `null` while the `<lexxy-editor>` stays in the DOM and keeps exposing this `Contents` via `element.contents`. A late drop relayed by Basecamp's document-level drop zone then calls `uploadFiles` on the disposed instance. Guarded so a disposed editor is a no-op.

**How a real user hits it:** while a navigation/cache is in flight (the old composer still on screen, e.g. on a slow connection), a file dropped onto it lands in the disposed instance. The disposal happens *while the element is still connected*, which is why a host-side `isConnected` guard can't catch it and the fix lives here — see closed companion PR basecamp/bc3#11975 for the analysis.

## Tests

Playwright regression tests, each driving a real editor and verified **red against main / green with the fix**:

- **Node selection**, **code block**, **gallery splice** — in `test/browser/tests/attachments/upload_into_unsupported_selection.test.js`.
- **Disposed editor** — `test/browser/tests/attachments/upload_after_editor_disposed.test.js` fires `turbo:before-cache`, then calls `uploadFiles` (the document drop zone's entry point); without the guard it throws the exact production `TypeError`.
