### PR TITLE
Pasting inline content onto a selected attachment crashes with Lexical error #99

### DIFF
--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -108,9 +108,29 @@ class NodeSelectionNodeInserter extends NodeInserter {
     // Overrides Lexical's default behavior of _removing_ the currently selected nodes
     // https://github.com/facebook/lexical/blob/v0.38.2/packages/lexical/src/LexicalSelection.ts#L412
     let lastNode = selectedNodes.at(-1)
+    let inlineContainer = null
+
     for (const node of nodes) {
-      lastNode = lastNode.insertAfter(node)
+      if (this.#canFollowAtTopLevel(node, lastNode)) {
+        lastNode = lastNode.insertAfter(node)
+        inlineContainer = null
+      } else {
+        inlineContainer ??= this.#insertParagraphAfter(lastNode)
+        inlineContainer.append(node)
+        lastNode = inlineContainer
+      }
     }
+  }
+
+  #canFollowAtTopLevel(node, lastNode) {
+    const followsTopLevelNode = lastNode.is(lastNode.getTopLevelElement())
+    return !followsTopLevelNode || $isElementNode(node) || $isDecoratorNode(node)
+  }
+
+  #insertParagraphAfter(node) {
+    const paragraph = $createParagraphNode()
+    node.insertAfter(paragraph)
+    return paragraph
   }
 }
 

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -40,6 +40,52 @@ test.describe("Uploading into an unsupported selection", () => {
     await expect(editor.content.locator("figure.attachment")).toHaveCount(2, { timeout: 10_000 })
   })
 
+  // Minified Lexical error #99 ("Only element or decorator nodes can be inserted to
+  // the root node"): NodeSelectionNodeInserter inserted every node after the selected
+  // one with `insertAfter`. When the selected node is a root-level attachment and an
+  // inserted node is inline (a text node from pasted content), that drops a text node
+  // straight into the root, which Lexical forbids.
+  test("inserting inline content while an attachment is node-selected keeps the root valid", async ({ page, editor }) => {
+    await editor.setValue(`${pdfAttachment}<p>pasted text</p>`)
+    await editor.flush()
+
+    const figure = editor.content.locator("figure.attachment")
+    await expect(figure).toBeVisible()
+
+    await figure.click()
+    await expect(figure).toHaveClass(/node--selected/)
+
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    // Detach the existing text node and re-insert it through the node-selection path,
+    // mimicking inline clipboard nodes being inserted while the attachment is selected.
+    const error = await page.evaluate(() => {
+      const editorElement = document.querySelector("lexxy-editor")
+      let message = null
+      editorElement.editor.update(() => {
+        const root = editorElement.editor.getEditorState()._nodeMap.get("root")
+        const paragraph = root.getChildren().find((child) => child.getType() === "paragraph")
+        const textNode = paragraph.getFirstChild()
+        textNode.remove()
+        try {
+          editorElement.contents.insertAtCursor(textNode)
+        } catch (err) {
+          message = err.message
+        }
+      })
+      return message
+    })
+
+    await editor.flush()
+
+    expect(error).toBeNull()
+    expect(errors).toEqual([])
+    await expect(figure).toHaveCount(1)
+    await expect(editor.content).toContainText("pasted text")
+    expect(await editor.plainTextValue()).toContain("pasted text")
+  })
+
   // "Cannot read properties of null (reading 'selectEnd')":
   // uploading a file while the caret sits in an empty code block leaves no node
   // at the caret, and CodeNodeInserter crashed trying to select it. Driven through


### PR DESCRIPTION
Selecting a top-level node (such as an attachment) and then pasting or dropping content that includes inline nodes crashed the editor with **Minified Lexical error #99** — *"Only element or decorator nodes can be inserted to the root node."* In production this is one of the top JS errors in Basecamp (BC3-JS-N562: ~85k events / ~1k users in 14 days).

## What it fixes

When a node is selected, `NodeSelectionNodeInserter` inserted every incoming node directly after the selected one with `insertAfter`. When the selected node lives at the root and an incoming node is inline (a text node, a link from pasted content), `insertAfter` placed it as a direct child of the root — which Lexical forbids — throwing error #99.

## How

`NodeSelectionNodeInserter#insertNodes` now wraps inline content in a paragraph when the preceding node is at the top level, while still inserting element and decorator nodes as root siblings (preserving the existing dropped-attachment behavior).

Reproduced with a failing Playwright test in `test/browser/tests/attachments/upload_into_unsupported_selection.test.js` (asserts no error #99 and that the inline content survives); the full attachments + paste suites pass.

- Sentry: https://basecamp.sentry.io/issues/7352220817/ (BC3-JS-N562)
- Bug card: https://3.basecamp.com/4968447/buckets/41746046/card_tables/cards/10001773098
