### PR TITLE
Tear down prompt popover before Turbo caches the page

### DIFF
--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -32,6 +32,7 @@ export class LexicalPromptElement extends HTMLElement {
     this.source = this.#createSource()
 
     this.#addTriggerListener()
+    this.#removePopoverBeforeTurboCaches()
     this.toggleAttribute("connected", true)
   }
 
@@ -39,7 +40,7 @@ export class LexicalPromptElement extends HTMLElement {
     this.#popoverListeners.dispose()
     this.#globalListeners.dispose()
     this.source = null
-    this.popoverElement = null
+    this.#removePopover()
   }
 
 
@@ -333,6 +334,21 @@ export class LexicalPromptElement extends HTMLElement {
 
     await nextFrame()
     this.#addTriggerListener()
+  }
+
+  // The popover is appended to the <lexxy-editor> subtree, so Turbo serializes it
+  // into the page cache. Removing it before caching prevents an orphaned, unmanaged
+  // popover from being restored on history back/forward.
+  #removePopoverBeforeTurboCaches() {
+    this.#globalListeners.track(
+      registerEventListener(document, "turbo:before-cache", () => this.#removePopover())
+    )
+  }
+
+  #removePopover() {
+    this.#popoverListeners.dispose()
+    this.popoverElement?.remove()
+    this.popoverElement = null
   }
 
   #filterOptions = async () => {

--- a/test/browser/tests/prompts/prompt_history_navigation.test.js
+++ b/test/browser/tests/prompts/prompt_history_navigation.test.js
@@ -1,0 +1,33 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt popover across Turbo history navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  // The popover is appended to the <lexxy-editor> subtree, so Turbo serializes it
+  // into the page cache on every navigation. An open popover would then be restored
+  // as an orphaned, unmanaged element on history back/forward — it reappears and
+  // sticks around. Tearing it down before Turbo caches keeps it out of the snapshot.
+  test("popover is torn down before Turbo caches the page", async ({ page, editor }) => {
+    await editor.send("@")
+    await expect(page.locator(".lexxy-prompt-menu--visible")).toBeVisible({ timeout: 5_000 })
+
+    await page.evaluate(() => document.dispatchEvent(new Event("turbo:before-cache")))
+
+    const cachedPopovers = await page.locator("lexxy-editor .lexxy-prompt-menu").count()
+    expect(cachedPopovers).toBe(0)
+  })
+
+  test("popover is removed from the DOM when the prompt element disconnects", async ({ page, editor }) => {
+    await editor.send("@")
+    await expect(page.locator(".lexxy-prompt-menu--visible")).toBeVisible({ timeout: 5_000 })
+
+    await page.evaluate(() => document.querySelector("lexxy-prompt").remove())
+
+    const orphanedPopovers = await page.locator(".lexxy-prompt-menu").count()
+    expect(orphanedPopovers).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

Open the @-prompt popover, then navigate browser **Back** then **Forward**: the prompt menu reappears (sometimes twice) and one instance sticks around as an orphan that can't be dismissed.

Card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9941487393

## Root cause

`LexicalPromptElement#buildPopover` appends the popover `<ul>` into the `<lexxy-editor>` subtree. Turbo serializes that subtree into the page snapshot on every navigation (`turbo:before-cache`). On history back/forward the cached snapshot is restored with the popover still present in the DOM — but the freshly reconnected prompt element no longer manages that element (its `popoverElement` reference is gone, listeners are disposed). The result is an orphaned, unmanaged popover.

The editor element already guards against exactly this with `#resetBeforeTurboCaches`. The prompt element had no equivalent.

## Fix

- Add `#removePopoverBeforeTurboCaches()`, mirroring the editor's pattern: on `turbo:before-cache`, remove the popover and dispose its listeners so it never enters the snapshot.
- On `disconnectedCallback`, actually remove the popover element (`#removePopover()`) instead of merely nulling the reference, so a disconnect doesn't leave an orphan behind either.

## Test

`test/browser/tests/prompts/prompt_history_navigation.test.js` (Playwright). Both cases were confirmed **failing on clean `origin/main`** before the fix and **passing** after.

Note on driving history: the `test/browser` harness serves static Vite fixtures with no Turbo runtime, so `page.goBack()/goForward()` cannot exercise Turbo's snapshot caching. Following the established precedent in `attachments/upload_after_editor_disposed.test.js`, the test drives the Turbo lifecycle deterministically by dispatching `turbo:before-cache` (the exact event that causes the snapshot), and asserts the popover is absent from the cached `<lexxy-editor>` subtree. A second case asserts the popover is removed on element disconnect.

## Validation

- `yarn lint` clean.
- Full `prompts/` suite: 37/37 passing on chromium and firefox.
- Full chromium suite green except a pre-existing, unrelated `editor/link_opener` "modifier+click opens new tab" failure that fails identically on clean `main` (headless modifier-click limitation).

## How to reproduce

In a Turbo-driven app (the dummy app's Posts pages work):
1. Open a Lexxy editor and type `@` to open the mention/prompt popover.
2. Navigate **Back** in the browser, then **Forward** (so Turbo restores the cached page).

**Before (bug):** the prompt menu reappears — sometimes twice — and one orphaned instance sticks around and won't dismiss (Turbo had cached the page with the popover still in the editor's DOM subtree).
**After (fix):** the popover is removed and its listeners disposed on `turbo:before-cache`, so it never enters the snapshot — no orphan after history navigation.
