### PR TITLE
Pasting into a blank list item inside a blockquote crashes with Lexical error #66

### DIFF
--- a/src/nodes/early_escape_list_item_node.js
+++ b/src/nodes/early_escape_list_item_node.js
@@ -17,16 +17,23 @@ export class EarlyEscapeListItemNode extends ListItemNode {
     return super.insertNewAfter(selection, restoreSelection)
   }
 
-  #shouldEscape(selection) {
-    // Pasting is not an escape gesture. Lexical's insertNodes inserts the pasted blocks
-    // after this node, so escaping (which removes it) would leave Lexical referencing
-    // a detached node and throw "Expected node to have a parent" (error #66).
-    if ($hasUpdateTag(PASTE_TAG)) return false
-    if (!$getNearestNodeOfType(this, QuoteNode)) return false
-    if ($isBlankNode(this)) return true
+  get #isInBlockquote() {
+    return Boolean($getNearestNodeOfType(this, QuoteNode))
+  }
 
-    const paragraph = $getNearestNodeOfType(selection.anchor.getNode(), ParagraphNode)
-    return paragraph && $isBlankNode(paragraph) && $isListItemNode(paragraph.getParent())
+  #shouldEscape(selection) {
+    if (this.#isInPasteOperation() || !this.#isInBlockquote) {
+      return false
+    } else if ($isBlankNode(this)) {
+      return true
+    } else {
+      const paragraph = $getNearestNodeOfType(selection.anchor.getNode(), ParagraphNode)
+      return paragraph && $isBlankNode(paragraph) && $isListItemNode(paragraph.getParent())
+    }
+  }
+
+  #isInPasteOperation() {
+    return $hasUpdateTag(PASTE_TAG)
   }
 
   #escapeFromList() {

--- a/src/nodes/early_escape_list_item_node.js
+++ b/src/nodes/early_escape_list_item_node.js
@@ -1,4 +1,4 @@
-import { $createParagraphNode, $splitNode, ParagraphNode } from "lexical"
+import { $createParagraphNode, $hasUpdateTag, $splitNode, PASTE_TAG, ParagraphNode } from "lexical"
 import { $isListItemNode, $isListNode, ListItemNode } from "@lexical/list"
 import { $isQuoteNode, QuoteNode } from "@lexical/rich-text"
 import { $getNearestNodeOfType } from "@lexical/utils"
@@ -18,6 +18,10 @@ export class EarlyEscapeListItemNode extends ListItemNode {
   }
 
   #shouldEscape(selection) {
+    // Pasting is not an escape gesture. Lexical's insertNodes inserts the pasted blocks
+    // after this node, so escaping (which removes it) would leave Lexical referencing
+    // a detached node and throw "Expected node to have a parent" (error #66).
+    if ($hasUpdateTag(PASTE_TAG)) return false
     if (!$getNearestNodeOfType(this, QuoteNode)) return false
     if ($isBlankNode(this)) return true
 

--- a/test/browser/tests/paste/paste_into_quoted_list.test.js
+++ b/test/browser/tests/paste/paste_into_quoted_list.test.js
@@ -1,0 +1,35 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorHtml, startMonitoringConsole } from "../../helpers/assertions.js"
+
+// Reproduces Lexical error #66 ("Expected node %s to have a parent"): pasting block
+// content with the caret on a blank-but-not-empty list item inside a blockquote.
+// EarlyEscapeListItemNode used to treat Lexical's internal paste-time insertNewAfter
+// call as an escape gesture, removing the list item that insertNodes still references —
+// throwing the invariant and losing the pasted content.
+test.describe("Paste into quoted list", () => {
+  test("pasting block content with the caret on a blank quoted list item keeps the pasted blocks", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<blockquote><ul><li>item</li></ul></blockquote>")
+    await editor.focus()
+
+    // Recreate the production path: Enter adds an empty bullet below "item",
+    // then Shift+Enter leaves it blank-but-not-empty with a collapsed caret on it.
+    await editor.send("End", "Enter", "Shift+Enter")
+
+    await editor.paste("first\nsecond", { html: "<p>first</p><p>second</p>" })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<blockquote><ul><li value="1">item</li><li value="2"><br>first</li></ul><p>second</p></blockquote>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+})


### PR DESCRIPTION
[Fixes BC3-JS-N7CJ](https://basecamp.sentry.io/issues/7507303017/) — 228 events / 186 users in 3 days. Card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9982981354

### What it fixes

Pasting block content with the cursor on a blank list item inside a blockquote crashed with Lexical error #66 ("Expected node %s to have a parent"), and the pasted content was lost. Every Sentry event goes through the same path: `Contents#insertDOM` → `insertAtCursor` → `RangeSelection.insertNodes`.

Reproduction: in a blockquote, Shift+Enter on an empty list item (leaving a list item whose only child is a line break), then paste rich text.

### How

Lexical's `RangeSelection.insertNodes` captures `firstBlock` (the list item), calls `insertParagraph` → `block.insertNewAfter(...)`, then inserts the pasted blocks with `insertRangeAfter(firstBlock, ...)`. `EarlyEscapeListItemNode#insertNewAfter` treated this internal call as an escape gesture: `#escapeFromList` removed the list item, so `insertRangeAfter` called `insertAfter` on a detached node and `getParentOrThrow` threw #66.

The fix guards `#shouldEscape` with `$hasUpdateTag(PASTE_TAG)`, mirroring the guard `EarlyEscapeCodeNode` already has. Pasting is not an escape gesture; during paste the node defers to the default list item behavior, so the pasted content lands in the list and the escape UX on Enter is unchanged.

Includes a Playwright regression test at `test/browser/tests/paste/paste_into_quoted_list.test.js` that recreates the production scenario with a real collapsed caret (Enter, then Shift+Enter on the quoted list, then paste). Red/green verified: it fails on main's `early_escape_list_item_node.js`, passes with the fix.

### Overlap notes

- #1106 / #1107 (and the sibling branch `sentry-lexical-error-63` for BC3-JS-N7E1) touch other crash paths (`selection.js`, `contents.js`, `node_inserter.js`, `uploader.js`). This fix is self-contained in `early_escape_list_item_node.js` and doesn't overlap their diffs.

