### PR TITLE
Pasting a URL with the caret on a block container crashes with Lexical error #222

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -144,7 +144,7 @@ export default class Clipboard {
     }
 
     const linkNode = $createLinkNode(url).append($createTextNode(url))
-    selection.insertNodes([ linkNode ])
+    this.contents.insertAtCursor(linkNode)
 
     $onUpdate(() => this.#dispatchLinkInsertEvent(linkNode.getKey(), { url }))
   }

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -171,7 +171,7 @@ export default class Contents {
 
       const selection = $getSelection()
       if ($isRangeSelection(selection)) {
-        selection.insertNodes([ linkNode ])
+        this.insertAtCursor(linkNode)
         linkNodeKey = linkNode.getKey()
       }
     })

--- a/test/browser/tests/paste/paste_url_with_caret_on_quote.test.js
+++ b/test/browser/tests/paste/paste_url_with_caret_on_quote.test.js
@@ -1,0 +1,48 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+// Pasting a URL routes through Clipboard#pastePlainText, which inserts a link node directly
+// via RangeSelection.insertNodes — bypassing the NodeInserter normalization that the rich-text
+// and markdown paste paths use. When the caret is an element point on a block container (e.g.
+// the blockquote itself, between two paragraphs), inserting a link node at that point produces
+// an invalid tree and crashes during reconciliation with Lexical error #222
+// (ElementDOMSlot.insertChild: before is not in element).
+test.describe("Paste a URL with the caret on a quote element", () => {
+  let pageErrors
+
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await editor.setValue("<blockquote><p>first</p><p>second</p></blockquote>")
+    await editor.focus()
+    await placeCaretOnQuoteElement(editor)
+  })
+
+  test("pasting a bare URL does not crash and lands a link inside the quote", async ({ editor }) => {
+    await editor.paste("https://example.com")
+    await editor.flush()
+
+    expect(pageErrors).toHaveLength(0)
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator('blockquote a[href="https://example.com"]')).toHaveText("https://example.com")
+    })
+  })
+})
+
+// Real mouse interaction can't reliably produce an element point on the quote node itself
+// (Lexical normalizes DOM selections to leaves), so set the Lexical selection directly,
+// mirroring the selection state Sentry reported. Offset 1 is the gap between the two paragraphs.
+async function placeCaretOnQuoteElement(editor) {
+  await editor.locator.evaluate((editorElement) => {
+    editorElement.editor.update(() => {
+      const editorState = editorElement.editor._pendingEditorState
+      const quote = editorState._nodeMap.get(editorState._nodeMap.get("root").__first)
+      quote.select(1, 1)
+    })
+  })
+}


### PR DESCRIPTION
Pasting a URL while the caret sits on a block container (e.g. the blockquote itself, between two paragraphs) crashes the editor and loses the pasted link. In production this surfaces as Lexical error #222 (`ElementDOMSlot.insertChild: before is not in element`) during reconciliation; in the dev build the same selection raises #211 (`Expected node … to have a block ElementNode ancestor`).

## What

The URL-paste path (`Clipboard#pastePlainText` → `Contents#createLink`, and the single-link branch of `Clipboard#insertSingleLinkAt`) inserted the link node with a bare `RangeSelection.insertNodes` call. That bypasses the `NodeInserter` normalization that the rich-text and markdown paste paths already use. Lexical's `insertNodes` requires every selection point to have a block ancestor with inline children; an element point on a block container has none, so inserting at that caret produced an invalid tree.

This is the same family as #1109 (Lexical error #211/#212 on rich-text and markdown paste with the caret on a quote) — the link-insertion entry points were the remaining consumers that hadn't been routed through the normalizer.

## How

Route both link-insertion entry points through `Contents#insertAtCursor`, which uses `NodeInserter` to descend the selection to a leaf position before inserting.

Added a Playwright regression test (`test/browser/tests/paste/paste_url_with_caret_on_quote.test.js`) that places the caret as an element point on a quote, pastes a bare URL, and asserts no page error plus a link landing inside the quote.

- Sentry: BC3-JS-N7CS — https://basecamp.sentry.io/issues/7507307868/ (1091 events / 378 users over 14d)
- Bug card: https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/10001775137
