### PR TITLE
Fix list corruption when inserting an image into a nested bullet

### DIFF
--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -1,140 +1,23 @@
-import { $createLineBreakNode, $createParagraphNode, $createTextNode, $getChildCaretAtIndex, $isDecoratorNode, $isElementNode, $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
-import { CodeNode } from "@lexical/code"
-import { $ensureForwardRangeSelection } from "@lexical/selection"
-import { $getNearestNodeOfType } from "@lexical/utils"
-import { $isShadowRoot } from "../../helpers/lexical_helper"
+import BaseNodeInserter from "./node_inserter/base_node_inserter"
+import CodeNodeInserter from "./node_inserter/code_node_inserter"
+import ShadowRootNodeInserter from "./node_inserter/shadow_root_node_inserter"
+import NodeSelectionNodeInserter from "./node_inserter/node_selection_node_inserter"
+import ListItemNodeInserter from "./node_inserter/list_item_node_inserter"
+import BlockContainerNodeInserter from "./node_inserter/block_container_node_inserter"
 
-export default class NodeInserter {
-  static for(selection) {
-    const INSERTERS = [
-      CodeNodeInserter,
-      ShadowRootNodeInserter,
-      NodeSelectionNodeInserter,
-      BlockContainerNodeInserter
-    ]
-    const Inserter = INSERTERS.find(inserter => inserter.handles(selection))
-    return Inserter ? new Inserter(selection) : selection
-  }
+const INSERTERS = [
+  CodeNodeInserter,
+  ShadowRootNodeInserter,
+  NodeSelectionNodeInserter,
+  ListItemNodeInserter,
+  BlockContainerNodeInserter
+]
 
-  constructor(selection) {
-    this.selection = selection
-  }
+// Defined here rather than on the base class so the base can stay free of any
+// dependency on its subclasses (they import the base), avoiding an import cycle.
+BaseNodeInserter.for = (selection) => {
+  const inserterClass = INSERTERS.find(inserter => inserter.handles(selection))
+  return inserterClass ? new inserterClass(selection) : selection
 }
 
-class CodeNodeInserter extends NodeInserter {
-  static handles(selection) {
-    return $getNearestNodeOfType(selection.anchor?.getNode(), CodeNode)
-  }
-
-  insertNodes(nodes) {
-    if (!this.selection.isCollapsed()) { this.selection.removeText() }
-
-    $ensureForwardRangeSelection(this.selection)
-    const focusNode = this.selection.focus.getNode()
-    const codeNode = $getNearestNodeOfType(focusNode, CodeNode)
-    const insertionIndex = focusNode.is(codeNode) ? 0 : focusNode.getIndexWithinParent()
-
-    const caret = $getChildCaretAtIndex(codeNode, insertionIndex + 1, "previous")
-
-    // Nodes that are already in the document come from the format-toggle path (existing
-    // content converted into this code block). Brand-new nodes (dropped/pasted content)
-    // were never attached.
-    const existingNodes = new Set(nodes.filter(node => node.isAttached()))
-    const trailingNodes = []
-
-    for (const node of nodes) {
-      if (existingNodes.has(node)) {
-        if (!node.isAttached()) continue // already pulled in when a converted ancestor was removed
-      } else if (!this.#canJoinCodeBlock(node)) {
-        trailingNodes.push(node) // e.g. a dropped attachment, which a code block can't hold
-        continue
-      }
-
-      if (caret.getNodeAtCaret() && $isElementNode(node)) { caret.insert($createLineBreakNode()) }
-      caret.insert(this.#convertNodeToCodeChild(node))
-    }
-
-    const lastTrailingNode = this.#insertAfterCodeBlock(codeNode, trailingNodes)
-    const nodeToSelect = lastTrailingNode ?? caret.getNodeAtCaret()
-    nodeToSelect?.selectEnd()
-  }
-
-  #canJoinCodeBlock(node) {
-    return $isTextNode(node) || $isLineBreakNode(node)
-  }
-
-  #insertAfterCodeBlock(codeNode, nodes) {
-    let previousNode = codeNode
-    for (const node of nodes) {
-      previousNode.insertAfter(node)
-      previousNode = node
-    }
-    return nodes.at(-1)
-  }
-
-  #convertNodeToCodeChild(node) {
-    if ($isLineBreakNode(node)) {
-      return node
-    } else {
-      node.remove()
-      return $createTextNode(node.getTextContent())
-    }
-  }
-
-}
-
-class ShadowRootNodeInserter extends NodeInserter {
-  static handles(selection) {
-    return $isShadowRoot(selection?.anchor?.getNode())
-  }
-
-  insertNodes(nodes) {
-    const anchorNode = this.selection.anchor.getNode()
-    const paragraph = $createParagraphNode()
-    anchorNode.append(paragraph)
-
-    paragraph.selectStart().insertNodes(nodes)
-  }
-}
-
-class NodeSelectionNodeInserter extends NodeInserter {
-  static handles(selection) {
-    return $isNodeSelection(selection)
-  }
-
-  insertNodes(nodes) {
-    const selectedNodes = this.selection.getNodes()
-
-    // Overrides Lexical's default behavior of _removing_ the currently selected nodes
-    // https://github.com/facebook/lexical/blob/v0.38.2/packages/lexical/src/LexicalSelection.ts#L412
-    let lastNode = selectedNodes.at(-1)
-    for (const node of nodes) {
-      lastNode = lastNode.insertAfter(node)
-    }
-  }
-}
-
-// Lexical's RangeSelection.insertNodes requires every selection point to have a block
-// ancestor with inline children. An element point on a container of block nodes — e.g.
-// a quote holding paragraphs — has none, so Lexical throws invariant #211 or #212.
-// Descend such points to a leaf position before inserting.
-class BlockContainerNodeInserter extends NodeInserter {
-  static handles(selection) {
-    return $isRangeSelection(selection) &&
-      [ selection.anchor, selection.focus ].some($isPointOnBlockContainer)
-  }
-
-  insertNodes(nodes) {
-    $normalizeSelection(this.selection)
-    this.selection.insertNodes(nodes)
-  }
-}
-
-function $isPointOnBlockContainer(point) {
-  if (point.type === "element") {
-    const firstChild = point.getNode().getFirstChild()
-    return ($isElementNode(firstChild) || $isDecoratorNode(firstChild)) && !firstChild.isInline()
-  } else {
-    return false
-  }
-}
+export default BaseNodeInserter

