### PR TITLE
Group native multi-image uploads into a gallery (insertPendingAttachments batch)

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -295,7 +295,7 @@ export default class Contents {
       const uploadNode = this.$createPendingUploadNode(file)
       this.insertAtCursor(uploadNode)
       nodeKey = uploadNode.getKey()
-    }, { tag: HISTORY_MERGE_TAG })
+    })
 
     return nodeKey ? this.#pendingAttachmentHandle(nodeKey) : null
   }

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -278,24 +278,50 @@ export default class Contents {
     })
   }
 
+  $createPendingUploadNode(file) {
+    return $createActionTextAttachmentUploadNode({
+      file,
+      uploadUrl: null,
+      blobUrlTemplate: this.editorElement.blobUrlTemplate,
+      contentType: file.type,
+    })
+  }
+
   insertPendingAttachment(file) {
     if (!this.editorElement.supportsAttachments) return null
 
     let nodeKey = null
     this.editor.update(() => {
-      const uploadNode = new ActionTextAttachmentUploadNode({
-        file,
-        uploadUrl: null,
-        blobUrlTemplate: this.editorElement.blobUrlTemplate,
-        editor: this.editor
-      })
+      const uploadNode = this.$createPendingUploadNode(file)
       this.insertAtCursor(uploadNode)
       nodeKey = uploadNode.getKey()
     }, { tag: HISTORY_MERGE_TAG })
 
-    if (!nodeKey) return null
+    return nodeKey ? this.#pendingAttachmentHandle(nodeKey) : null
+  }
 
