### PR TITLE
Fix list editing inside blockquotes

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -17,7 +17,7 @@ import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_nod
 import { $createActionTextAttachmentUploadNode, ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node"
 import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils"
 import NodeInserter from "./contents/node_inserter"
-import { $expandSelectionToLineBreaksAndSplitAtEdges, $isShadowRoot, $splitSelectedParagraphsAtInnerLineBreaks } from "../helpers/lexical_helper"
+import { $consecutiveSiblingGroups, $expandSelectionToLineBreaksAndSplitAtEdges, $isShadowRoot, $splitSelectedParagraphsAtInnerLineBreaks } from "../helpers/lexical_helper"
 
 export default class Contents {
   constructor(editorElement) {
@@ -423,7 +423,7 @@ export default class Contents {
   }
 
   #insertListInsideQuote(listType) {
-    for (const group of this.#consecutiveSiblingGroups(this.#quotedBlocksInSelection())) {
+    for (const group of $consecutiveSiblingGroups(this.#quotedBlocksInSelection())) {
       this.#wrapBlocksInList(group, listType)
     }
   }
@@ -450,24 +450,6 @@ export default class Contents {
       list.append(listItem)
       block.remove()
     }
-  }
-
-  #consecutiveSiblingGroups(blocks) {
-    const ordered = [ ...blocks ].sort((a, b) => a.getIndexWithinParent() - b.getIndexWithinParent())
-    const groups = []
-
-    for (const block of ordered) {
-      const lastGroup = groups.at(-1)
-      const previous = lastGroup?.at(-1)
-
-      if (previous && previous.getParent().is(block.getParent()) && previous.getNextSibling()?.is(block)) {
-        lastGroup.push(block)
-      } else {
-        groups.push([ block ])
-      }
-    }
-
-    return groups
   }
 
   #splitParagraphsAtLineBreaksUnlessInsideList() {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -414,7 +414,7 @@ export default class Contents {
   }
 
   #applyListFormat(listType, command) {
-    if (this.#selectionInsideQuote()) {
+    if (this.selection.isInsideBlockQuote) {
       this.#insertListInsideQuote(listType)
     } else {
       this.#splitParagraphsAtLineBreaksUnlessInsideList()
@@ -422,16 +422,6 @@ export default class Contents {
     }
   }
 
-  // Lexical's $insertList only stops climbing at a root or shadow root, so a
-  // QuoteNode is transparent to it: listing a quoted paragraph swallows the
-  // whole blockquote into a single list item and destroys the quote. We detect
-  // that case here and build the list ourselves (#insertListInsideQuote).
-  #selectionInsideQuote() {
-    return this.#quotedBlocksInSelection().length > 0
-  }
-
-  // Build the list at the paragraph level for the quoted blocks, leaving the
-  // surrounding quote intact.
   #insertListInsideQuote(listType) {
     for (const group of this.#consecutiveSiblingGroups(this.#quotedBlocksInSelection())) {
       this.#wrapBlocksInList(group, listType)

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -7,7 +7,7 @@ import {
 
 import { $createCodeNode, $isCodeNode } from "@lexical/code"
 import { $createHeadingNode, $createQuoteNode, $isQuoteNode } from "@lexical/rich-text"
-import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
+import { $createListItemNode, $createListNode, $isListNode, INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { $createLinkNode, $toggleLink } from "@lexical/link"
 import { parseHtml } from "../helpers/html_helper"
@@ -77,13 +77,11 @@ export default class Contents {
   }
 
   applyUnorderedListFormat() {
-    this.#splitParagraphsAtLineBreaksUnlessInsideList()
-    this.editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined)
+    this.#applyListFormat("bullet", INSERT_UNORDERED_LIST_COMMAND)
   }
 
   applyOrderedListFormat() {
-    this.#splitParagraphsAtLineBreaksUnlessInsideList()
-    this.editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined)
+    this.#applyListFormat("number", INSERT_ORDERED_LIST_COMMAND)
   }
 
   clearFormatting() {
@@ -413,6 +411,67 @@ export default class Contents {
     }
 
     codeNode.remove()
+  }
+
+  #applyListFormat(listType, command) {
+    if (this.#insertListInsideQuote(listType)) return
+
+    this.#splitParagraphsAtLineBreaksUnlessInsideList()
+    this.editor.dispatchCommand(command, undefined)
+  }
+
+  // Lexical's $insertList only stops climbing at a root or shadow root, so a
+  // QuoteNode is transparent to it: listing a quoted paragraph swallows the
+  // whole blockquote into a single list item and destroys the quote. When the
+  // selection lives inside a quote we build the list at the paragraph level
+  // ourselves, leaving the surrounding quote intact.
+  #insertListInsideQuote(listType) {
+    const selection = $getSelection()
+    if (!$isRangeSelection(selection)) return false
+
+    const blocks = this.#outermostElements(this.#blockLevelElementsInSelection(selection))
+    const quotedBlocks = blocks.filter((block) => $isQuoteNode(block.getParent()))
+    if (quotedBlocks.length === 0) return false
+
+    for (const group of this.#consecutiveSiblingGroups(quotedBlocks)) {
+      this.#wrapBlocksInList(group, listType)
+    }
+
+    return true
+  }
+
+  #wrapBlocksInList(blocks, listType) {
+    const list = $createListNode(listType)
+    blocks[0].insertBefore(list)
+
+    for (const block of blocks) {
+      const listItem = $createListItemNode()
+      if ($isListNode(block)) {
+        listItem.append(...block.getChildren().flatMap((item) => item.getChildren()))
+      } else {
+        listItem.append(...block.getChildren())
+      }
+      list.append(listItem)
+      block.remove()
+    }
+  }
+
+  #consecutiveSiblingGroups(blocks) {
+    const ordered = [ ...blocks ].sort((a, b) => a.getIndexWithinParent() - b.getIndexWithinParent())
+    const groups = []
+
+    for (const block of ordered) {
+      const lastGroup = groups.at(-1)
+      const previous = lastGroup?.at(-1)
+
+      if (previous && previous.getParent().is(block.getParent()) && previous.getNextSibling()?.is(block)) {
+        lastGroup.push(block)
+      } else {
+        groups.push([ block ])
+      }
+    }
+
+    return groups
   }
 
   #splitParagraphsAtLineBreaksUnlessInsideList() {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -414,30 +414,36 @@ export default class Contents {
   }
 
   #applyListFormat(listType, command) {
