### PR TITLE
Filter prompts by the word following an inserted trigger

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -197,15 +197,25 @@ export default class Contents {
       const fullText = anchorNode.getTextContent()
       const offset = anchor.offset
 
-      const textBeforeCursor = fullText.slice(0, offset)
-
-      const lastIndex = textBeforeCursor.lastIndexOf(string)
+      const lastIndex = fullText.slice(0, offset).lastIndexOf(string)
       if (lastIndex !== -1) {
-        result = textBeforeCursor.slice(lastIndex + string.length)
+        result = fullText.slice(lastIndex + string.length, this.#endOffsetAt(fullText, offset))
       }
     })
 
     return result
+  }
+
+  // The query runs from the trigger up to the next whitespace, even when the
+  // cursor sits inside an existing word — inserting "@" before "Jack" must
+  // filter by "Jack" rather than treating the prompt as empty.
+  #endOffsetAt(fullText, cursorOffset) {
+    const whitespaceOffset = fullText.slice(cursorOffset).search(/\s/)
+    if (whitespaceOffset === -1) {
+      return fullText.length
+    } else {
+      return cursorOffset + whitespaceOffset
+    }
   }
 
   containsTextBackUntil(string) {
@@ -238,10 +248,10 @@ export default class Contents {
     const { anchorNode, offset } = this.#getTextAnchorData()
     if (!anchorNode) return
 
-    const lastIndex = this.#findLastIndexBeforeCursor(anchorNode, offset, stringToReplace)
+    const lastIndex = this.#findReplacementStart(anchorNode, offset, stringToReplace)
     if (lastIndex === -1) return
 
-    this.#performTextReplacement(anchorNode, selection, offset, lastIndex, replacementNodes)
+    this.#performTextReplacement(anchorNode, selection, lastIndex, stringToReplace, replacementNodes)
   }
 
   uploadFiles(files, { selectLast } = {}) {
@@ -528,19 +538,27 @@ export default class Contents {
     return { anchorNode, offset: anchor.offset }
   }
 
-  #findLastIndexBeforeCursor(anchorNode, offset, stringToReplace) {
+  // The replaced span can straddle the cursor (e.g. "@Jack" when "@" was just
+  // inserted before "Jack"), so we anchor on the trigger before the cursor and
+  // verify the whole string matches there rather than searching text up to it.
+  #findReplacementStart(anchorNode, offset, stringToReplace) {
     const fullText = anchorNode.getTextContent()
-    const textBeforeCursor = fullText.slice(0, offset)
-    return textBeforeCursor.lastIndexOf(stringToReplace)
+    const triggerIndex = fullText.slice(0, offset).lastIndexOf(stringToReplace[0])
+
+    if (triggerIndex !== -1 && fullText.startsWith(stringToReplace, triggerIndex)) {
+      return triggerIndex
+    } else {
+      return -1
+    }
   }
 
-  #performTextReplacement(anchorNode, selection, offset, lastIndex, replacementNodes) {
+  #performTextReplacement(anchorNode, selection, startIndex, stringToReplace, replacementNodes) {
     const fullText = anchorNode.getTextContent()
-    const textBeforeString = fullText.slice(0, lastIndex)
-    const textAfterCursor = fullText.slice(offset)
+    const textBeforeString = fullText.slice(0, startIndex)
+    const textAfterString = fullText.slice(startIndex + stringToReplace.length)
 
     const textNodeBefore = this.#cloneTextNodeFormatting(anchorNode, selection, textBeforeString)
-    const textNodeAfter = this.#cloneTextNodeFormatting(anchorNode, selection, textAfterCursor || " ")
+    const textNodeAfter = this.#cloneTextNodeFormatting(anchorNode, selection, textAfterString || " ")
 
     anchorNode.replace(textNodeBefore)
 
@@ -548,7 +566,7 @@ export default class Contents {
     lastInsertedNode.insertAfter(textNodeAfter)
 
     this.#appendLineBreakIfNeeded(textNodeAfter.getParentOrThrow())
-    const cursorOffset = textAfterCursor ? 0 : 1
+    const cursorOffset = textAfterString ? 0 : 1
     textNodeAfter.select(cursorOffset, cursorOffset)
   }
 

--- a/test/browser/tests/prompts/at_inserted_before_word.test.js
+++ b/test/browser/tests/prompts/at_inserted_before_word.test.js
@@ -1,0 +1,40 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("@ inserted before an existing word", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-filtering.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("filters by the word that follows the trigger", async ({ page, editor }) => {
+    await editor.send("Jack")
+    await editor.send("Home")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items).toHaveCount(2)
+
+    const names = await items.allTextContents()
+    expect(names).toEqual([ "Jack Franklin", "Clara Jackson" ])
+  })
+
+  test("replaces the trigger and the following word with the selected mention", async ({ page, editor }) => {
+    await editor.send("Jack")
+    await editor.send("Home")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    await expect(popover).not.toBeVisible()
+    expect(await editor.plainTextValue()).toContain("Jack Franklin")
+    expect(await editor.plainTextValue()).not.toContain("@")
+  })
+})


### PR DESCRIPTION
## Problem

Basecamp card [9939048464](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9939048464): **[Mentions] Mentions pull entire project list when adding @ afterwards.**

In BC4, if you type a user's name and then go back and insert an `@` in front of it, the prompt filters to only the names/groups matching the already-typed text. In BC5 (Lexxy), doing the same shows the entire project member list — the text after the `@` was ignored as a filter query.

## Root cause

The prompt's filter query is computed by `Contents#textBackUntil(trigger)`, which only looked at text *before* the cursor (`fullText.slice(0, offset)`). When you insert `@` at the start of an existing word, the cursor sits right after the `@` and before the word, so there was no query text and the source filtered on an empty string — returning everyone.

## Fix

- `textBackUntil` now extends the query from the trigger up to the next whitespace, spanning the cursor. Inserting `@` before `Jack` yields the query `Jack`.
- `replaceTextBackUntil` was updated so selecting an option replaces the full `@word` span (which can straddle the cursor), not just the `@` before the cursor. It now anchors on the trigger and replaces `trigger + query`.

Normal typing (`@ja|`) is unaffected since there's no trailing word after the cursor.

## Tests

Added `test/browser/tests/prompts/at_inserted_before_word.test.js` covering both filtering by the following word and replacing the full `@word` span on selection.