### PR TITLE
Toggling a code block crashes when the selection spans nested structures

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -115,7 +115,7 @@ export default class Contents {
       blockElements.forEach(node => this.#unwrapCodeBlock(node))
     } else {
       $expandSelectionToLineBreaksAndSplitAtEdges(selection)
-      const elements = this.#blockLevelElementsInSelection(selection)
+      const elements = this.#outermostElements(this.#blockLevelElementsInSelection(selection))
       if (elements.length === 0) return
 
       const codeNode = $createCodeNode("plain")
@@ -439,6 +439,18 @@ export default class Contents {
       if (topLevel) elements.add(topLevel)
     }
     return Array.from(elements)
+  }
+
+  // Selections spanning nested structures (a quote and its inner paragraphs,
+  // nested list items) yield both an element and its ancestor. Converting the
+  // ancestor detaches its whole subtree — including a node freshly inserted
+  // inside it — which can leave the selection on removed nodes (Lexical
+  // invariant #19). The outermost elements already cover their descendants'
+  // text content, so keep only those.
+  #outermostElements(elements) {
+    return elements.filter((element) => {
+      return elements.every((other) => other === element || !element.getParents().includes(other))
+    })
   }
 
   #insertUploadNodes(nodes) {

--- a/test/browser/tests/formatting/code_block_navigation.test.js
+++ b/test/browser/tests/formatting/code_block_navigation.test.js
@@ -90,3 +90,39 @@ test.describe("Code block navigation", () => {
     })
   })
 })
+
+test.describe("Code block conversion", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("converts a selection spanning a paragraph and a quote", async ({ page, editor }) => {
+    await editor.setValue("<p>before</p><blockquote><p>quoted</p></blockquote>")
+    await editor.selectAll()
+
+    await page.getByRole("button", { name: "Code" }).click()
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toContainText("before")
+      await expect(content.locator("code")).toContainText("quoted")
+      await expect(content.locator("blockquote")).toHaveCount(0)
+    })
+  })
+
+  test("converts a selection spanning a nested list", async ({ page, editor }) => {
+    await editor.setValue("<ul><li>item one<ul><li>nested</li></ul></li></ul>")
+    await editor.selectAll()
+
+    await page.getByRole("button", { name: "Code" }).click()
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toContainText("item one")
+      await expect(content.locator("code")).toContainText("nested")
+      await expect(content.locator("li")).toHaveCount(0)
+    })
+  })
+})

--- a/test/javascript/unit/editor/toggle_code_block.test.js
+++ b/test/javascript/unit/editor/toggle_code_block.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest"
+import { createTestEditor, destroyTestEditor, dispatchToolbarCommand, selectAll, selectFirstText, setContent, tick } from "../helpers/editor_helper"
+
+describe("insertCodeBlock command", () => {
+  test("converts a selection spanning a paragraph and a quote without losing the selection", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>before</p><blockquote><p>quoted</p></blockquote>")
+    selectAll(editorElement)
+
+    expect(() => dispatchToolbarCommand(editorElement, "insertCodeBlock")).not.toThrow()
+    await tick()
+
+    expect(editorElement.value).toContain("<pre")
+    expect(editorElement.value).toContain("before<br>quoted")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("converts a nested list with the caret inside it without losing the selection", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<ul><li>item one<ul><li>nested</li></ul></li></ul>")
+    selectFirstText(editorElement, 2)
+
+    expect(() => dispatchToolbarCommand(editorElement, "insertCodeBlock")).not.toThrow()
+    await tick()
+
+    expect(editorElement.value).toContain("<pre")
+    expect(editorElement.value).toContain("item one<br>nested")
+
+    await destroyTestEditor(editorElement)
+  })
+})

--- a/test/javascript/unit/helpers/editor_helper.js
+++ b/test/javascript/unit/helpers/editor_helper.js
@@ -1,4 +1,4 @@
-import { $getRoot } from "lexical"
+import { $getRoot, $isTextNode } from "lexical"
 import { defineElements } from "../../../../src/elements/index"
 import { NativeAdapter } from "../../../../src/editor/adapters/native_adapter"
 
@@ -83,6 +83,21 @@ export function selectAll(editorElement) {
 export function selectEnd(editorElement) {
   editorElement.editor.update(() => {
     $getRoot().selectEnd()
+  })
+}
+
+export function selectFirstText(editorElement, offset = 0) {
+  editorElement.editor.update(() => {
+    const text = $getRoot().getFirstDescendant()
+    if ($isTextNode(text)) text.select(offset, offset)
+  }, { discrete: true })
+}
+
+// Mirrors LexicalToolbarElement#dispatchButtonCommand: toolbar buttons dispatch
+// their command from inside an editor.update() block.
+export function dispatchToolbarCommand(editorElement, command, payload) {
+  editorElement.editor.update(() => {
+    editorElement.editor.dispatchCommand(command, payload)
   })
 }
 


### PR DESCRIPTION
[Fixes BC3-JS-N7D7](https://basecamp.sentry.io/issues/7507330568/) — 562 events / 470 users since May 26 (153 / 149 in the last 3 days). Card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9982983094

### What it fixes

Clicking the code toolbar button with the selection spanning nested structures — a quote and its inner paragraphs, or nested list items — crashed with Lexical invariant #19 ("updateEditor: selection has been lost because the previously selected nodes have been removed and selection wasn't moved to another node"). Lexical rolls the update back, so the click silently did nothing. Every Sentry event goes through the same path: toolbar `dispatchButtonCommand` → `editor.update` → invariant thrown at commit.

### How

`Contents#toggleCodeBlock` collects the nearest block element for every selected node, inserts the new code node after the *last* collected element, and hands all of them to `CodeNodeInserter`, which converts each to code text via `node.remove()` + `$createTextNode(node.getTextContent())`.

With nested structures the collected list contains both an element and its ancestor (e.g. `[paragraph, quote, paragraphInsideQuote]`). The code node gets inserted after the last element — *inside* the ancestor's subtree — so converting the ancestor detaches the code node along with it. The subsequent caret inserts and `selectEnd()` land in a detached tree; garbage collection purges those keys, and the pending selection fails Lexical's node-map check.

The fix filters the collected elements down to the outermost ones before picking the insertion point. Their `getTextContent()` already covers their descendants (the inserter already skips detached descendants), so the converted output is unchanged — the code node just can no longer be created inside an element that's about to be removed.

Failing-first regression tests at both layers, each verified to fail on `main`’s `contents.js` and pass with the fix: Playwright tests through the real toolbar button (`test/browser/tests/formatting/code_block_navigation.test.js`, "Code block conversion") and unit tests via the toolbar’s dispatch path (`test/javascript/unit/editor/toggle_code_block.test.js`, helpers promoted to `editor_helper.js`).

### Overlap notes

Self-contained in `contents.js#toggleCodeBlock`; no overlap with #1106/#1107/#1108/#1109 diffs (different crash paths: arrow-nav race, drop/paste guards, paste invariant #66, paste invariants #211/#212).

While reproducing, a brute-force matrix also surfaced a separate non-#19 crash in the same command: a selection covering a horizontal divider throws "Expected node to have closest block element node" from `#blockLevelElementsInSelection`. Different error signature, different Sentry issue — left out of scope here.


