### PR TITLE
Strip invalid child nodes from pasted lists

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -17,6 +17,7 @@ import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_nod
 import { $createActionTextAttachmentUploadNode, ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils"
 import NodeInserter from "./contents/node_inserter"
+import PastedContentFormatter from "./contents/pasted_content_formatter"
 import { $consecutiveSiblingGroups, $expandSelectionToLineBreaksAndSplitAtEdges, $isShadowRoot, $splitSelectedParagraphsAtInnerLineBreaks } from "../helpers/lexical_helper"
 
 export default class Contents {
@@ -364,8 +365,7 @@ export default class Contents {
   }
 
   #formatPastedDOM(doc) {
-    this.#unwrapPlaceholderAnchors(doc)
-    this.#stripTableCellColorStyles(doc)
+    new PastedContentFormatter(doc).format()
   }
 
   #dispatchPastedNodesCommand(nodes) {
@@ -530,30 +530,6 @@ export default class Contents {
     }
 
     node.remove()
-  }
-
-  // Anchors with non-meaningful hrefs (e.g. "#", "") appear in content copied
-  // from rendered views where mentions and interactive elements are wrapped in
-  // <a href="#"> tags. Unwrap them so their text content pastes as plain text
-  // and real links are preserved.
-  #unwrapPlaceholderAnchors(doc) {
-    for (const anchor of doc.querySelectorAll("a")) {
-      const href = anchor.getAttribute("href") || ""
-      if (href === "" || href === "#") {
-        anchor.replaceWith(...anchor.childNodes)
-      }
-    }
-  }
-
-  // Table cells copied from a page inherit the source theme's inline color
-  // styles (e.g. dark-mode backgrounds). Strip them so pasted tables adopt
-  // the current theme instead of carrying stale colors.
-  #stripTableCellColorStyles(doc) {
-    for (const cell of doc.querySelectorAll("td, th")) {
-      cell.style.removeProperty("background-color")
-      cell.style.removeProperty("background")
-      cell.style.removeProperty("color")
-    }
   }
 
   #getTextAnchorData() {

--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -1,0 +1,47 @@
+export default class PastedContentFormatter {
+  constructor(doc) {
+    this.doc = doc
+  }
+
+  format() {
+    this.#unwrapPlaceholderAnchors()
+    this.#stripTableCellColorStyles()
+    this.#stripStrayListChildren()
+    return this.doc
+  }
+
+  // Anchors with non-meaningful hrefs (e.g. "#", "") appear in content copied
+  // from rendered views where mentions and interactive elements are wrapped in
+  // <a href="#"> tags. Unwrap them so their text content pastes as plain text
+  // and real links are preserved.
+  #unwrapPlaceholderAnchors() {
+    for (const anchor of this.doc.querySelectorAll("a")) {
+      const href = anchor.getAttribute("href") || ""
+      if (href === "" || href === "#") {
+        anchor.replaceWith(...anchor.childNodes)
+      }
+    }
+  }
+
+  // Table cells copied from a page inherit the source theme's inline color
+  // styles (e.g. dark-mode backgrounds). Strip them so pasted tables adopt
+  // the current theme instead of carrying stale colors.
+  #stripTableCellColorStyles() {
+    for (const cell of this.doc.querySelectorAll("td, th")) {
+      cell.style.removeProperty("background-color")
+      cell.style.removeProperty("background")
+      cell.style.removeProperty("color")
+    }
+  }
+
+  // Only <li> is a valid child of a list; drop stray <br>/whitespace so the
+  // import doesn't wrap them into an empty leading item.
+  #stripStrayListChildren() {
+    for (const list of this.doc.querySelectorAll("ol, ul")) {
+      for (const child of Array.from(list.childNodes)) {
+        if (child.nodeType === Node.ELEMENT_NODE && child.tagName === "LI") continue
+        list.removeChild(child)
+      }
+    }
+  }
+}

--- a/test/browser/tests/paste/clean_invalid_pasted_list_html.test.js
+++ b/test/browser/tests/paste/clean_invalid_pasted_list_html.test.js
@@ -1,0 +1,88 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorHtml, startMonitoringConsole } from "../../helpers/assertions.js"
+
+test.describe("Paste list with stray non-<li> children before the first item", () => {
+  test("strips a stray <br> and whitespace before the first <ol> item", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ol>\n    <br>\n    <li>First item<br></li>\n    <li>Second item<br></li>\n    <li>Third item<br></li>\n</ol>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ol><li value="1">First item</li><li value="2">Second item</li><li value="3">Third item</li></ol>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+
+  test("strips a stray <br> before the first <ul> item", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ul>\n    <br>\n    <li>First item<br></li>\n    <li>Second item<br></li>\n</ul>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ul><li value="1">First item</li><li value="2">Second item</li></ul>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+
+  test("strips leading whitespace text before the first <ol> item", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ol>\n    <li>First item</li>\n    <li>Second item</li>\n</ol>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ol><li value="1">First item</li><li value="2">Second item</li></ol>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+
+  test("keeps an empty <li> that is not leading", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ol><li>First item</li><li></li><li>Second item</li></ol>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ol><li value="1">First item</li><li value="2"></li><li value="3">Second item</li></ol>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+})


### PR DESCRIPTION
## Problem

Pasting a numbered list copied from HelpScout adds a spurious extra leading "1.", shifting every subsequent number.

## Root cause

The pasted HTML contains invalid nodes — a stray `<br>` and whitespace text as **direct children of the `<ol>`**, before the first `<li>`:

```html
<ol>
    <br>
    <li>First item</li>
    <li>Second item</li>
    <li>Third item</li>
</ol>
```

Only `<li>` is a valid child of `<ol>`/`<ul>`. `DOMParser` keeps the stray `<br>` inside the list rather than foster-parenting it out, and Lexical's `$generateNodesFromDOM` then wraps it into an empty leading `<li value="1"><br></li>` — hence the extra number.

## Fix

A new `PastedContentFormatter` (`src/editor/contents/pasted_content_formatter.js`) owns the paste-DOM cleanup; `Contents#formatPastedDOM(doc)` delegates to it (`new PastedContentFormatter(doc).format()`). Its `#stripStrayListChildren` step removes any non-`<li>` direct child (bare `<br>`, whitespace/text) from every pasted `<ol>`/`<ul>` before import — safe by construction, since real content only ever lives inside `<li>`. The existing placeholder-anchor unwrapping and table-cell color stripping moved into the same formatter.

## Test

`test/browser/tests/paste/clean_invalid_pasted_list_html.test.js` pastes HTML with stray `<br>`/whitespace directly inside an `<ol>`/`<ul>` (synthetic content) and asserts no spurious leading item — numbering starts at the first real item. Confirmed failing on `main` (produced `<li value="1"><br></li>`) and passing with the fix.

## How to reproduce

1. Copy a numbered list from HelpScout (or any source whose HTML has stray `<br>`/whitespace directly inside the `<ol>` before the first `<li>`).
2. Paste it into the Lexxy editor.

**Before:** an extra leading "1."; numbers shifted.
**After:** numbering starts correctly at the first real item.

---
**Basecamp card:** https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9939030998
