### PR TITLE
Fix Lexical #211 crashes when inserting at a quote element point

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -7,6 +7,7 @@ import { $createTextNode, $getSelection, $isParagraphNode, $isRangeSelection, $o
 import { $insertDataTransferForRichText } from "@lexical/clipboard"
 import { $createLinkNode, $isLinkNode, $toggleLink } from "@lexical/link"
 import { ListenerBin } from "../helpers/listener_helper"
+import NodeInserter from "./contents/node_inserter"
 
 export default class Clipboard {
   #listeners = new ListenerBin()
@@ -144,7 +145,7 @@ export default class Clipboard {
     }
 
     const linkNode = $createLinkNode(url).append($createTextNode(url))
-    selection.insertNodes([ linkNode ])
+    NodeInserter.for(selection).insertNodes([ linkNode ])
 
     $onUpdate(() => this.#dispatchLinkInsertEvent(linkNode.getKey(), { url }))
   }

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -4,9 +4,12 @@ import {
   $isRangeSelection,
   $isTextNode,
   $setSelection,
+  COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_NORMAL,
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
+  INSERT_LINE_BREAK_COMMAND,
+  INSERT_PARAGRAPH_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND,
@@ -20,7 +23,7 @@ import { INSERT_TABLE_COMMAND } from "@lexical/table"
 
 import { createElement } from "../helpers/html_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
-import { getListType } from "../helpers/lexical_helper"
+import { $normalizeBlockContainerSelection, getListType } from "../helpers/lexical_helper"
 import { HorizontalDividerNode } from "../nodes/horizontal_divider_node"
 import { REMOVE_HIGHLIGHT_COMMAND, TOGGLE_HIGHLIGHT_COMMAND } from "../extensions/highlight_extension"
 
@@ -306,6 +309,16 @@ export class CommandDispatcher {
   #registerKeyboardCommands() {
     this.#registerCommandHandler(KEY_ARROW_RIGHT_COMMAND, COMMAND_PRIORITY_NORMAL, this.#handleArrowRightKey.bind(this))
     this.#registerCommandHandler(KEY_TAB_COMMAND, COMMAND_PRIORITY_NORMAL, this.#handleTabKey.bind(this))
+
+    // Run before Lexical's built-in insert handlers to descend an element point on a
+    // block container to a leaf, avoiding error #211 on Enter / Shift+Enter in a quote.
+    this.#registerCommandHandler(INSERT_LINE_BREAK_COMMAND, COMMAND_PRIORITY_HIGH, this.#normalizeBlockContainerSelection.bind(this))
+    this.#registerCommandHandler(INSERT_PARAGRAPH_COMMAND, COMMAND_PRIORITY_HIGH, this.#normalizeBlockContainerSelection.bind(this))
+  }
+
+  #normalizeBlockContainerSelection() {
+    $normalizeBlockContainerSelection()
+    return false
   }
 
   #handleArrowRightKey(event) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -170,7 +170,7 @@ export default class Contents {
 
       const selection = $getSelection()
       if ($isRangeSelection(selection)) {
-        selection.insertNodes([ linkNode ])
+        NodeInserter.for(selection).insertNodes([ linkNode ])
         linkNodeKey = linkNode.getKey()
       }
     })