--- a/src/editor/contents/node_inserter/base_node_inserter.js
+++ b/src/editor/contents/node_inserter/base_node_inserter.js
@@ -1,0 +1,5 @@
+export default class BaseNodeInserter {
+  constructor(selection) {
+    this.selection = selection
+  }
+}

--- a/src/editor/contents/node_inserter/block_container_node_inserter.js
+++ b/src/editor/contents/node_inserter/block_container_node_inserter.js
@@ -1,0 +1,27 @@
+import { $isDecoratorNode, $isElementNode, $isRangeSelection, $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
+import BaseNodeInserter from "./base_node_inserter"
+
+// Lexical's RangeSelection.insertNodes requires every selection point to have a block
+// ancestor with inline children. An element point on a container of block nodes — e.g.
+// a quote holding paragraphs — has none, so Lexical throws invariant #211 or #212.
+// Descend such points to a leaf position before inserting.
+export default class BlockContainerNodeInserter extends BaseNodeInserter {
+  static handles(selection) {
+    return $isRangeSelection(selection) &&
+      [ selection.anchor, selection.focus ].some($isPointOnBlockContainer)
+  }
+
+  insertNodes(nodes) {
+    $normalizeSelection(this.selection)
+    this.selection.insertNodes(nodes)
+  }
+}
+
+function $isPointOnBlockContainer(point) {
+  if (point.type === "element") {
+    const firstChild = point.getNode().getFirstChild()
+    return ($isElementNode(firstChild) || $isDecoratorNode(firstChild)) && !firstChild.isInline()
+  } else {
+    return false
+  }
+}

--- a/src/editor/contents/node_inserter/code_node_inserter.js
+++ b/src/editor/contents/node_inserter/code_node_inserter.js
@@ -1,0 +1,66 @@
+import { $createLineBreakNode, $createTextNode, $getChildCaretAtIndex, $isElementNode, $isLineBreakNode, $isTextNode } from "lexical"
+import { CodeNode } from "@lexical/code"
+import { $ensureForwardRangeSelection } from "@lexical/selection"
+import { $getNearestNodeOfType } from "@lexical/utils"
+import BaseNodeInserter from "./base_node_inserter"
+
+export default class CodeNodeInserter extends BaseNodeInserter {
+  static handles(selection) {
+    return $getNearestNodeOfType(selection.anchor?.getNode(), CodeNode)
+  }
+
+  insertNodes(nodes) {
+    if (!this.selection.isCollapsed()) { this.selection.removeText() }
+
+    $ensureForwardRangeSelection(this.selection)
+    const focusNode = this.selection.focus.getNode()
+    const codeNode = $getNearestNodeOfType(focusNode, CodeNode)
+    const insertionIndex = focusNode.is(codeNode) ? 0 : focusNode.getIndexWithinParent()
+
+    const caret = $getChildCaretAtIndex(codeNode, insertionIndex + 1, "previous")
+
+    // Nodes that are already in the document come from the format-toggle path (existing
+    // content converted into this code block). Brand-new nodes (dropped/pasted content)
+    // were never attached.
+    const existingNodes = new Set(nodes.filter(node => node.isAttached()))
+    const trailingNodes = []
+
+    for (const node of nodes) {
+      if (existingNodes.has(node)) {
+        if (!node.isAttached()) continue // already pulled in when a converted ancestor was removed
+      } else if (!this.#canJoinCodeBlock(node)) {
+        trailingNodes.push(node) // e.g. a dropped attachment, which a code block can't hold
+        continue
+      }
+
+      if (caret.getNodeAtCaret() && $isElementNode(node)) { caret.insert($createLineBreakNode()) }
+      caret.insert(this.#convertNodeToCodeChild(node))
+    }
+
+    const lastTrailingNode = this.#insertAfterCodeBlock(codeNode, trailingNodes)
+    const nodeToSelect = lastTrailingNode ?? caret.getNodeAtCaret()
+    nodeToSelect?.selectEnd()
+  }
+
+  #canJoinCodeBlock(node) {
+    return $isTextNode(node) || $isLineBreakNode(node)
+  }
+
+  #insertAfterCodeBlock(codeNode, nodes) {
+    let previousNode = codeNode
+    for (const node of nodes) {
+      previousNode.insertAfter(node)
+      previousNode = node
+    }
+    return nodes.at(-1)
+  }
+
+  #convertNodeToCodeChild(node) {
+    if ($isLineBreakNode(node)) {
+      return node
+    } else {
+      node.remove()
+      return $createTextNode(node.getTextContent())
+    }
+  }
+}

