### PR TITLE
Preserve Trix blank lines when editing in Lexxy

### DIFF
--- a/src/extensions/trix_content_extension.js
+++ b/src/extensions/trix_content_extension.js
@@ -1,4 +1,4 @@
-import { defineExtension } from "lexical"
+import { $createParagraphNode, defineExtension } from "lexical"
 import { CodeNode, normalizeCodeLang } from "@lexical/code"
 import { extendConversion, extendTextNodeConversion } from "../helpers/lexical_helper"
 import { $applyHighlightStyle } from "./highlight_extension"
@@ -36,11 +36,26 @@ export class TrixContentExtension extends LexxyExtension {
           pre: (element) => onlyPreLanguageElements(element, {
             conversion: extendConversion(CodeNode, "pre", $applyLanguage),
             priority: 1
+          }),
+          div: (element) => onlyEmptyBlocks(element, {
+            conversion: () => ({ node: $createParagraphNode() }),
+            priority: 1
           })
         }
       }
     })
   }
+}
+
+// Trix represents blank lines as empty block elements like <div><br></div> or <div></div>.
+// Lexical drops a <br> that is the only child of a block and then discards the now-empty block,
+// collapsing the blank line. We convert those empty blocks into empty paragraphs so the spacing
+// survives the edit. Blocks with text or non-<br> elements fall through to Lexical's default
+// handling so content and attachments are imported normally.
+function onlyEmptyBlocks(element, conversion) {
+  const hasText = element.textContent.trim() !== ""
+  const hasNonLineBreakElement = Array.from(element.children).some((child) => child.nodeName !== "BR")
+  return hasText || hasNonLineBreakElement ? null : conversion
 }
 
 function onlyStyledElements(element, conversion) {

--- a/test/browser/tests/editor/load_html.test.js
+++ b/test/browser/tests/editor/load_html.test.js
@@ -36,6 +36,25 @@ test.describe("Load HTML", () => {
     })
   })
 
+  test("preserves blank-line paragraphs between Trix div blocks", async ({ editor }) => {
+    await editor.setValue("<div>First paragraph.</div><div><br></div><div>Second paragraph.</div>")
+    await assertEditorHtml(editor, "<p>First paragraph.</p><p><br></p><p>Second paragraph.</p>")
+  })
+
+  test("preserves multiple consecutive blank-line paragraphs", async ({ editor }) => {
+    await editor.setValue("<div>First.</div><div><br></div><div><br></div><div>Last.</div>")
+    await assertEditorHtml(editor, "<p>First.</p><p><br></p><p><br></p><p>Last.</p>")
+  })
+
+  test("keeps blank-line paragraphs stable across a serialize round-trip", async ({ editor }) => {
+    // Mirrors the edit → save → re-edit cycle: the editor's own serialized output must reload
+    // without the blank line being stripped again.
+    await editor.setValue("<div>First paragraph.</div><div><br></div><div>Second paragraph.</div>")
+    const serialized = await editor.value()
+    await editor.setValue(serialized)
+    await assertEditorHtml(editor, "<p>First paragraph.</p><p><br></p><p>Second paragraph.</p>")
+  })
+
   test("preserves inline image data URIs untouched (no paste-time conversion)", async ({ editor }) => {
     const dataURI = `data:image/png;base64,${Buffer.from("\x89PNG\r\n\x1a\n", "binary").toString("base64")}`
     await editor.setValue(`<p>before</p><img src="${dataURI}"><p>after</p>`)

--- a/test/system/trix/from_trix_to_lexxy_test.rb
+++ b/test/system/trix/from_trix_to_lexxy_test.rb
@@ -26,6 +26,27 @@ class Trix::FromTrixToLexxyTest < ApplicationSystemTestCase
     assert_text "Hello from Trix and Lexxy"
   end
 
+  test "preserves blank lines from a Trix-authored document on edit and save round-trip" do
+    # Trix stores blank lines as empty block elements like <div><br></div>. This mirrors a
+    # document authored in the old Trix editor that is now opened in Lexxy for editing.
+    post = Post.create!(
+      title: "Trix blank lines",
+      body: "<div>First paragraph.</div><div><br></div><div>Second paragraph.</div>"
+    )
+
+    visit edit_post_path(post)
+
+    assert_editor_html "<p>First paragraph.</p><p><br></p><p>Second paragraph.</p>"
+
+    # The blank line must survive the full save → render → re-edit round-trip, not just the
+    # initial load. Customers reported re-added spacing being stripped again on save.
+    click_on "Update Post"
+    assert_text "Post was successfully updated."
+
+    visit edit_post_path(post)
+    assert_editor_html "<p>First paragraph.</p><p><br></p><p>Second paragraph.</p>"
+  end
+
   test "attachment" do
     visit new_trix_post_path
 


### PR DESCRIPTION
## Problem

Documents authored in the old Trix editor (e.g. 2024-era posts) lose their paragraph spacing when opened for editing in Lexxy. Trix stores blank lines as empty block elements like `<div><br></div>`. On import, Lexical drops a `<br>` that is the only child of a block and then discards the now-empty block, collapsing the blank line. The symptom is intermittent stripping of line breaks/paragraph spacing on Edit, and re-added spacing being stripped again on the next save.

## Fix

Add a Trix-content import rule that converts empty `<div>` blocks into empty paragraphs, so the blank line survives both the initial load and the full save → render → re-edit round-trip. Blocks that contain text or non-`<br>` elements fall through to Lexical's default handling, leaving normal content and attachments untouched.

## Tests

- Playwright (`test/browser/tests/editor/load_html.test.js`): blank-line preservation between Trix div blocks, multiple consecutive blank lines, and a serialize round-trip (the editor's own output reloads without re-collapsing the blank line). Confirmed failing on `main` before the fix.
- Capybara system test (`test/system/trix/from_trix_to_lexxy_test.rb`): a Trix-authored document with a blank line is edited in Lexxy, saved, and re-edited — asserting the spacing survives the Action Text round-trip.

---
**Basecamp card:** https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9969813249

## How to reproduce

Use a document originally authored in the old **Trix** editor (blank lines stored as `<div><br></div>`), e.g. a 2024-era doc, and edit it in Lexxy:
1. Open such a doc for editing — note its blank lines / paragraph spacing.
2. Make an edit and save; re-open for editing.

**Before (bug):** blank lines/paragraph spacing are stripped on edit, and re-added spacing is stripped again on the next save (the empty `<div><br></div>` blocks are dropped on import).
**After (fix):** empty Trix blocks are converted to empty paragraphs on import, so blank lines survive the edit and the save → render → re-edit round-trip.

> Note: this overlaps server-side pipeline work (bc3#11999) — see the card discussion with Sam before merging.