--- a/src/editor/contents/node_inserter/block_container_node_inserter.js
+++ b/src/editor/contents/node_inserter/block_container_node_inserter.js
@@ -1,4 +1,5 @@
-import { $isDecoratorNode, $isElementNode, $isRangeSelection, $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
+import { $normalizeSelection__EXPERIMENTAL as $normalizeSelection } from "lexical"
+import { $hasPointOnBlockContainer } from "../../../helpers/lexical_helper"
 import BaseNodeInserter from "./base_node_inserter"
 
 // Lexical's RangeSelection.insertNodes requires every selection point to have a block
@@ -7,21 +8,11 @@ import BaseNodeInserter from "./base_node_inserter"
 // Descend such points to a leaf position before inserting.
 export default class BlockContainerNodeInserter extends BaseNodeInserter {
   static handles(selection) {
-    return $isRangeSelection(selection) &&
-      [ selection.anchor, selection.focus ].some($isPointOnBlockContainer)
+    return $hasPointOnBlockContainer(selection)
   }
 
   insertNodes(nodes) {
     $normalizeSelection(this.selection)
     this.selection.insertNodes(nodes)
-  }
-}
-
-function $isPointOnBlockContainer(point) {
-  if (point.type === "element") {
-    const firstChild = point.getNode().getFirstChild()
-    return ($isElementNode(firstChild) || $isDecoratorNode(firstChild)) && !firstChild.isInline()
-  } else {
-    return false
   }
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,4 +1,4 @@
-import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getRoot, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
+import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getRoot, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $normalizeSelection__EXPERIMENTAL as $normalizeSelection, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
@@ -350,6 +350,31 @@ function $splitAroundLineBreak(lineBreakCaret) {
   }
 
   return outer
+}
+
+// Lexical's RangeSelection.insertNodes/insertLineBreak require every selection point to have a
+// block ancestor with inline children. An element point on a container of block nodes — e.g. a
+// quote holding paragraphs — has none, so Lexical throws invariant #211 or #212. This detects
+// such a point so callers can descend it to a leaf before inserting.
+export function $isPointOnBlockContainer(point) {
+  if (point.type !== "element") return false
+
+  const firstChild = point.getNode().getFirstChild()
+  return ($isElementNode(firstChild) || $isDecoratorNode(firstChild)) && !firstChild.isInline()
+}
+
+export function $hasPointOnBlockContainer(selection) {
+  return $isRangeSelection(selection) &&
+    [ selection.anchor, selection.focus ].some($isPointOnBlockContainer)
+}
+
+// Descend any block-container element point in the selection to a leaf position, so a subsequent
+// Lexical insert (insertNodes, insertLineBreak, INSERT_PARAGRAPH) doesn't throw invariant #211/#212.
+export function $normalizeBlockContainerSelection(selection = $getSelection()) {
+  if (!$hasPointOnBlockContainer(selection)) return false
+
+  $normalizeSelection(selection)
+  return true
 }
 
 export function $consecutiveSiblingGroups(blocks) {

--- a/test/browser/helpers/editor_handle.js
+++ b/test/browser/helpers/editor_handle.js
@@ -88,6 +88,20 @@ export class EditorHandle {
     await this.flush()
   }
 
+  // Selects the first block container (a quote) at an element point — a selection
+  // state mouse/keyboard can't produce, since Lexical normalizes DOM selections to leaves.
+  async placeCaretOnQuoteElement() {
+    await this.locator.evaluate((el) => {
+      return new Promise((resolve) => {
+        el.editor.update(() => {
+          const editorState = el.editor._pendingEditorState
+          const quote = editorState._nodeMap.get(editorState._nodeMap.get("root").__first)
+          quote.select(1, 1)
+        }, { onUpdate: resolve })
+      })
+    })
+  }
+
   async paste(text, { html, files = [], uriList } = {}) {
     await this.#ensureFirstInteraction()
     await this.content.evaluate(

--- a/test/browser/tests/formatting/line_break_with_caret_on_quote.test.js
+++ b/test/browser/tests/formatting/line_break_with_caret_on_quote.test.js
@@ -1,0 +1,41 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+test.describe("Enter / Shift+Enter with the caret on a quote element", () => {
+  let pageErrors
+
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await editor.focus()
+    await editor.setValue("<blockquote><p>first</p><p>second</p></blockquote>")
+    await editor.placeCaretOnQuoteElement()
+  })
+
+  test("Shift+Enter does not crash and keeps the quote content", async ({ editor }) => {
+    await editor.content.press("Shift+Enter")
+    await editor.flush()
+
+    expect(pageErrors).toHaveLength(0)
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toContainText("first")
+      await expect(content.locator("blockquote")).toContainText("second")
+    })
+  })
+
+  test("Enter does not crash and keeps the quote content", async ({ editor }) => {
+    await editor.content.press("Enter")
+    await editor.flush()
+
+    expect(pageErrors).toHaveLength(0)
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toContainText("first")
+      await expect(content.locator("blockquote")).toContainText("second")
+    })
+  })
+})