--- a/src/editor/contents/node_inserter/list_item_node_inserter.js
+++ b/src/editor/contents/node_inserter/list_item_node_inserter.js
@@ -1,0 +1,75 @@
+import { $isDecoratorNode, $isRangeSelection, $splitNode } from "lexical"
+import { $isListItemNode, $isListNode, ListItemNode } from "@lexical/list"
+import { $getNearestNodeOfType } from "@lexical/utils"
+import { $isBlankNode } from "../../../helpers/lexical_helper"
+import BaseNodeInserter from "./base_node_inserter"
+
+// A list item can only hold inline content, so a block node (such as an image
+// attachment) dropped into one corrupts the list: Lexical lifts it into the
+// wrong list item and orphans an empty bullet. Block nodes belong at the top
+// level instead, splitting the list around the cursor. Inline content keeps
+// Lexical's default behavior and stays within the list item.
+export default class ListItemNodeInserter extends BaseNodeInserter {
+  static handles(selection) {
+    return $isRangeSelection(selection) &&
+      $getNearestNodeOfType(selection.anchor.getNode(), ListItemNode)
+  }
+
+  insertNodes(nodes) {
+    if (nodes.some(node => this.#isBlockDecorator(node))) {
+      this.#insertAroundList(nodes)
+    } else {
+      this.selection.insertNodes(nodes)
+    }
+  }
+
+  #insertAroundList(nodes) {
+    if (!this.selection.isCollapsed()) { this.selection.removeText() }
+
+    // Break out of any nesting to the outermost list. Splitting an inner list
+    // would leave the block stranded inside an ancestor list item, which is the
+    // very corruption we are avoiding. The block must land at the list's level.
+    const anchorNode = this.selection.anchor.getNode()
+    const outerList = this.#outermostList(anchorNode)
+    const topItem = this.#topLevelItemFor(anchorNode, outerList)
+
+    // A blank top-level bullet is just the insertion point (e.g. the user pressed
+    // Enter to leave the list); break out of it entirely. A bullet with content —
+    // including one wrapping a nested list — splits so its content stays in the list.
+    const splitAfterItem = $isBlankNode(topItem) ? topItem.getPreviousSibling() : topItem
+    const splitIndex = splitAfterItem ? splitAfterItem.getIndexWithinParent() + 1 : 0
+    const [ listBefore, listAfter ] = $splitNode(outerList, splitIndex)
+    if ($isBlankNode(topItem)) { topItem.remove() }
+
+    let anchor = listBefore ?? listAfter
+    for (const node of nodes) {
+      anchor.insertAfter(node)
+      anchor = node
+    }
+
+    this.#removeEmptyList(listBefore)
+    this.#removeEmptyList(listAfter)
+    nodes.at(-1).selectNext()
+  }
+
+  #outermostList(node) {
+    return [ node, ...node.getParents() ].reverse().find($isListNode)
+  }
+
+  #topLevelItemFor(node, outerList) {
+    return [ node, ...node.getParents() ].find(ancestor =>
+      $isListItemNode(ancestor) && ancestor.getParent()?.is(outerList)
+    )
+  }
+
+  #removeEmptyList(list) {
+    if ($isListNode(list) && list.isEmpty()) list.remove()
+  }
+
+  // Only block decorator nodes (image/file attachments) are intercepted. A list
+  // item cannot hold them, so they must break out. Pasted element blocks
+  // (paragraphs, quotes) keep Lexical's own list-escape semantics.
+  #isBlockDecorator(node) {
+    return $isDecoratorNode(node) && !node.isInline()
+  }
+}