-    if (this.#insertListInsideQuote(listType)) return
-
-    this.#splitParagraphsAtLineBreaksUnlessInsideList()
-    this.editor.dispatchCommand(command, undefined)
+    if (this.#selectionInsideQuote()) {
+      this.#insertListInsideQuote(listType)
+    } else {
+      this.#splitParagraphsAtLineBreaksUnlessInsideList()
+      this.editor.dispatchCommand(command)
+    }
   }
 
   // Lexical's $insertList only stops climbing at a root or shadow root, so a
   // QuoteNode is transparent to it: listing a quoted paragraph swallows the
-  // whole blockquote into a single list item and destroys the quote. When the
-  // selection lives inside a quote we build the list at the paragraph level
-  // ourselves, leaving the surrounding quote intact.
+  // whole blockquote into a single list item and destroys the quote. We detect
+  // that case here and build the list ourselves (#insertListInsideQuote).
+  #selectionInsideQuote() {
+    return this.#quotedBlocksInSelection().length > 0
+  }
+
+  // Build the list at the paragraph level for the quoted blocks, leaving the
+  // surrounding quote intact.
   #insertListInsideQuote(listType) {
-    const selection = $getSelection()
-    if (!$isRangeSelection(selection)) return false
-
-    const blocks = this.#outermostElements(this.#blockLevelElementsInSelection(selection))
-    const quotedBlocks = blocks.filter((block) => $isQuoteNode(block.getParent()))
-    if (quotedBlocks.length === 0) return false
-
-    for (const group of this.#consecutiveSiblingGroups(quotedBlocks)) {
+    for (const group of this.#consecutiveSiblingGroups(this.#quotedBlocksInSelection())) {
       this.#wrapBlocksInList(group, listType)
     }
+  }
 
