### PR TITLE
Pasting with the caret on a quote element crashes with Lexical error #211/#212

### DIFF
--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -1,4 +1,4 @@
-import { $createLineBreakNode, $createParagraphNode, $createTextNode, $getChildCaretAtIndex, $isElementNode, $isLineBreakNode, $isNodeSelection } from "lexical"
+import { $createLineBreakNode, $createParagraphNode, $createTextNode, $getChildCaretAtIndex, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isNodeSelection, $isRangeSelection, $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
 import { CodeNode } from "@lexical/code"
 import { $ensureForwardRangeSelection } from "@lexical/selection"
 import { $getNearestNodeOfType } from "@lexical/utils"
@@ -9,7 +9,8 @@ export default class NodeInserter {
     const INSERTERS = [
       CodeNodeInserter,
       ShadowRootNodeInserter,
-      NodeSelectionNodeInserter
+      NodeSelectionNodeInserter,
+      BlockContainerNodeInserter
     ]
     const Inserter = INSERTERS.find(inserter => inserter.handles(selection))
     return Inserter ? new Inserter(selection) : selection
@@ -84,5 +85,30 @@ class NodeSelectionNodeInserter extends NodeInserter {
     for (const node of nodes) {
       lastNode = lastNode.insertAfter(node)
     }
+  }
+}
+
+// Lexical's RangeSelection.insertNodes requires every selection point to have a block
+// ancestor with inline children. An element point on a container of block nodes — e.g.
+// a quote holding paragraphs — has none, so Lexical throws invariant #211 or #212.
+// Descend such points to a leaf position before inserting.
+class BlockContainerNodeInserter extends NodeInserter {
+  static handles(selection) {
+    return $isRangeSelection(selection) &&
+      [ selection.anchor, selection.focus ].some($isPointOnBlockContainer)
+  }
+
+  insertNodes(nodes) {
+    $normalizeSelection(this.selection)
+    this.selection.insertNodes(nodes)
+  }
+}
+
+function $isPointOnBlockContainer(point) {
+  if (point.type === "element") {
+    const firstChild = point.getNode().getFirstChild()
+    return ($isElementNode(firstChild) || $isDecoratorNode(firstChild)) && !firstChild.isInline()
+  } else {
+    return false
   }
 }

--- a/test/browser/tests/paste/paste_with_caret_on_quote.test.js
+++ b/test/browser/tests/paste/paste_with_caret_on_quote.test.js
@@ -1,0 +1,59 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent, assertEditorHtml } from "../../helpers/assertions.js"
+
+// Browsers can place the caret on the blockquote element itself — an element point on the
+// QuoteNode — e.g. when clicking the gap between two paragraphs inside a quote. Lexical's
+// RangeSelection.insertNodes requires every selection point to have a block ancestor with
+// inline children; a quote holding paragraphs has none, so pasting at that caret crashed
+// with Lexical error #211 (inline content) or #212 (block content) and lost the pasted content.
+test.describe("Paste with the caret on a quote element", () => {
+  let pageErrors
+
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await editor.setValue("<blockquote><p>first</p><p>second</p></blockquote>")
+    await editor.focus()
+    await placeCaretOnQuoteElement(editor)
+  })
+
+  test("pasting inline content does not crash and lands inside the quote", async ({ editor }) => {
+    await editor.paste("pasted", { html: "<span>pasted</span>" })
+    await editor.flush()
+
+    expect(pageErrors).toHaveLength(0)
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toContainText("pasted")
+    })
+    await assertEditorHtml(editor, "<blockquote><p>first</p><p>pastedsecond</p></blockquote>")
+  })
+
+  test("pasting block content does not crash and is preserved", async ({ editor }) => {
+    await editor.paste("pasted one\npasted two", { html: "<p>pasted one</p><p>pasted two</p>" })
+    await editor.flush()
+
+    expect(pageErrors).toHaveLength(0)
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toContainText("pasted one")
+      await expect(content.locator("blockquote")).toContainText("pasted two")
+    })
+  })
+})
+
+// Real mouse interaction can't reliably produce an element point on the quote node itself
+// (Lexical normalizes DOM selections to leaves), so set the Lexical selection directly,
+// mirroring the selection state Sentry reported. Offset 1 is the gap between the two paragraphs.
+async function placeCaretOnQuoteElement(editor) {
+  await editor.locator.evaluate((editorElement) => {
+    editorElement.editor.update(() => {
+      const editorState = editorElement.editor._pendingEditorState
+      const quote = editorState._nodeMap.get(editorState._nodeMap.get("root").__first)
+      quote.select(1, 1)
+    })
+  })
+}

--- a/test/browser/tests/paste/paste_with_caret_on_quote.test.js
+++ b/test/browser/tests/paste/paste_with_caret_on_quote.test.js
@@ -43,6 +43,20 @@ test.describe("Paste with the caret on a quote element", () => {
       await expect(content.locator("blockquote")).toContainText("pasted two")
     })
   })
+
+  // A second consumer hit the same crash from a different entry point: a plain-text markdown
+  // paste (Clipboard#pasteMarkdown → Contents#insertDOM → insertAtCursor → insertNodes). Pasting
+  // text without an HTML payload routes through the markdown path, which produces block content
+  // and reproduced the #212 variant. See https://github.com/basecamp/lexxy/pull/1109.
+  test("pasting markdown does not crash and lands inside the quote", async ({ editor }) => {
+    await editor.paste("pasted markdown")
+    await editor.flush()
+
+    expect(pageErrors).toHaveLength(0)
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toContainText("pasted markdown")
+    })
+  })
 })
 
 // Real mouse interaction can't reliably produce an element point on the quote node itself


### PR DESCRIPTION
[Fixes BC3-JS-N7AZ](https://basecamp.sentry.io/issues/7507281623/) — 884 events / 537 users since May 26 (180 / 138 in the last 3 days). Card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9982982415

### What it fixes

Pasting with the caret sitting on the blockquote element itself (an element point on the `QuoteNode`, e.g. after clicking in the gap between two paragraphs inside a quote) crashed and lost the paste. Every Sentry event goes through the same path: `Contents#insertDOM` → `insertAtCursor` → `RangeSelection.insertNodes`, throwing Lexical error #211 ("Expected node QuoteNode of type quote to have a block ElementNode ancestor") for inline content or #212 ("…to have a block ancestor") for block content.

### How

Lexical's `RangeSelection.insertNodes` requires every selection point to have a block ancestor with inline children (`INTERNAL_$isBlock`). A lexxy quote always holds paragraphs (`$ensureQuoteHasParagraphChild`), so an element point on the quote has no such ancestor — the quote fails the leaf-block check and its parent is the root.

A new `BlockContainerNodeInserter` handles range selections where a point sits on a container of block nodes: it normalizes the selection down to a leaf position (`$normalizeSelection__EXPERIMENTAL`, the same descent Lexical applies to DOM selections) and then delegates to the regular `insertNodes`.

Includes Playwright regression tests at `test/browser/tests/paste/paste_with_caret_on_quote.test.js` covering both the #211 (inline paste) and #212 (block paste) variants. They place the caret as an element point on the quote and drive a real clipboard paste. Verified red/green: with `src/` reverted to `main` both tests fail (2 failed); with the fix both pass (2 passed).