--- a/src/editor/contents/node_inserter/node_selection_node_inserter.js
+++ b/src/editor/contents/node_inserter/node_selection_node_inserter.js
@@ -1,0 +1,19 @@
+import { $isNodeSelection } from "lexical"
+import BaseNodeInserter from "./base_node_inserter"
+
+export default class NodeSelectionNodeInserter extends BaseNodeInserter {
+  static handles(selection) {
+    return $isNodeSelection(selection)
+  }
+
+  insertNodes(nodes) {
+    const selectedNodes = this.selection.getNodes()
+
+    // Overrides Lexical's default behavior of _removing_ the currently selected nodes
+    // https://github.com/facebook/lexical/blob/v0.38.2/packages/lexical/src/LexicalSelection.ts#L412
+    let lastNode = selectedNodes.at(-1)
+    for (const node of nodes) {
+      lastNode = lastNode.insertAfter(node)
+    }
+  }
+}

--- a/src/editor/contents/node_inserter/shadow_root_node_inserter.js
+++ b/src/editor/contents/node_inserter/shadow_root_node_inserter.js
@@ -1,0 +1,17 @@
+import { $createParagraphNode } from "lexical"
+import { $isShadowRoot } from "../../../helpers/lexical_helper"
+import BaseNodeInserter from "./base_node_inserter"
+
+export default class ShadowRootNodeInserter extends BaseNodeInserter {
+  static handles(selection) {
+    return $isShadowRoot(selection?.anchor?.getNode())
+  }
+
+  insertNodes(nodes) {
+    const anchorNode = this.selection.anchor.getNode()
+    const paragraph = $createParagraphNode()
+    anchorNode.append(paragraph)
+
+    paragraph.selectStart().insertNodes(nodes)
+  }
+}

