### PR TITLE
Fix flaky deferred-preview system test (assert the swap)

### DIFF
--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -13,17 +13,14 @@ class AttachmentsTest < ApplicationSystemTestCase
     assert_image_figure_attachment content_type: "image/png", caption: "example.png"
   end
 
-  test "upload previewable attachment shows file icon while preview loads" do
+  test "upload previewable attachment swaps in the preview" do
     attach_file file_fixture("dummy.pdf") do
       click_on "Upload files"
     end
 
-    # Previewable non-image uploads (PDFs) show as file icon initially while
-    # the server generates the thumbnail. The preview swaps in once ready.
-    assert_figure_attachment content_type: "application/pdf" do
-      assert_selector ".attachment__icon"
-      assert_selector ".attachment__name", text: "dummy.pdf"
-    end
+    # A previewable non-image (PDF) shows a file icon while the server generates
+    # the thumbnail, then swaps in the preview image once it loads.
+    assert_selector "figure.attachment--preview[data-content-type='application/pdf'] .attachment__container img", wait: 10
   end
 
   test "upload image via image button" do


### PR DESCRIPTION
Fixes the pre-existing CI flake in `test/system/attachments_test.rb` (the "Rails system tests (Rails 8.1 (no adapter))" job, also seen on #1128's runs).

## Root cause
The test "…shows file icon while preview loads" asserted the **transient file-icon placeholder** shown while a previewable PDF's preview generates. Under CI load the preview loads and swaps in before Capybara asserts the placeholder → intermittent failure.

## Fix
Assert the **swap outcome** instead — the preview image appears (`figure.attachment--preview … .attachment__container img`) via the real preload-and-swap path. This is deterministic (Capybara waits for the final state) and **keeps the default preload-and-swap path covered end-to-end** (no `preview_status_url` injection, no sleep, no path switch). It drops the explicit "placeholder shows first" check (that transient state is covered deterministically by the Playwright `preview_status_url.test.js` "without preview_status_url" cases via `delayBlobResponses`).

## Verification
Ran **12× locally** → all green. rubocop clean. (Test-only change.)