-    return true
+  #quotedBlocksInSelection() {
+    const selection = $getSelection()
+    if (!$isRangeSelection(selection)) return []
+
+    const blocks = this.#outermostElements(this.#blockLevelElementsInSelection(selection))
+    return blocks.filter((block) => $isQuoteNode(block.getParent()))
   }
 
   #wrapBlocksInList(blocks, listType) {

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -586,6 +586,9 @@ export default class Selection {
   // - First item (no previous sibling): convert to a paragraph above the
   //   list, matching the standard "unwrap list formatting" behavior that
   //   users expect from pressing backspace at the start of a list item.
+  //   Inside a blockquote we instead just remove the empty item and move
+  //   the cursor into the next one — stranding a paragraph there would
+  //   leave the blank line the user is trying to close.
   //
   // When the empty item is the last/only one in the list, we return false
   // and let Lexical's default (convert to paragraph) provide the standard
@@ -604,19 +607,22 @@ export default class Selection {
     if (!nextSibling) return false
 
     const previousSibling = listItem.getPreviousSibling()
-    if (previousSibling) {
-      previousSibling.selectEnd()
-      listItem.remove()
-      return true
-    }
-
     const listNode = $getNearestNodeOfType(listItem, ListNode)
     if (!listNode) return false
 
-    const paragraph = $createParagraphNode()
-    listNode.insertBefore(paragraph)
-    listItem.remove()
-    paragraph.selectStart()
+    if (previousSibling) {
+      previousSibling.selectEnd()
+      listItem.remove()
+    } else if ($isQuoteNode(listNode.getParent())) {
+      nextSibling.selectStart()
+      listItem.remove()
+    } else {
+      const paragraph = $createParagraphNode()
+      listNode.insertBefore(paragraph)
+      listItem.remove()
+      paragraph.selectStart()
+    }
+
     return true
   }
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -12,7 +12,7 @@ import { isSelectionHighlighted } from "../helpers/format_helper"
 import { getNonce } from "../helpers/csp_helper"
 import { $createNodeSelectionWith, $isListItemStructurallyEmpty, getListType } from "../helpers/lexical_helper"
 import { LinkNode } from "@lexical/link"
-import { $isHeadingNode, $isQuoteNode } from "@lexical/rich-text"
+import { $isHeadingNode, $isQuoteNode, QuoteNode } from "@lexical/rich-text"
 import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 
@@ -157,6 +157,10 @@ export default class Selection {
 
   get isInsideList() {
     return this.nearestNodeOfType(ListItemNode)
+  }
+
+  get isInsideBlockQuote() {
+    return this.nearestNodeOfType(QuoteNode)
   }
 
   get isIndentedList() {

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -348,3 +348,21 @@ function $splitAroundLineBreak(lineBreakCaret) {
   return outer
 }
 
+export function $consecutiveSiblingGroups(blocks) {
+  const ordered = [ ...blocks ].sort((a, b) => a.getIndexWithinParent() - b.getIndexWithinParent())
+  const groups = []
+
+  for (const block of ordered) {
+    const lastGroup = groups.at(-1)
+    const previous = lastGroup?.at(-1)
+
+    if (previous && previous.getParent().is(block.getParent()) && previous.getNextSibling()?.is(block)) {
+      lastGroup.push(block)
+    } else {
+      groups.push([ block ])
+    }
+  }
+
+  return groups
+}
+

--- a/test/browser/tests/formatting/list_in_quote.test.js
+++ b/test/browser/tests/formatting/list_in_quote.test.js
@@ -1,0 +1,138 @@
+import { test } from "../../test_helper.js"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Lists inside blockquotes", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test.describe("Backspace closing a blank line gap", () => {
+    test("backspace on a blank first list item merges the gap instead of stranding a paragraph", async ({ editor }) => {
+      await editor.setValue(
+        "<blockquote><ul><li value=\"1\"><br></li><li value=\"2\">Second</li><li value=\"3\">Third</li></ul></blockquote>",
+      )
+      await editor.flush()
+
+      await editor.content.locator("blockquote ul li").first().click()
+      await editor.send("Home")
+      await editor.send("Backspace")
+      await editor.flush()
+
+      await assertEditorHtml(
+        editor,
+        "<blockquote><ul><li value=\"1\">Second</li><li value=\"2\">Third</li></ul></blockquote>",
+      )
+    })
+
+    test("backspace after clearing the first bullet's text removes the blank line", async ({ editor }) => {
+      await editor.setValue(
+        "<blockquote><ul><li value=\"1\">First</li><li value=\"2\">Second</li></ul></blockquote>",
+      )
+      await editor.flush()
+
+      const firstItem = editor.content.locator("blockquote ul li").first()
+      await firstItem.click()
+      await editor.locator.evaluate((el) => {
+        const li = el.querySelector("blockquote ul li")
+        const range = document.createRange()
+        range.selectNodeContents(li)
+        const selection = window.getSelection()
+        selection.removeAllRanges()
+        selection.addRange(range)
+      })
+      await editor.flush()
+      await editor.send("Delete")
+      await editor.flush()
+      await editor.send("Backspace")
+      await editor.flush()
+
+      await assertEditorHtml(
+        editor,
+        "<blockquote><ul><li value=\"1\">Second</li></ul></blockquote>",
+      )
+    })
+  })
+
+  test.describe("Adding bullets inside a quote keeps the quote", () => {
+    test("inserting an unordered list on a quoted paragraph lists only that paragraph", async ({ editor }) => {
+      await editor.setValue("<blockquote><p>Alpha</p><p>Beta</p></blockquote>")
+      await editor.flush()
+
+      await editor.content.locator("blockquote p").nth(1).click()
+      await editor.send("Home")
+      await editor.locator.evaluate((el) => el.editor.dispatchCommand("insertUnorderedList"))
+      await editor.flush()
+
+      await assertEditorHtml(
+        editor,
+        "<blockquote><p>Alpha</p><ul><li value=\"1\">Beta</li></ul></blockquote>",
+      )
+    })
+
+    test("re-adding bullets after removing them keeps the quote", async ({ editor }) => {
+      await editor.setValue(
+        "<blockquote><p>Title</p><ul><li value=\"1\">a</li><li value=\"2\">b</li></ul></blockquote>",
+      )
+      await editor.flush()
+
+      const selectListItems = () => {
+        return editor.locator.evaluate((el) => {
+          const items = el.querySelectorAll("blockquote ul li")
+          const range = document.createRange()
+          range.setStart(items[0].firstChild, 0)
+          range.setEnd(items[1].firstChild, items[1].textContent.length)
+          const selection = window.getSelection()
+          selection.removeAllRanges()
+          selection.addRange(range)
+        })
+      }
+
+      await editor.content.locator("blockquote ul li").first().click()
+      await selectListItems()
+      await editor.flush()
+      await editor.locator.evaluate((el) => el.editor.dispatchCommand("insertUnorderedList"))
+      await editor.flush()
+
+      await assertEditorHtml(
+        editor,
+        "<blockquote><p>Title</p><p>a</p><p>b</p></blockquote>",
+      )
+
+      await editor.locator.evaluate((el) => {
+        const paragraphs = el.querySelectorAll("blockquote p")
+        const first = paragraphs[paragraphs.length - 2]
+        const last = paragraphs[paragraphs.length - 1]
+        const range = document.createRange()
+        range.setStart(first.firstChild, 0)
+        range.setEnd(last.firstChild, last.textContent.length)
+        const selection = window.getSelection()
+        selection.removeAllRanges()
+        selection.addRange(range)
+      })
+      await editor.flush()
+      await editor.locator.evaluate((el) => el.editor.dispatchCommand("insertUnorderedList"))
+      await editor.flush()
+
+      await assertEditorHtml(
+        editor,
+        "<blockquote><p>Title</p><ul><li value=\"1\">a</li><li value=\"2\">b</li></ul></blockquote>",
+      )
+    })
+
+    test("inserting an ordered list on a quoted paragraph keeps the quote", async ({ editor }) => {
+      await editor.setValue("<blockquote><p>Alpha</p><p>Beta</p></blockquote>")
+      await editor.flush()
+
+      await editor.content.locator("blockquote p").nth(1).click()
+      await editor.send("Home")
+      await editor.locator.evaluate((el) => el.editor.dispatchCommand("insertOrderedList"))
+      await editor.flush()
+
+      await assertEditorHtml(
+        editor,
+        "<blockquote><p>Alpha</p><ol><li value=\"1\">Beta</li></ol></blockquote>",
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes two related defects when editing bullet lists inside a blockquote, reported on a Basecamp bug card.

## Backspace on a blank list item

In quoted text with bullets, pressing Backspace on an empty first list item stranded a `<p><br></p>` above the list instead of closing the gap — so the blank line could not be removed (forward Delete worked, Backspace did not). Inside a quote we now remove the empty item and move the cursor into the next one, matching the "close the gap" expectation. The root-level exit-list behavior (convert first item to a paragraph above the list) is unchanged.

## Adding a list to a quoted paragraph

Lexical's `$insertList` climbs to the nearest root or shadow root, treating a `QuoteNode` as transparent: listing a quoted paragraph swallowed the whole blockquote into a single list item and destroyed the quote. When the selection lives inside a quote we now build the list at the paragraph level ourselves, listing only the selected blocks and leaving the surrounding quote intact. Toggling a list off inside a quote and root-level list behavior are unaffected.

## Tests

New Playwright coverage in `test/browser/tests/formatting/list_in_quote.test.js` for both cases (backspace gap closing for blank/cleared first items; inserting unordered/ordered lists on quoted paragraphs; re-adding bullets after removing them). All five fail on clean `main` and pass with this change. Existing formatting, paste, list, and editor suites pass; `yarn lint` clean.

---
**Basecamp card:** https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9961874479

## How to reproduce

Use a blockquote that contains a bulleted list (paste or build one):

**Issue 1 — backspace can't close the gap:**
1. Inside a quote, have a few bullet items. Delete the text of the first bullet item so it's an empty line.
2. Press **Backspace** to remove that empty line.
   - **Before (bug):** Backspace won't close the gap (only the forward Delete key worked).
   - **After (fix):** Backspace removes the empty item and joins the line as expected.

**Issue 2 — adding bullets breaks the quote:**
1. Inside a quote, place the caret on a non-bulleted line (e.g. after deleting some bullets).
2. Toggle the bullet-list button to add bullets.
   - **Before (bug):** the whole blockquote is swallowed into a single list item / the quote is destroyed.
   - **After (fix):** the selected line(s) become a list *inside* the quote; the blockquote stays intact.
