### PR TITLE
Fix Firefox-only attachment test flakes (valid, figure-filling fallback PNG)

### DIFF
--- a/test/browser/helpers/active_storage_mock.js
+++ b/test/browser/helpers/active_storage_mock.js
@@ -1,9 +1,13 @@
 // Mocks the Active Storage direct upload endpoints using Playwright route interception.
 // Returns a handle for asserting that the expected calls were made.
 
-// 1×1 transparent PNG used as a fallback when the fixture file doesn't exist on disk.
-const TRANSPARENT_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAAlwSFlzAAAWJQAAFiUBSVIk8AAAAA0lEQVQI12P4z8BQDwAEgAF/QualzQAAAABJRU5ErkJggg==",
+// Fallback preview image. Must be byte-valid — Firefox rejects malformed data and
+// fires <img> onerror, reverting the preview swap to the file icon (a flake). Must
+// also be wider than the figure's min-inline-size (10ch); a sub-figure image leaves
+// the figure chrome on top of the click point, so Firefox reports the figure as
+// intercepting pointer events when tests click the preview img.
+const FALLBACK_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAHgAAABaCAYAAABzAJLvAAAA6ElEQVR4nO3RwQkAIBDAMMe+Ed1KxxBqHvkXumb2oWu9DsBgDMbgTxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcdwGOw47/2hYVfQAAAABJRU5ErkJggg==",
   "base64"
 )
 
@@ -106,16 +110,16 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
         return
       }
 
-      // Serve the fixture file if it exists, otherwise return a 1×1 transparent PNG.
+      // Serve the fixture file if it exists, otherwise the small FALLBACK_PNG.
       // The fixture file is only needed when delayBlobResponses is true (preview swap test).
-      // For other tests, always serve the tiny PNG to avoid layout shifts from full-size
-      // images that can break position-dependent tests like drag and drop.
+      // The fallback keeps full-size images out of other tests to avoid layout shifts
+      // that can break position-dependent tests like drag and drop.
       const fs = await import("fs")
       const fixturePath = `test/fixtures/files/${filename}`
       if (delayBlobResponses && fs.existsSync(fixturePath)) {
         await route.fulfill({ status: 200, contentType, path: fixturePath })
       } else {
-        await route.fulfill({ status: 200, contentType: "image/png", body: TRANSPARENT_PNG })
+        await route.fulfill({ status: 200, contentType: "image/png", body: FALLBACK_PNG })
       }
     }
 


### PR DESCRIPTION
The Active Storage test mock's fallback PNG was malformed. **Firefox** (not Chromium/WebKit) rejects it with "Image corrupt or truncated" and fires the `<img>` onerror, which reverts the deferred-preview swap back to the file icon — so the deferred-preview attachment tests flaked on Firefox CI.

A byte-valid **1×1** PNG fixes that flake but introduces a worse, consistent failure: the preview img renders at its 1px intrinsic size, far smaller than the figure's `min-inline-size` (10ch), so the figure chrome sits on top of the click point. Firefox then reports the figure as *intercepting pointer events* whenever a test clicks the preview img (delete with keyboard, delete with delete button, gallery creation, etc.).

Fix: serve a **120×90** valid PNG — wider than the figure, so the img fills the click target on every browser, while staying small enough to avoid the layout shifts the fallback exists to prevent.

## How to reproduce

On `main`, run the attachment/gallery browser tests on Firefox:

```
npx playwright test --config test/browser/playwright.config.js --project=firefox \
  test/browser/tests/attachments/
```

Tests that click an uploaded image's preview (`delete attachment with keyboard`, `delete attachment with delete button`, gallery creation) fail with `<figure …> intercepts pointer events`. With this change they pass.

Verified locally on Firefox: attachments + gallery 114/114 (`--repeat-each=3`), drag/drop suites 48/48, and Chromium attachments 96/96 — no source or timing changes needed.