### PR TITLE
Preserve trailing soft line breaks across edit/save round trips

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -18,7 +18,7 @@ import { HorizontalDividerNode } from "../nodes/horizontal_divider_node"
 import { CommandDispatcher } from "../editor/command_dispatcher"
 import Selection from "../editor/selection"
 import { createElement, dispatch, generateDomId, parseHtml } from "../helpers/html_helper"
-import { isAttachmentSpacerTextNode, isEditorFocused } from "../helpers/lexical_helper"
+import { isAttachmentSpacerTextNode, isEditorFocused, protectTrailingLineBreaks } from "../helpers/lexical_helper"
 import { sanitize, setSanitizerConfig } from "../helpers/sanitization_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 import LexicalToolbar from "./toolbar"
@@ -230,6 +230,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   $generateNodesFromDOM(doc, { editor = this.editor } = {}) {
+    protectTrailingLineBreaks(doc)
     let nodes = $generateLexicalNodesFromDOM(editor, doc)
     if ($hasUpdateTag(PASTE_TAG)) nodes = $convertInlineImageDataURIs(nodes, this)
     return filterDisallowedAttachmentNodes(nodes, this)

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -181,6 +181,41 @@ export function $textBeforeOffset(targetNode, offset) {
   return parts.join("")
 }
 
+// Lexical's LineBreakNode.importDOM drops a <br> that is the last child of a
+// block element, treating it as the phantom break browsers add to keep an
+// empty line visible in a contenteditable. That heuristic also discards a
+// genuine soft break the user typed at the end of a line (e.g. "foo<br>"),
+// so trailing breaks erode one per edit→save→re-edit cycle. We append an
+// empty <span> sentinel after a trailing <br> in blocks that have real
+// content; the break is no longer the last child, and the empty span imports
+// to nothing. Empty blocks (<p><br></p>) are left untouched so they stay
+// empty paragraphs rather than gaining a stray break.
+export function protectTrailingLineBreaks(doc) {
+  for (const block of doc.querySelectorAll("p, li, h1, h2, h3, h4, h5, h6, blockquote")) {
+    const lastChild = lastMeaningfulChild(block)
+    if (lastChild?.nodeName === "BR" && blockHasContentBeforeTrailingBreaks(block)) {
+      block.appendChild(doc.createElement("span"))
+    }
+  }
+}
+
+function lastMeaningfulChild(block) {
+  for (const child of Array.from(block.childNodes).reverse()) {
+    if (!isWhitespaceTextNode(child)) return child
+  }
+  return null
+}
+
+function blockHasContentBeforeTrailingBreaks(block) {
+  return Array.from(block.childNodes).some(child => {
+    return child.nodeName !== "BR" && !isWhitespaceTextNode(child)
+  })
+}
+
+function isWhitespaceTextNode(node) {
+  return node.nodeType === Node.TEXT_NODE && node.textContent.trim() === ""
+}
+
 export function isAttachmentSpacerTextNode(node, previousNode, index, childCount) {
   return $isTextNode(node)
     && node.getTextContent() === " "

--- a/test/browser/tests/editor/line_break_preservation.test.js
+++ b/test/browser/tests/editor/line_break_preservation.test.js
@@ -1,0 +1,31 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+// Lexical's LineBreakNode.importDOM drops a <br> that is the last child of a
+// block, treating it as the phantom break browsers add to keep an empty line
+// visible. That also discards a genuine soft break the user typed at the end
+// of a line, so trailing breaks erode one per edit -> save -> re-edit cycle
+// (the save round-trip re-imports the stored HTML). These tests exercise that
+// import path directly via setValue/value.
+test.describe("Trailing line break preservation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("keeps a single trailing soft break in a content block", async ({ editor }) => {
+    await editor.setValue("<p>First line<br></p>")
+    expect(await editor.value()).toContain("First line<br>")
+  })
+
+  test("keeps multiple trailing soft breaks (Shift+Enter twice)", async ({ editor }) => {
+    await editor.setValue("<p>First line<br><br></p>")
+    expect(await editor.value()).toContain("First line<br><br>")
+  })
+
+  test("leaves an empty paragraph empty (no stray break added)", async ({ editor }) => {
+    await editor.setValue("<p>first</p><p><br></p><p>last</p>")
+    await assertEditorHtml(editor, "<p>first</p><p><br></p><p>last</p>")
+  })
+})

