### PR TITLE
Pasting inline content onto a selected attachment crashes with Lexical error #99

### DIFF
--- a/src/editor/contents/node_inserter/node_selection_node_inserter.js
+++ b/src/editor/contents/node_inserter/node_selection_node_inserter.js
@@ -1,4 +1,5 @@
 import { $isNodeSelection } from "lexical"
+import { $makeSafeForRoot } from "../../../helpers/lexical_helper"
 import BaseNodeInserter from "./base_node_inserter"
 
 export default class NodeSelectionNodeInserter extends BaseNodeInserter {
@@ -7,13 +8,19 @@ export default class NodeSelectionNodeInserter extends BaseNodeInserter {
   }
 
   insertNodes(nodes) {
-    const selectedNodes = this.selection.getNodes()
-
     // Overrides Lexical's default behavior of _removing_ the currently selected nodes
     // https://github.com/facebook/lexical/blob/v0.38.2/packages/lexical/src/LexicalSelection.ts#L412
-    let lastNode = selectedNodes.at(-1)
+    let lastNode = this.selection.getNodes().at(-1)
+
     for (const node of nodes) {
-      lastNode = lastNode.insertAfter(node)
+      // Inserting after a top-level node would make this one a root child. Inline nodes
+      // can't live there (Lexical error #99), so wrap them in their required parent first.
+      const nodeToInsert = this.#insertsIntoRoot(lastNode) ? $makeSafeForRoot(node) : node
+      lastNode = lastNode.insertAfter(nodeToInsert)
     }
+  }
+
+  #insertsIntoRoot(node) {
+    return node.is(node.getTopLevelElement())
   }
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -32,8 +32,12 @@ export function $isSafeForRoot(node) {
 export function $makeSafeForRoot(node) {
   if ($isSafeForRoot(node)) {
     return node
-  } else {
+  } else if (node.getParent()) {
     return $wrapNodeInElement(node, () => node.createParentElementNode())
+  } else {
+    // Detached nodes (e.g. clipboard nodes being inserted) can't be `replace`d in place,
+    // so append them into a fresh required parent instead.
+    return node.createParentElementNode().append(node)
   }
 }
 

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -40,6 +40,47 @@ test.describe("Uploading into an unsupported selection", () => {
     await expect(editor.content.locator("figure.attachment")).toHaveCount(2, { timeout: 10_000 })
   })
 
+  test("inserting inline content while an attachment is node-selected keeps the root valid", async ({ page, editor }) => {
+    await editor.setValue(`${pdfAttachment}<p>pasted text</p>`)
+    await editor.flush()
+
+    const figure = editor.content.locator("figure.attachment")
+    await expect(figure).toBeVisible()
+
+    await figure.click()
+    await expect(figure).toHaveClass(/node--selected/)
+
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    // Detach the existing text node and re-insert it through the node-selection path,
+    // mimicking inline clipboard nodes being inserted while the attachment is selected.
+    const error = await page.evaluate(() => {
+      const editorElement = document.querySelector("lexxy-editor")
+      let message = null
+      editorElement.editor.update(() => {
+        const root = editorElement.editor.getEditorState()._nodeMap.get("root")
+        const paragraph = root.getChildren().find((child) => child.getType() === "paragraph")
+        const textNode = paragraph.getFirstChild()
+        textNode.remove()
+        try {
+          editorElement.contents.insertAtCursor(textNode)
+        } catch (err) {
+          message = err.message
+        }
+      })
+      return message
+    })
+
+    await editor.flush()
+
+    expect(error).toBeNull()
+    expect(errors).toEqual([])
+    await expect(figure).toHaveCount(1)
+    await expect(editor.content).toContainText("pasted text")
+    expect(await editor.plainTextValue()).toContain("pasted text")
+  })
+
   // "Cannot read properties of null (reading 'selectEnd')":
   // uploading a file while the caret sits in an empty code block leaves no node
   // at the caret, and CodeNodeInserter crashed trying to select it. Driven through


### PR DESCRIPTION
## Problem

Sentry BC3-JS-N562 — "Minified Lexical error #99" — is one of the highest-volume BC5 production exceptions (~85k occurrences / 1071 users in 14 days). Error #99 is "Only element or decorator nodes can be inserted in to the root node."

## Root cause

When a top-level node (e.g. an attachment) is node-selected, `NodeSelectionNodeInserter` inserted every node from the pasted/dropped content directly after the selected one via `insertAfter`. Inline nodes (a text node, a link) can't be direct children of the root, so the first inline node dropped straight into the root and Lexical threw error #99.

## Fix

`NodeSelectionNodeInserter` now wraps any node that isn't safe for the root in its required parent before inserting it, reusing the existing **`$makeSafeForRoot`** helper (thanks @samuelpecher) — which respects each node's declared element parent type (`createParentElementNode`) and leaves element/decorator nodes untouched.

`$makeSafeForRoot` previously assumed an already-attached node (it wraps via `$wrapNodeInElement`, which `replace`s in place). Clipboard nodes being inserted have no parent yet, so it now handles the detached case by appending the node into a fresh required parent.

## Testing

- Added a Playwright regression test under `attachments/upload_into_unsupported_selection.test.js` that node-selects an attachment, inserts an inline text node through the node-selection path, and asserts no error and valid content. Verified it fails with error #99 on the pre-fix code and passes after.
- Regression test: 40/40 on chromium, 24/24 on firefox (`--repeat-each`).
- Full `attachments` and `paste` suites pass on chromium; `yarn lint` clean.

Supersedes the stale #1124, which patched the pre-refactor monolithic `node_inserter.js` and no longer merges (the inserters were since split into `node_inserter/`).

Sentry: https://basecamp.sentry.io/issues/7352220817/ (BC3-JS-N562)

Card: https://3.basecamp.com/2914079/buckets/41746046/card_tables/cards/10001773098

## How to reproduce

The crash needs two specific conditions — missing either one is why it can look hard to hit:

1. **Insert an attachment** (upload an image or any file).
2. **Node-select it**: single-click the attachment so the whole figure gets the selection outline (a `NodeSelection`). A blinking caret next to it is a *range* selection and won't trigger this.
3. **Paste inline content** onto it — e.g. select a few words **mid-sentence** on any web page and copy, then paste. The clipboard must carry inline HTML.
   - Plain text, a bare URL, or whole-paragraph copies do **not** crash: Lexical wraps those in a paragraph (already safe for the root). It's specifically a bare inline run (text / link / span with no block wrapper) that lands directly in the root.

**Before:** the editor throws Lexical error #99 ("Only element or decorator nodes can be inserted in to the root node") and the editor breaks.
**After:** the inline content is wrapped in its required parent and inserted as a root sibling after the attachment; element/decorator nodes still insert directly. No crash.