### PR TITLE
Abort in-flight uploads when their attachment is removed

### DIFF
--- a/src/editor/attachments/upload_requests.js
+++ b/src/editor/attachments/upload_requests.js
@@ -1,0 +1,23 @@
+export class UploadRequests {
+  #requestsByKey = new Map()
+
+  track(key, request) {
+    this.#requestsByKey.set(key, request)
+  }
+
+  forget(key) {
+    this.#requestsByKey.delete(key)
+  }
+
+  abort(key) {
+    const request = this.#requestsByKey.get(key)
+    if (request) {
+      this.#requestsByKey.delete(key)
+      request.abort()
+    }
+  }
+
+  clear() {
+    this.#requestsByKey.clear()
+  }
+}

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -15,6 +15,7 @@ import { registerMarkdownLeadingTagHandler } from "../editor/markdown/leading_ta
 
 import theme from "../config/theme"
 import { HorizontalDividerNode } from "../nodes/horizontal_divider_node"
+import { UploadRequests } from "../editor/attachments/upload_requests"
 import { CommandDispatcher } from "../editor/command_dispatcher"
 import Selection from "../editor/selection"
 import { createElement, dispatch, generateDomId, parseHtml } from "../helpers/html_helper"
@@ -62,11 +63,16 @@ export class LexicalEditorElement extends HTMLElement {
 
   #validity = new Map()
   #validationTextArea = document.createElement("textarea")
+  #uploadRequests
 
   constructor() {
     super()
     this.internals = this.attachInternals()
     this.internals.role = "presentation"
+  }
+
+  get uploadRequests() {
+    return this.#uploadRequests
   }
 
   connectedCallback() {
@@ -89,6 +95,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.#disposables.push(this.clipboard)
 
     this.adapter = new BrowserAdapter()
+    this.#uploadRequests = new UploadRequests()
 
     const commandDispatcher = CommandDispatcher.configureFor(this)
     this.#disposables.push(commandDispatcher)
@@ -869,6 +876,7 @@ export class LexicalEditorElement extends HTMLElement {
   #reset() {
     this.#dispose()
     this.#resetValidity()
+    this.#uploadRequests?.clear()
     this.editorContentElement?.remove()
     this.editorContentElement = null
 

--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -48,11 +48,12 @@ export class AttachmentsExtension extends LexxyExtension {
 
   #handleUploadMutations(mutations) {
     const previousUploadsCount = this.#uploadsCount
-    for (const [ , mutation ] of mutations) {
+    for (const [ key, mutation ] of mutations) {
       if (mutation === "created") {
         this.#uploadsCount++
       } else if (mutation === "destroyed") {
         this.#uploadsCount--
+        this.editorElement.uploadRequests.abort(key)
       }
     }
 

--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -151,6 +151,8 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
     this.#dispatchEvent("lexxy:upload-start", { file: this.file })
 
     upload.create((error, blob) => {
+      this.#forgetUploadRequest()
+
       if (error) {
         this.#dispatchEvent("lexxy:upload-end", { file: this.file, error })
         this.#handleUploadError(error)
@@ -173,10 +175,24 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
       directUploadWillStoreFileWithXHR: (request) => {
         if (shouldAuthenticateUploads) request.withCredentials = true
 
+        this.#rememberUploadRequest(request)
+
         const uploadProgressHandler = (event) => this.#handleUploadProgress(event, request)
         request.upload.addEventListener("progress", uploadProgressHandler)
       }
     }
+  }
+
+  #forgetUploadRequest() {
+    this.#editorElement.uploadRequests.forget(this.getKey())
+  }
+
+  #rememberUploadRequest(request) {
+    this.#editorElement.uploadRequests.track(this.getKey(), request)
+  }
+
+  get #editorElement() {
+    return this.editor.getRootElement()?.closest("lexxy-editor")
   }
 
   #setUploadStarted() {

--- a/test/browser/helpers/active_storage_mock.js
+++ b/test/browser/helpers/active_storage_mock.js
@@ -11,7 +11,7 @@ const FALLBACK_PNG = Buffer.from(
   "base64"
 )
 
-export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true, previewReadyStatus = 410, failBlobResponses = false } = {}) {
+export async function mockActiveStorageUploads(page, { delayBlobResponses = false, delayDirectUploadResponse = false, uploadDelayMs = 0, holdFileUploads = false, includePreviewStatusUrl = false, previewStatusInitiallyProcessing = true, previewReadyStatus = 410, failBlobResponses = false } = {}) {
   let blobCounter = 0
   const calls = { blobCreations: [], fileUploads: [], previewStatusRequests: [], previewUrlRequests: [] }
   const pendingBlobRoutes = []
@@ -161,6 +161,11 @@ export async function mockActiveStorageUploads(page, { delayBlobResponses = fals
       url: request.url(),
       contentType: request.headers()["content-type"],
     })
+
+    // When holdFileUploads is true, the PUT is never fulfilled, keeping the
+    // upload in flight. This lets tests assert that trashing an attachment
+    // aborts the connection (Playwright reports an aborted request as failed).
+    if (holdFileUploads) return
 
     if (uploadDelayMs > 0) {
       await page.waitForTimeout(uploadDelayMs)

--- a/test/browser/tests/attachments/upload_abort_on_delete.test.js
+++ b/test/browser/tests/attachments/upload_abort_on_delete.test.js
@@ -1,0 +1,40 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+test.describe("Aborting an in-flight upload when its attachment is removed", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("trashing an uploading attachment aborts the upload connection", async ({ page, editor }) => {
+    await mockActiveStorageUploads(page, { holdFileUploads: true })
+
+    const diskUploadStarted = page.waitForRequest((request) =>
+      request.url().includes("/rails/active_storage/disk/") && request.method() === "PUT",
+    )
+
+    const abortedRequests = []
+    page.on("requestfailed", (request) => {
+      if (request.url().includes("/rails/active_storage/disk/")) {
+        abortedRequests.push(request)
+      }
+    })
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+
+    const figure = page.locator("figure.attachment")
+    await expect(figure).toBeVisible({ timeout: 10_000 })
+    await expect(figure.locator("progress")).toBeVisible()
+
+    await diskUploadStarted
+
+    await figure.locator("img").click()
+    await editor.send("Delete")
+    await expect(figure).toHaveCount(0)
+
+    await expect.poll(() => abortedRequests.length, { timeout: 10_000 }).toBeGreaterThan(0)
+  })
+})

--- a/test/javascript/unit/editor/attachments/upload_requests.test.js
+++ b/test/javascript/unit/editor/attachments/upload_requests.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from "vitest"
+import { UploadRequests } from "src/editor/attachments/upload_requests"
+
+function fakeRequest() {
+  return { abort: vi.fn() }
+}
+
+describe("UploadRequests", () => {
+  test("aborts a tracked request and forgets it", () => {
+    const uploadRequests = new UploadRequests()
+    const request = fakeRequest()
+
+    uploadRequests.track("node-1", request)
+    uploadRequests.abort("node-1")
+
+    expect(request.abort).toHaveBeenCalledTimes(1)
+  })
+
+  test("only aborts the request for the given key", () => {
+    const uploadRequests = new UploadRequests()
+    const first = fakeRequest()
+    const second = fakeRequest()
+
+    uploadRequests.track("node-1", first)
+    uploadRequests.track("node-2", second)
+    uploadRequests.abort("node-1")
+
+    expect(first.abort).toHaveBeenCalledTimes(1)
+    expect(second.abort).not.toHaveBeenCalled()
+  })
+
+  test("does not abort again after the request has been aborted", () => {
+    const uploadRequests = new UploadRequests()
+    const request = fakeRequest()
+
+    uploadRequests.track("node-1", request)
+    uploadRequests.abort("node-1")
+    uploadRequests.abort("node-1")
+
+    expect(request.abort).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not abort a forgotten request", () => {
+    const uploadRequests = new UploadRequests()
+    const request = fakeRequest()
+
+    uploadRequests.track("node-1", request)
+    uploadRequests.forget("node-1")
+    uploadRequests.abort("node-1")
+
+    expect(request.abort).not.toHaveBeenCalled()
+  })
+
+  test("aborting an unknown key is a no-op", () => {
+    const uploadRequests = new UploadRequests()
+
+    expect(() => uploadRequests.abort("missing")).not.toThrow()
+  })
+})


### PR DESCRIPTION
## What

Cancelling an attachment upload — trashing it before it finishes — left the upload running in the background until it completed or timed out. Now removing an in-progress attachment aborts the upload immediately (matching how Docs & Files behaves).

## How

- The upload node captures the in-flight `XMLHttpRequest` via Active Storage's `directUploadWillStoreFileWithXHR` delegate.
- In-flight requests are tracked by a small `UploadRequests` class (`src/editor/attachments/upload_requests.js`) — one instance per editor, owned by the `<lexxy-editor>` element and exposed as `editor.uploadRequests`, keyed by node key (the only handle the destroyed-node mutation gives us).
- When the upload node is destroyed (its attachment is removed), the attachments extension calls `editor.uploadRequests.abort(key)`, aborting the captured request. Completed uploads forget their request, and the structure is cleared on editor reset.

## Tests

- Vitest unit test for `UploadRequests` (track / forget / abort / clear).
- Playwright regression test that holds an Active Storage disk upload open, trashes the attachment mid-flight, and asserts the request is aborted.

Basecamp card: https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/10002095083