### PR TITLE
Transfer autocapitalize value to contenteditable

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -49,7 +49,7 @@ export class LexicalEditorElement extends HTMLElement {
   static debug = false
   static commands = [ "bold", "italic", "strikethrough" ]
 
-  static observedAttributes = [ "connected", "required" ]
+  static observedAttributes = [ "autocapitalize", "connected", "required" ]
 
   #initialValue = ""
   #previousInternalFormValue = null
@@ -116,8 +116,15 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    if (name === "connected") this.connectedChangedCallback(oldValue, newValue)
-    if (name === "required") this.requiredChangedCallback(oldValue, newValue)
+    if (typeof this[`${name}ChangedCallback`] === "function") {
+      this[`${name}ChangedCallback`](oldValue, newValue)
+    }
+  }
+
+  autocapitalizeChangedCallback() {
+    if (this.editorContentElement) {
+      this.#transferAttributeToContentEditable(this.editorContentElement, "autocapitalize")
+    }
   }
 
   connectedChangedCallback(oldValue, newValue) {
@@ -449,25 +456,33 @@ export class LexicalEditorElement extends HTMLElement {
 
   #createEditorContentElement() {
     const editorContentElement = createElement("div", {
+      id: `${this.id}-content`,
       classList: "lexxy-editor__content",
       contenteditable: true,
-      autocapitalize: "none",
       role: "textbox",
       "aria-multiline": true,
       "aria-label": this.#labelText,
       placeholder: this.getAttribute("placeholder")
     })
-    editorContentElement.id = `${this.id}-content`
+
     this.#ariaAttributes.forEach(attribute => editorContentElement.setAttribute(attribute.name, attribute.value))
 
-    if (this.getAttribute("tabindex")) {
-      editorContentElement.setAttribute("tabindex", this.getAttribute("tabindex"))
-      this.removeAttribute("tabindex")
-    } else {
-      editorContentElement.setAttribute("tabindex", 0)
-    }
+    this.#transferAttributeToContentEditable(editorContentElement, "autocapitalize")
+    this.#transferAttributeToContentEditable(editorContentElement, "tabindex", { defaultValue: 0, removeSource: true })
 
     return editorContentElement
+  }
+
+  #transferAttributeToContentEditable(element, qualifiedName, { defaultValue = null, removeSource = false } = {}) {
+    if (this.hasAttribute(qualifiedName)) {
+      element.setAttribute(qualifiedName, this.getAttribute(qualifiedName))
+    } else if (defaultValue !== null) {
+      element.setAttribute(qualifiedName, defaultValue)
+    } else {
+      element.removeAttribute(qualifiedName)
+    }
+
+    if (removeSource) this.removeAttribute(qualifiedName)
   }
 
   get #labelText() {

--- a/test/browser/fixtures/attribute-transfer.html
+++ b/test/browser/fixtures/attribute-transfer.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Attribute transfer</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="title">
+      <input type="text" name="post[title]" placeholder="Post title" aria-label="Post title">
+    </div>
+
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..." autocapitalize="characters" tabindex="3" required></lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/editor/attribute_transfer.test.js
+++ b/test/browser/tests/editor/attribute_transfer.test.js
@@ -1,0 +1,66 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("autocapitalize", () => {
+  test("transfers the editor's value to the content element", async ({ page, editor }) => {
+    await page.goto("/attribute-transfer.html")
+    await editor.waitForConnected()
+
+    await expect(editor.content).toHaveAttribute("autocapitalize", "characters")
+  })
+
+  test("keeps the value on the editor so changes can be observed", async ({ page, editor }) => {
+    await page.goto("/attribute-transfer.html")
+    await editor.waitForConnected()
+
+    await expect(editor.locator).toHaveAttribute("autocapitalize", "characters")
+  })
+
+  test("leaves the content element unset when the editor has no value", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    await expect(editor.content).not.toHaveAttribute("autocapitalize")
+  })
+
+  test("synchronizes later changes to the content element", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    await editor.locator.evaluate((el) => el.setAttribute("autocapitalize", "words"))
+
+    await expect(editor.content).toHaveAttribute("autocapitalize", "words")
+  })
+
+  test("synchronizes removal to the content element", async ({ page, editor }) => {
+    await page.goto("/attribute-transfer.html")
+    await editor.waitForConnected()
+
+    await editor.locator.evaluate((el) => el.removeAttribute("autocapitalize"))
+
+    await expect(editor.content).not.toHaveAttribute("autocapitalize")
+  })
+})
+
+test.describe("tabindex", () => {
+  test("transfers the editor's value to the content element", async ({ page, editor }) => {
+    await page.goto("/attribute-transfer.html")
+    await editor.waitForConnected()
+
+    await expect(editor.content).toHaveAttribute("tabindex", "3")
+  })
+
+  test("removes the value from the editor once transferred", async ({ page, editor }) => {
+    await page.goto("/attribute-transfer.html")
+    await editor.waitForConnected()
+
+    await expect(editor.locator).not.toHaveAttribute("tabindex")
+  })
+
+  test("defaults the content element to 0 when the editor has no value", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    await expect(editor.content).toHaveAttribute("tabindex", "0")
+  })
+})


### PR DESCRIPTION
Removes the previous hard-coded `autocapitalize="none"` to workaround broken Android text replacement and respects `lexxy-editor[autocapitalize]` by transferring the attribute value to the `contenteditable` and synchronizing future attribute updates.