--- a/test/system/line_break_round_trip_test.rb
+++ b/test/system/line_break_round_trip_test.rb
@@ -1,0 +1,42 @@
+require "application_system_test_case"
+
+class LineBreakRoundTripTest < ApplicationSystemTestCase
+  # Reproduces the reported bug: adding a soft line break (Shift+Enter), saving,
+  # then editing again to add another break elsewhere drops the earlier break.
+  # The break survives the first save -> render -> re-edit cycle but is lost on a
+  # subsequent edit -> save because re-importing the saved HTML discards a <br>
+  # that ends up as the last child of a block.
+  test "a trailing soft line break survives a later edit and save" do
+    visit edit_post_path(posts(:empty))
+    wait_for_editor
+
+    find_editor.send "First line"
+    find_editor.send [ :shift, :enter ]
+    find_editor.send [ :shift, :enter ]
+
+    click_on "Update Post"
+    assert_selector "article.post", text: "First line"
+
+    # First re-edit: the break must still be present after one round trip.
+    click_on "Edit this post"
+    wait_for_editor
+    assert_includes find_editor.value, "First line<br><br>"
+
+    # Add a second break elsewhere and save again. The earlier break must survive.
+    find_editor.send :end
+    find_editor.send "Second line"
+    find_editor.send [ :shift, :enter ]
+    find_editor.send [ :shift, :enter ]
+    find_editor.send "Third line"
+
+    click_on "Update Post"
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    value = find_editor.value
+    assert_includes value, "First line<br><br>"
+    assert_includes value, "Second line<br><br>"
+    assert_includes value, "Third line"
+  end
+end


### PR DESCRIPTION
## Problem

Editing a doc with soft line breaks (Shift+Enter) to add new ones breaks the earlier ones. Press Shift+Enter twice to add a soft line break and save — it persists. Edit again, add another Shift+Enter break elsewhere and save — the *earlier* break disappears.

The break survives the first save → render → re-edit cycle but is dropped on a subsequent edit + save.

## Root cause

Lexical's `LineBreakNode.importDOM` (`isLastChildInBlockNode`) deliberately drops a `<br>` that is the last child of a block element, treating it as the phantom break browsers insert to keep an empty trailing line visible in a `contenteditable`. That heuristic also discards a *genuine* soft break the user typed at the end of a line (e.g. `<p>foo<br></p>`).

Because of this, every time the saved HTML is re-imported on re-edit, a trailing `<br>` is silently dropped — so trailing breaks erode one per edit → save → re-edit cycle.

This is a Lexxy-side serialization round-trip bug at the import boundary, not a host-app (bc3) issue.

## Fix

Before importing, `protectTrailingLineBreaks(doc)` appends an empty `<span>` sentinel after a trailing `<br>` in blocks that have real content. The `<br>` is no longer the last child, so Lexical keeps it; the empty span imports to nothing. Empty blocks (`<p><br></p>`) are left untouched so they stay empty paragraphs rather than gaining a stray break.

## Test

`test/system/line_break_round_trip_test.rb` reproduces the reported scenario with real keystrokes: type text, Shift+Enter twice, save, re-edit (assert break present), add a second break elsewhere, save, re-edit, and assert the earlier break survives. Confirmed failing on clean `main` (`<p>First line<br></p>` — one break lost on first re-import) and passing with the fix.

---
**Basecamp card:** https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9955295463

## How to reproduce

1. In a Posts editor, type a line, then press **Shift+Enter twice** (a trailing soft line break) and **Save**.
2. **Edit** again — the break is still there.
3. Add a second break elsewhere (Shift+Enter twice), **Save**, then **Edit** again.

**Before:** the *earlier* trailing break is gone — trailing soft breaks erode one per edit→save→re-edit cycle (Lexical's import drops a `<br>` that's the last child of a block).
**After:** earlier and later breaks both survive the round-trip.

> Note: overlaps Sam's bc3#11999 ("Trim trailing blank lines") — the server-side pipeline trims trailing `<br>`/`<p><br></p>`. Confirm client vs. pipeline ownership with Sam before merging.