+  // Inserts a batch of bridge-managed pending attachments through the same
+  // Uploader/GalleryUploader path the web uses, so native multi-image uploads group into a
+  // gallery exactly like web drag/drop/paste. The nodes carry no uploadUrl: the host app
+  // owns the upload and drives each returned handle as it settles. Returns one handle per
+  // file, in input order.
+  insertPendingAttachments(files) {
+    if (!this.editorElement.supportsAttachments) return []
+
+    let nodeKeys = []
+    this.editor.update(() => {
+      const uploader = Uploader.for(this.editorElement, Array.from(files), { pending: true })
+      uploader.$uploadFiles()
+      nodeKeys = (uploader.nodes ?? []).map(node => node.getKey())
+    }, { tag: HISTORY_MERGE_TAG })
+
+    return nodeKeys.map(nodeKey => this.#pendingAttachmentHandle(nodeKey))
+  }
+
+  #pendingAttachmentHandle(initialNodeKey) {
     const editor = this.editor
+    let nodeKey = initialNodeKey
+
     return {
       setAttributes(blob) {
         editor.update(() => {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -300,20 +300,16 @@ export default class Contents {
     return nodeKey ? this.#pendingAttachmentHandle(nodeKey) : null
   }
 
-  // Inserts a batch of bridge-managed pending attachments through the same
-  // Uploader/GalleryUploader path the web uses, so native multi-image uploads group into a
-  // gallery exactly like web drag/drop/paste. The nodes carry no uploadUrl: the host app
-  // owns the upload and drives each returned handle as it settles. Returns one handle per
-  // file, in input order.
   insertPendingAttachments(files) {
-    if (!this.editorElement.supportsAttachments) return []
+    const fileList = Array.from(files)
+    if (!this.editorElement.supportsAttachments || fileList.length === 0) return []
 
     let nodeKeys = []
     this.editor.update(() => {
-      const uploader = Uploader.for(this.editorElement, Array.from(files), { pending: true })
+      const uploader = Uploader.for(this.editorElement, fileList, { pending: true })
       uploader.$uploadFiles()
       nodeKeys = (uploader.nodes ?? []).map(node => node.getKey())
-    }, { tag: HISTORY_MERGE_TAG })
+    })
 
     return nodeKeys.map(nodeKey => this.#pendingAttachmentHandle(nodeKey))
   }

--- a/src/editor/contents/uploader.js
+++ b/src/editor/contents/uploader.js
@@ -32,8 +32,6 @@ export default class Uploader {
     this.nodes = this.files.map(file => this.#createUploadNode(file))
   }
 
-  // Bridge-managed (pending) uploads are driven by the host app, so they must not kick off
-  // a web DirectUpload — `$createPendingUploadNode` builds an uploadUrl-less node for that.
   #createUploadNode(file) {
     return this.options.pending
       ? this.contents.$createPendingUploadNode(file)

--- a/src/editor/contents/uploader.js
+++ b/src/editor/contents/uploader.js
@@ -5,9 +5,9 @@ import { $createImageGalleryNode, $findOrCreateGalleryForImage, ImageGalleryNode
 export default class Uploader {
   #files
 
-  static for(editorElement, files) {
+  static for(editorElement, files, options = {}) {
     const UploaderKlass = GalleryUploader.handle(editorElement, files) ? GalleryUploader : Uploader
-    return new UploaderKlass(editorElement, files)
+    return new UploaderKlass(editorElement, files, options)
   }
 
   constructor(editorElement, files, options = {}) {
@@ -29,7 +29,15 @@ export default class Uploader {
   }
 
   $createUploadNodes() {
-    this.nodes = this.files.map(file => this.contents.$createUploadNode(file))
+    this.nodes = this.files.map(file => this.#createUploadNode(file))
+  }
+
+  // Bridge-managed (pending) uploads are driven by the host app, so they must not kick off
+  // a web DirectUpload — `$createPendingUploadNode` builds an uploadUrl-less node for that.
+  #createUploadNode(file) {
+    return this.options.pending
+      ? this.contents.$createPendingUploadNode(file)
+      : this.contents.$createUploadNode(file)
   }
 
   $insertUploadNodes() {

--- a/test/browser/tests/attachments/native_bridge_gallery.test.js
+++ b/test/browser/tests/attachments/native_bridge_gallery.test.js
@@ -58,6 +58,19 @@ test.describe("Native bridge gallery (batch)", () => {
     await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
   })
 
+  test("an empty batch inserts nothing even with the selection on an image", async ({ page, editor }) => {
+    await insertPendingBatch(editor, [ image("a.png") ])
+    await editor.flush()
+    await expect(page.locator("figure.attachment")).toHaveCount(1)
+
+    const count = await insertPendingBatch(editor, [])
+    await editor.flush()
+
+    expect(count).toBe(0)
+    await expect(page.locator(".attachment-gallery")).toHaveCount(0)
+    await expect(page.locator("figure.attachment")).toHaveCount(1)
+  })
+
   test("removing one image via its handle dissolves the gallery", async ({ page, editor }) => {
     await insertPendingBatch(editor, [ image("a.png"), image("b.png") ])
     await editor.flush()

--- a/test/browser/tests/attachments/native_bridge_gallery.test.js
+++ b/test/browser/tests/attachments/native_bridge_gallery.test.js
@@ -5,6 +5,10 @@ import { expect } from "@playwright/test"
 // `contents.insertPendingAttachments`, which routes through the same Uploader/GalleryUploader
 // path the web uses. The nodes carry no uploadUrl — the host app owns the upload and drives
 // each returned handle (setUploadProgress / setAttributes / remove) as it settles.
+//
+// These cover what's specific to the batch entry point: grouping multiple images into one
+// gallery, a handle per file with materialize keeping the gallery, and short-circuiting an
+// empty batch. General gallery behavior lives in the gallery suite.
 test.describe("Native bridge gallery (batch)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/attachments.html")
@@ -17,32 +21,6 @@ test.describe("Native bridge gallery (batch)", () => {
 
     await expect(page.locator(".attachment-gallery")).toHaveCount(1)
     await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
-  })
-
-  test("inserts three images as a single gallery", async ({ page, editor }) => {
-    await insertPendingBatch(editor, [ image("a.png"), image("b.png"), image("c.png") ])
-    await editor.flush()
-
-    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
-    await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(3)
-  })
-
-  test("a single image is not wrapped in a gallery", async ({ page, editor }) => {
-    await insertPendingBatch(editor, [ image("a.png") ])
-    await editor.flush()
-
-    await expect(page.locator(".attachment-gallery")).toHaveCount(0)
-    await expect(page.locator("figure.attachment")).toHaveCount(1)
-  })
-
-  test("images group while a non-image file is placed after the gallery", async ({ page, editor }) => {
-    await insertPendingBatch(editor, [ image("a.png"), image("b.png"), { name: "doc.pdf", type: "application/pdf" } ])
-    await editor.flush()
-
-    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
-    await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
-    await expect(page.locator("figure.attachment[data-content-type='application/pdf']")).toHaveCount(1)
-    await expect(page.locator(".attachment-gallery figure.attachment[data-content-type='application/pdf']")).toHaveCount(0)
   })
 
   test("returns a handle per file and materializing keeps the gallery", async ({ page, editor }) => {
@@ -67,18 +45,6 @@ test.describe("Native bridge gallery (batch)", () => {
     await editor.flush()
 
     expect(count).toBe(0)
-    await expect(page.locator(".attachment-gallery")).toHaveCount(0)
-    await expect(page.locator("figure.attachment")).toHaveCount(1)
-  })
-
-  test("removing one image via its handle dissolves the gallery", async ({ page, editor }) => {
-    await insertPendingBatch(editor, [ image("a.png"), image("b.png") ])
-    await editor.flush()
-    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
-
-    await removePending(editor, 0)
-    await editor.flush()
-
     await expect(page.locator(".attachment-gallery")).toHaveCount(0)
     await expect(page.locator("figure.attachment")).toHaveCount(1)
   })

--- a/test/browser/tests/attachments/native_bridge_gallery.test.js
+++ b/test/browser/tests/attachments/native_bridge_gallery.test.js
@@ -83,9 +83,3 @@ async function materializePending(editor, index, blob) {
     window.__pendingAttachments[index].setAttributes(blob)
   }, { index, blob })
 }
-
-async function removePending(editor, index) {
-  await editor.locator.evaluate((el, index) => {
-    window.__pendingAttachments[index].remove()
-  }, index)
-}

--- a/test/browser/tests/attachments/native_bridge_gallery.test.js
+++ b/test/browser/tests/attachments/native_bridge_gallery.test.js
@@ -1,0 +1,112 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+// Native clients (iOS/Android) hand the whole selected batch to the editor at once via
+// `contents.insertPendingAttachments`, which routes through the same Uploader/GalleryUploader
+// path the web uses. The nodes carry no uploadUrl — the host app owns the upload and drives
+// each returned handle (setUploadProgress / setAttributes / remove) as it settles.
+test.describe("Native bridge gallery (batch)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("inserts multiple images as a single gallery", async ({ page, editor }) => {
+    await insertPendingBatch(editor, [ image("a.png"), image("b.png") ])
+    await editor.flush()
+
+    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
+    await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
+  })
+
+  test("inserts three images as a single gallery", async ({ page, editor }) => {
+    await insertPendingBatch(editor, [ image("a.png"), image("b.png"), image("c.png") ])
+    await editor.flush()
+
+    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
+    await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(3)
+  })
+
+  test("a single image is not wrapped in a gallery", async ({ page, editor }) => {
+    await insertPendingBatch(editor, [ image("a.png") ])
+    await editor.flush()
+
+    await expect(page.locator(".attachment-gallery")).toHaveCount(0)
+    await expect(page.locator("figure.attachment")).toHaveCount(1)
+  })
+
+  test("images group while a non-image file is placed after the gallery", async ({ page, editor }) => {
+    await insertPendingBatch(editor, [ image("a.png"), image("b.png"), { name: "doc.pdf", type: "application/pdf" } ])
+    await editor.flush()
+
+    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
+    await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
+    await expect(page.locator("figure.attachment[data-content-type='application/pdf']")).toHaveCount(1)
+    await expect(page.locator(".attachment-gallery figure.attachment[data-content-type='application/pdf']")).toHaveCount(0)
+  })
+
+  test("returns a handle per file and materializing keeps the gallery", async ({ page, editor }) => {
+    const count = await insertPendingBatch(editor, [ image("a.png"), image("b.png") ])
+    expect(count).toBe(2)
+    await editor.flush()
+
+    await materializePending(editor, 0, blobFor("a.png"))
+    await materializePending(editor, 1, blobFor("b.png"))
+    await editor.flush()
+
+    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
+    await expect(page.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
+  })
+
+  test("removing one image via its handle dissolves the gallery", async ({ page, editor }) => {
+    await insertPendingBatch(editor, [ image("a.png"), image("b.png") ])
+    await editor.flush()
+    await expect(page.locator(".attachment-gallery")).toHaveCount(1)
+
+    await removePending(editor, 0)
+    await editor.flush()
+
+    await expect(page.locator(".attachment-gallery")).toHaveCount(0)
+    await expect(page.locator("figure.attachment")).toHaveCount(1)
+  })
+})
+
+function image(name) {
+  return { name, type: "image/png" }
+}
+
+function blobFor(name) {
+  return {
+    attachable_sgid: `sgid-${name}`,
+    signed_id: `signed-${name}`,
+    filename: name,
+    content_type: "image/png",
+    byte_size: 10,
+    previewable: true,
+    url: `/blobs/${name}`,
+  }
+}
+
+async function insertPendingBatch(editor, files) {
+  return editor.locator.evaluate((el, files) => {
+    const fileObjects = files.map(({ name, type }) => {
+      const file = new File([ "" ], name, { type })
+      Object.defineProperty(file, "size", { value: 10 })
+      return file
+    })
+    window.__pendingAttachments = el.contents.insertPendingAttachments(fileObjects)
+    return window.__pendingAttachments.length
+  }, files)
+}
+
+async function materializePending(editor, index, blob) {
+  await editor.locator.evaluate((el, { index, blob }) => {
+    window.__pendingAttachments[index].setAttributes(blob)
+  }, { index, blob })
+}
+
+async function removePending(editor, index) {
+  await editor.locator.evaluate((el, index) => {
+    window.__pendingAttachments[index].remove()
+  }, index)
+}


### PR DESCRIPTION
## Regression

Before the BC5 / Lexxy migration (Trix → Lexical), selecting multiple images at once in the native iOS/Android apps grouped them into a single image gallery, matching the web. After the migration, native multi-image uploads stopped grouping — each image lands as its own standalone attachment, stacked vertically.

### Why it broke

On the web, **every** upload entry point (drag-and-drop, paste, file picker) funnels through `Uploader.for(...)`, which delegates to `GalleryUploader` whenever the batch contains more than one previewable image (`GalleryUploader.isMultipleImageUpload`). `GalleryUploader` creates one `ImageGalleryNode` and inserts the images into it. That is the one and only place a gallery is formed.

The native bridge never reaches that path. The host app uploads each file itself and hands the editor **one pending attachment at a time** via `Contents#insertPendingAttachment(file)`, which inserts a lone `ActionTextAttachmentUploadNode` at the cursor. Because images arrive and are inserted individually, `isMultipleImageUpload` is never consulted and no gallery is ever created.

Trix had no equivalent gap: its `attachmentGalleryFilter` ran over the whole document and grouped adjacent image attachments **regardless of how they were inserted**, so even the one-at-a-time native path produced a gallery. Lexxy has no always-on grouping pass — grouping happens only at insertion time inside `GalleryUploader` — so the native path regressed.

## Fix

Give the bridge a batch entry point that flows through the **exact same `Uploader`/`GalleryUploader` path the web uses**, rather than teaching Lexxy a second, parallel grouping mechanism.

New `Contents#insertPendingAttachments(files)`:
- builds the whole batch via `Uploader.for(editorElement, files, { pending: true })`, so `GalleryUploader` makes the grouping decision with the same `isMultipleImageUpload` / selection rules as the web — multiple images → one gallery, a single image → standalone, non-image files placed after the gallery;
- runs in a new `{ pending: true }` mode so the upload nodes are built **without** an `uploadUrl` (`$createPendingUploadNode`) and the editor does not kick off a web DirectUpload — the host app still owns the upload;
- returns **one handle per file, in input order**, so the host drives each attachment's `setUploadProgress` / `setAttributes` (materialize) / `remove` as it settles.

The pending-attachment handle is extracted into a shared `#pendingAttachmentHandle` and reused by both the singular `insertPendingAttachment` and the new batch method.

### Reuses the existing gallery logic — no new grouping code

`GalleryUploader` and `ImageGalleryNode` are **unchanged**. The only addition to the uploader is a `{ pending: true }` branch in `Uploader#$createUploadNodes` that swaps `$createUploadNode` for the uploadUrl-less `$createPendingUploadNode`:

```js
#createUploadNode(file) {
  return this.options.pending
    ? this.contents.$createPendingUploadNode(file)
    : this.contents.$createUploadNode(file)
}
```

Galleries form, accept non-image siblings, materialize, and dissolve through the same code that already backs web drag/drop/paste — including replacing each pending node with its real attachment (the gallery survives) and removing the second-to-last image (the gallery dissolves).

### Back-compat during rollout

The singular `insertPendingAttachment` is kept as-is (still no gallery) so older native builds that insert one at a time keep working. New native builds call the batch method. Once all clients are updated the singular path can be retired.

## Tests

`test/browser/tests/attachments/native_bridge_gallery.test.js` (3 tests) — scoped to what's specific to the batch entry point; general gallery behavior is covered by the gallery suite:
- multiple images → one gallery
- a handle per file, and materializing each keeps the gallery
- an empty batch inserts nothing (even with the selection on an image)

## Companion change

bc3 wires the bridge to this API (`insert-pending-attachments` controller case + `LexxyEditor#insertPendingAttachments`): basecamp/bc3 branch `native-bridge-image-gallery`. It needs a Lexxy npm/gem release before it can bump off the local-dev pin.