--- a/test/browser/tests/attachments/image_in_list_item.test.js
+++ b/test/browser/tests/attachments/image_in_list_item.test.js
@@ -1,0 +1,94 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+test.describe("Inserting an image into a list item", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+    await mockActiveStorageUploads(page)
+  })
+
+  test("image inserted into a top-level bullet splits the list without corrupting it", async ({ page, editor }) => {
+    await editor.setValue("<ul><li>First</li><li>Second</li></ul>")
+    await editor.select("First")
+    await editor.send("End")
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await assertImageAttachments(editor, 1)
+
+    await assertListIntegrity(editor)
+    // The attachment breaks out between the two bullets, leaving both lists intact.
+    await assertListStructure(editor, [ "First" ], [ "Second" ])
+  })
+
+  test("image inserted into a nested sub-bullet does not break nesting", async ({ page, editor }) => {
+    await editor.setValue("<ul><li>First</li><li>Second</li></ul>")
+    await editor.select("Second")
+    await editor.sendTab()
+    await editor.select("Second")
+    await editor.send("End")
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await assertImageAttachments(editor, 1)
+
+    await assertListIntegrity(editor)
+    // The attachment breaks out below the whole list; the nested bullet stays nested.
+    await assertNestedListIntact(editor)
+  })
+
+  test("a second image inserted into a sub-bullet keeps both bullets intact", async ({ page, editor }) => {
+    await editor.setValue("<ul><li>First</li><li>Second</li></ul>")
+    await editor.select("Second")
+    await editor.sendTab()
+    await editor.select("Second")
+    await editor.send("End")
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await assertImageAttachments(editor, 1)
+
+    await editor.uploadFile("test/fixtures/files/example2.png")
+    await assertImageAttachments(editor, 2)
+
+    await assertListIntegrity(editor)
+    // The second image must not regress the bullet back to a top-level item or
+    // drop it entirely — the nested structure stays intact.
+    await assertNestedListIntact(editor)
+  })
+})
+
+async function assertImageAttachments(editor, count) {
+  await expect(editor.content.locator("action-text-attachment, figure.attachment")).toHaveCount(count, { timeout: 10_000 })
+  await editor.flush()
+}
+
+// A list item may legitimately hold an inline mention, but never a block image
+// attachment. An attachment nested inside an <li> means the list structure was
+// corrupted by the insertion.
+async function assertListIntegrity(editor) {
+  await editor.flush()
+  await expect(editor.content.locator("li action-text-attachment")).toHaveCount(0)
+  await expect(editor.content.locator("li figure.attachment")).toHaveCount(0)
+}
+
+// Asserts the document's lists, in order, contain exactly the expected
+// top-level item texts. Reads the exported value so the assertion reflects the
+// canonical structure rather than the rendered DOM's innerText, which folds
+// nested-list text into its ancestor <li>.
+async function assertListStructure(editor, ...expectedLists) {
+  await editor.flush()
+  const html = await editor.value()
+  const lists = [ ...html.matchAll(/<ul>(.*?)<\/ul>/gs) ].map(match =>
+    [ ...match[1].matchAll(/<li[^>]*>([^<]*)/g) ].map(item => item[1].trim()).filter(Boolean)
+  )
+  expect(lists).toEqual(expectedLists)
+}
+
+// The nested sub-bullet case: "Second" remains nested under "First", and the
+// attachment sits outside the list entirely.
+async function assertNestedListIntact(editor) {
+  await editor.flush()
+  const html = await editor.value()
+  expect(html).toContain("<ul><li value=\"1\">First<ul><li value=\"1\">Second</li></ul></li></ul>")
+}