--- a/test/browser/tests/paste/paste_url_with_caret_on_quote.test.js
+++ b/test/browser/tests/paste/paste_url_with_caret_on_quote.test.js
@@ -2,13 +2,6 @@ import { test } from "../../test_helper.js"
 import { expect } from "@playwright/test"
 import { assertEditorContent } from "../../helpers/assertions.js"
 
-// Pasting a bare URL routes through Clipboard#pastePlainText → Contents#createLink (and the
-// text/uri-list variant through Clipboard#insertSingleLinkAt), both of which call
-// RangeSelection.insertNodes directly instead of going through NodeInserter. When the caret
-// is an element point on a quote element (a block container holding paragraphs), Lexical's
-// insertNodes finds no block ancestor with inline children and throws error #211.
-// See https://github.com/basecamp/lexxy/pull/1109 for the same crash on the markdown/HTML
-// paste path, which was already routed through NodeInserter.
 test.describe("Paste URL with the caret on a quote element", () => {
   let pageErrors
 
@@ -21,7 +14,7 @@ test.describe("Paste URL with the caret on a quote element", () => {
 
     await editor.setValue("<blockquote><p>first</p><p>second</p></blockquote>")
     await editor.focus()
-    await placeCaretOnQuoteElement(editor)
+    await editor.placeCaretOnQuoteElement()
   })
 
   test("pasting a plain-text URL does not crash and creates a link inside the quote", async ({ editor }) => {
@@ -40,16 +33,3 @@ test.describe("Paste URL with the caret on a quote element", () => {
     expect(pageErrors).toHaveLength(0)
   })
 })
-
-// Real mouse interaction can't reliably produce an element point on the quote node itself
-// (Lexical normalizes DOM selections to leaves), so set the Lexical selection directly,
-// mirroring the selection state Sentry reported. Offset 1 is the gap between the two paragraphs.
-async function placeCaretOnQuoteElement(editor) {
-  await editor.locator.evaluate((editorElement) => {
-    editorElement.editor.update(() => {
-      const editorState = editorElement.editor._pendingEditorState
-      const quote = editorState._nodeMap.get(editorState._nodeMap.get("root").__first)
-      quote.select(1, 1)
-    })
-  })
-}

--- a/test/browser/tests/paste/paste_url_with_caret_on_quote.test.js
+++ b/test/browser/tests/paste/paste_url_with_caret_on_quote.test.js
@@ -1,0 +1,55 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+// Pasting a bare URL routes through Clipboard#pastePlainText → Contents#createLink (and the
+// text/uri-list variant through Clipboard#insertSingleLinkAt), both of which call
+// RangeSelection.insertNodes directly instead of going through NodeInserter. When the caret
+// is an element point on a quote element (a block container holding paragraphs), Lexical's
+// insertNodes finds no block ancestor with inline children and throws error #211.
+// See https://github.com/basecamp/lexxy/pull/1109 for the same crash on the markdown/HTML
+// paste path, which was already routed through NodeInserter.
+test.describe("Paste URL with the caret on a quote element", () => {
+  let pageErrors
+
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/attachments.html")
+    await editor.waitForConnected()
+
+    pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error.message))
+
+    await editor.setValue("<blockquote><p>first</p><p>second</p></blockquote>")
+    await editor.focus()
+    await placeCaretOnQuoteElement(editor)
+  })
+
+  test("pasting a plain-text URL does not crash and creates a link inside the quote", async ({ editor }) => {
+    await editor.paste("https://37signals.com")
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator('blockquote a[href="https://37signals.com"]')).toHaveCount(1)
+    })
+    expect(pageErrors).toHaveLength(0)
+  })
+
+  test("pasting a text/uri-list URL does not crash and creates a link inside the quote", async ({ editor }) => {
+    await editor.paste(null, { uriList: "https://37signals.com" })
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator('blockquote a[href="https://37signals.com"]')).toHaveCount(1)
+    })
+    expect(pageErrors).toHaveLength(0)
+  })
+})
+
+// Real mouse interaction can't reliably produce an element point on the quote node itself
+// (Lexical normalizes DOM selections to leaves), so set the Lexical selection directly,
+// mirroring the selection state Sentry reported. Offset 1 is the gap between the two paragraphs.
+async function placeCaretOnQuoteElement(editor) {
+  await editor.locator.evaluate((editorElement) => {
+    editorElement.editor.update(() => {
+      const editorState = editorElement.editor._pendingEditorState
+      const quote = editorState._nodeMap.get(editorState._nodeMap.get("root").__first)
+      quote.select(1, 1)
+    })
+  })
+}


