### PR TITLE
Add toolbar role and Alt+F10 shortcut to table tools

### DIFF
--- a/src/elements/table/table_tools.js
+++ b/src/elements/table/table_tools.js
@@ -15,6 +15,7 @@ export class TableTools extends HTMLElement {
   connectedCallback() {
     this.tableController = new TableController(this.#editorElement)
     this.classList.add("lexxy-floating-controls")
+    this.role = "toolbar"
 
     this.#setUpButtons()
     this.#hide()
@@ -145,14 +146,26 @@ export class TableTools extends HTMLElement {
   }
 
   #registerKeyboardShortcuts() {
-    this.#listeners.track(this.#editor.registerCommand(KEY_DOWN_COMMAND, this.#handleAccessibilityShortcutKey, COMMAND_PRIORITY_HIGH))
+    this.#listeners.track(this.#editor.registerCommand(KEY_DOWN_COMMAND, this.#focusToolbarOnShortcut, COMMAND_PRIORITY_HIGH))
   }
 
-  #handleAccessibilityShortcutKey = (event) => {
-    if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === "F10") {
-      const firstButton = this.querySelector("button, [tabindex]:not([tabindex='-1'])")
-      firstButton?.focus()
+  #focusToolbarOnShortcut = (event) => {
+    if (this.#hasSelectedTable && this.#isFocusToolbarShortcut(event)) {
+      event.preventDefault()
+      this.#tableToolsButtons[0]?.focus()
+      return true
+    } else {
+      return false
     }
+  }
+
+  get #hasSelectedTable() {
+    return this.tableController?.currentTableNodeKey != null
+  }
+
+  #isFocusToolbarShortcut(event) {
+    if (event.key !== "F10") return false
+    return event.altKey || ((event.ctrlKey || event.metaKey) && event.shiftKey)
   }
 
   #handleToolsKeydown = (event) => {

--- a/test/browser/tests/tables/toolbar.test.js
+++ b/test/browser/tests/tables/toolbar.test.js
@@ -1,0 +1,44 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Tables — Toolbar accessibility", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+    await editor.clickToolbarButton("insertTable")
+    await editor.content.locator("table th").first().click()
+  })
+
+  test("Alt+F10 moves focus to the first table tool", async ({ page, editor }) => {
+    await page.keyboard.press("Alt+F10")
+
+    await expect(
+      editor.locator.locator("lexxy-table-tools button[aria-label='Remove row']").first()
+    ).toBeFocused()
+  })
+
+  test("Control+Shift+F10 also moves focus to the first table tool", async ({ page, editor }) => {
+    await page.keyboard.press("Control+Shift+F10")
+
+    await expect(
+      editor.locator.locator("lexxy-table-tools button[aria-label='Remove row']").first()
+    ).toBeFocused()
+  })
+
+  test("arrow keys move focus between table tools", async ({ page, editor }) => {
+    await page.keyboard.press("Alt+F10")
+    await page.keyboard.press("ArrowRight")
+
+    await expect(
+      editor.locator.locator("lexxy-table-tools .lexxy-table-control--row summary")
+    ).toBeFocused()
+  })
+
+  test("Escape returns focus to the table", async ({ page, editor }) => {
+    await page.keyboard.press("Alt+F10")
+    await page.keyboard.press("Escape")
+
+    await expect(editor.content).toBeFocused()
+  })
+})


### PR DESCRIPTION
The table controls were already keyboard-operable, you could move between buttons with the arrow keys and leave with Escape, but the container wasn't exposed as a toolbar, so screen readers didn't announce it as one, and the only shortcut to reach it was Ctrl/Cmd+Shift+F10, which matches no established editor convention. On Windows Shift+F10 is the context-menu shortcut, so reusing F10 that way is confusing.

The standard for moving focus to an editor toolbar is Alt+F10, shared across the major rich text editors:

- TinyMCE: https://www.tiny.cloud/docs/tinymce/latest/keyboard-shortcuts/
- CKEditor 5: https://ckeditor.com/docs/ckeditor5/latest/features/keyboard-support.html
- CKEditor 4: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_a11y.html
- Froala: https://froala.com/wysiwyg-editor/accessibility/
- Syncfusion: https://ej2.syncfusion.com/javascript/documentation/rich-text-editor/keyboard-support

They all share the same pattern: Alt+F10 to enter, arrows to move between controls, Esc to return to the content. CKEditor 5 applies it to contextual toolbars too, which is our case. On Mac it's the same chord with Option, and `event.altKey` already covers it.

So this PR:

- Sets `role="toolbar"` on `lexxy-table-tools` so it's announced as a toolbar, matching the base role already set on the main `lexxy-toolbar`.
- Adds Alt+F10 to focus the first control, keeping the existing Ctrl/Cmd+Shift+F10 working.
- Guards the shortcut to fire only while a table is selected, and marks the key event as handled.
- Adds browser tests for both shortcuts, the arrow-key navigation, and Escape.

The arrow-key navigation and Escape-to-exit were already in place.