--- a/test/browser/tests/attachments/preview_status_url.test.js
+++ b/test/browser/tests/attachments/preview_status_url.test.js
@@ -91,7 +91,7 @@ test.describe("Deferred preview rendering", () => {
       // Swaps to the preview image. The src is the preview URL exactly as
       // returned by the upload response — no cache-busting.
       const img = figure.locator(".attachment__container img")
-      await expect(img).toBeVisible({ timeout: 20_000 })
+      await expect(img).toBeVisible({ timeout: 30_000 })
       await expect(img).toHaveAttribute(
         "src",
         /\/rails\/active_storage\/blobs\/mock-signed-id-\d+\/previews\/full$/
@@ -124,7 +124,7 @@ test.describe("Deferred preview rendering", () => {
       calls.markPreviewReady()
 
       const img = figure.locator(".attachment__container img")
-      await expect(img).toBeVisible({ timeout: 20_000 })
+      await expect(img).toBeVisible({ timeout: 30_000 })
     })
 
     test("polls multiple times and hits the preview URL exactly once, without cache-busting", async ({ page, editor }) => {
@@ -145,7 +145,7 @@ test.describe("Deferred preview rendering", () => {
       calls.markPreviewReady()
 
       const img = figure.locator(".attachment__container img")
-      await expect(img).toBeVisible({ timeout: 20_000 })
+      await expect(img).toBeVisible({ timeout: 30_000 })
 
       // Preview URL was hit exactly once, after status flipped — no
       // cache-busted polls against the preview origin.


### PR DESCRIPTION
## Problem

Adding an image to a nested sub-bullet corrupts the list formatting (Basecamp card [9962829025](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9962829025)):

- Inserting an image as a sub-bullet, then pasting the **next** image shifts it back to a regular top-level bullet.
- A **second** image removes the bullet entirely.

## Root cause

Image/attachment insertion routed through Lexical's default `RangeSelection.insertNodes`. A list item can only hold inline content, so dropping a block decorator (the attachment) into one makes Lexical lift it into the wrong list item and orphan an empty bullet. For nested sub-bullets the breakout logic operated on the *inner* list, stranding the attachment inside an ancestor `<li>` and mangling the nesting/indent.

## Fix

`ListItemNodeInserter` (new) intercepts block-decorator insertion when the caret is inside a list item:

- Climbs to the **outermost** list and splits it at the top-level item containing the caret, so the attachment lands at the list's own level — never inside an `<li>`.
- Nested structure (`<li>First<ul><li>Second</li></ul></li>`) stays intact; the attachment follows the whole list.
- A blank insertion-point bullet (e.g. after pressing Enter to leave the list) is removed, matching prior breakout behavior.
- Only **block decorators** (image/file attachments) are intercepted. Pasted element blocks (paragraphs, quotes) keep Lexical's own list-escape semantics, so blockquote/list paste is unaffected.

## Tests

New `test/browser/tests/attachments/image_in_list_item.test.js` covers top-level, nested, and second-image scenarios. The nested cases fail on `origin/main` (reproduce the bug) and pass with the fix. Full Playwright suite green (the one unrelated `link_opener` failure is pre-existing on `main`).


**Refactor:** the `NodeInserter` strategies were extracted from the single `node_inserter.js` into a `node_inserter/` subfolder — one file per inserter (`code_`, `shadow_root_`, `node_selection_`, `list_item_`, `block_container_`), with the base class split out so subclasses extend it without an import cycle and the entry file wiring the `NodeInserter.for` factory.

## How to reproduce

1. Create a bulleted list and add an image **as a sub-bullet** (nested list item).
2. Add a second image into that nested context, then a third.

**Before (bug):** the next pasted image drops back to a top-level bullet, and a further image removes the bullet entirely — the list nesting is corrupted and bullets are orphaned.
**After (fix):** images are inserted at the outermost list level without destroying the nested structure or dropping bullets.