### PR DESCRIPTION
## Problem

Lexical error **#211** ("expected node to have a block ElementNode ancestor") crashes the editor. Two triggers, same family — inserting content when the caret is an **element point on a block container** (a `<blockquote>` holding paragraphs, e.g. the gap between two paragraphs):

1. **Enter / Shift+Enter while the caret is an element point on a quote** — the dominant production trigger. Verified against Sentry `BC3-JS-N7C3` (1,230 events / 872 users, `messages/new` compose pages): `KEY_ENTER_COMMAND → INSERT_LINE_BREAK_COMMAND → insertLineBreak → insertNodes → #211`, entirely through Lexical's built-in rich-text handlers.
2. **Pasting a bare URL** at the same caret state — `Contents#createLink` (text/plain) and `Clipboard#insertSingleLinkAt` (text/uri-list) called `selection.insertNodes` directly, bypassing the `NodeInserter` guard.

`RangeSelection.insertNodes` finds no inline-bearing block ancestor at an element point on a block container and throws. (Same family as #222.)

## Fix

Normalize the selection — descend the block-container element point to a leaf — before the insert happens:

- **`command_dispatcher.js`**: high-priority handlers for `INSERT_LINE_BREAK_COMMAND` and `INSERT_PARAGRAPH_COMMAND` that `$normalizeSelection` the block-container element point to a leaf, then return `false` so Lexical's built-in handler proceeds on the corrected selection. (Covers trigger 1.)
- **link paste**: route `createLink` / `insertSingleLinkAt` through `NodeInserter.for(...)`. (Covers trigger 2.)
- Shared helpers extracted to `lexical_helper.js` (`$isPointOnBlockContainer` / `$hasPointOnBlockContainer` / `$normalizeBlockContainerSelection`); `BlockContainerNodeInserter` refactored to reuse them (no behavior change).

## Tests

- `test/browser/tests/formatting/line_break_with_caret_on_quote.test.js` — Enter/Shift+Enter into a quote element point.
- `test/browser/tests/paste/paste_url_with_caret_on_quote.test.js` — URL paste into a quote element point.

Both confirmed **red on `main`** (throw the dev-mode #211 "QuoteNode … expected a block ElementNode ancestor") and **green with the fix**. Lint clean; paste + formatting + attachments suites pass.

## Validation note

This #211 state — the caret as an element point on the quote node — **cannot be produced by a mouse/keyboard click** (Lexical normalizes DOM selections to leaf text nodes); it only arises from internal editing operations, which is why the regression tests drive it programmatically. Validation here is the red/green tests above, which reproduce the exact #211 and match the real Sentry stack.

---
**Cards:** [#211 10001774941](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/10001774941) · [#222 10001775137](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/10001775137)
