### PR TITLE
Add yarn release:alpha (publish under the alpha dist-tag)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "test:browser:headed": "npx playwright test --config test/browser/playwright.config.js --headed",
     "test:browser:debug": "npx playwright test --config test/browser/playwright.config.js --debug",
     "prerelease": "yarn build:npm",
-    "release": "yarn build:npm && yarn publish"
+    "release": "yarn build:npm && yarn publish",
+    "release:alpha": "yarn build:npm && yarn publish --tag alpha"
   },
   "dependencies": {
     "@lexical/clipboard": "^0.44.0",


### PR DESCRIPTION
## Problem

`yarn release` runs `yarn publish` with no `--tag`, so npm marks whatever is published as **`latest`** — even prerelease versions. This has already happened: the package's dist-tags currently read

```
latest:  0.9.19-alpha.1          ← a prerelease is the default install
canary:  0.9.19-alpha.autocapitalize
beta:    0.9.6-beta.bc0
next:    0.9.15-beta.next-0
```

so a plain `npm install @37signals/lexxy` resolves to an alpha.

## Change

Add a `release:alpha` script that mirrors `release` but publishes under the **`alpha`** dist-tag:

```json
"release":        "yarn build:npm && yarn publish",
"release:alpha":  "yarn build:npm && yarn publish --tag alpha"
```

`yarn publish --tag alpha` (yarn classic 1.22) still prompts for the version bump and pushes the git tag exactly like `release`, but publishes under `alpha` and leaves `latest` untouched.

- `npm install @37signals/lexxy` → stable (`latest`)
- `npm install @37signals/lexxy@alpha` → the prerelease

## How to use

```
yarn release:alpha
# bump to e.g. 0.9.19-alpha.2 when prompted
```

## Follow-up (not in this PR)

This stops *future* alphas from hijacking `latest`, but the current `latest → 0.9.19-alpha.1` is already live. Repoint it once the intended stable version is known:

```
npm dist-tag add @37signals/lexxy <stable-version> latest
```