### PR TITLE
Allow dragging mentions to reorder them within a line

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -249,6 +249,22 @@
     opacity: 0.4;
   }
 
+  [data-lexxy-decorator][draggable] {
+    cursor: grab;
+  }
+
+  [data-lexxy-decorator].lexxy-dragging {
+    opacity: 0.4;
+  }
+
+  .lexxy-drop-caret {
+    background-color: var(--lexxy-focus-ring-color);
+    border-radius: 1px;
+    inline-size: 2px;
+    pointer-events: none;
+    position: fixed;
+  }
+
   [class*="lexxy-drop-target--"] {
     position: relative;
   }

--- a/src/editor/attachments/custom/drag_and_drop.js
+++ b/src/editor/attachments/custom/drag_and_drop.js
@@ -1,0 +1,234 @@
+import {
+  $createRangeSelectionFromDom,
+  $getNodeByKey,
+  $setSelection,
+  COMMAND_PRIORITY_HIGH,
+  DRAGSTART_COMMAND,
+  DROP_COMMAND
+} from "lexical"
+
+import { $isCustomActionTextAttachmentNode } from "../../../nodes/custom_action_text_attachment_node"
+import { caretFromPoint, caretRect } from "../../../helpers/caret_helpers"
+import { createElement } from "../../../helpers/html_helper"
+import { ListenerBin } from "../../../helpers/listener_helper"
+
+const MIME_TYPE = "application/x-lexxy-custom-attachment-key"
+
+// Custom inline attachments reorder by dropping at a text caret, unlike block
+// attachments which insert between blocks or into galleries.
+export class CustomAttachmentDragAndDrop {
+  #editor
+  #draggedNodeKey = null
+  #draggingRafId = null
+  #dragOverRafId = null
+  #dropIndicator = null
+  #listeners = new ListenerBin()
+
+  constructor(editor) {
+    this.#editor = editor
+
+    // Register at HIGH priority to intercept before the base @lexical/rich-text
+    // handlers, which consume drag events. The block-attachment handler also
+    // registers here but bails for inline custom attachments, so we get our turn.
+    this.#listeners.track(
+      editor.registerCommand(DRAGSTART_COMMAND, (event) => this.#handleDragStart(event), COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(DROP_COMMAND, (event) => this.#handleDrop(event), COMMAND_PRIORITY_HIGH)
+    )
+
+    this.#listeners.track(editor.registerRootListener((root, prevRoot) => {
+      if (prevRoot) {
+        prevRoot.removeEventListener("dragover", this.#onDragOver)
+        prevRoot.removeEventListener("dragend", this.#onDragEnd)
+      }
+      if (root) {
+        root.addEventListener("dragover", this.#onDragOver)
+        root.addEventListener("dragend", this.#onDragEnd)
+      }
+    }))
+  }
+
+  destroy() {
+    this.#cleanup()
+    this.#dropIndicator?.remove()
+    this.#dropIndicator = null
+    this.#listeners.dispose()
+  }
+
+  #handleDragStart(event) {
+    const attachment = this.#customAttachmentElementFrom(event.target)
+    if (!attachment) return false
+
+    this.#draggedNodeKey = attachment.dataset.lexicalNodeKey
+    event.dataTransfer.setData(MIME_TYPE, this.#draggedNodeKey)
+    event.dataTransfer.effectAllowed = "move"
+
+    this.#draggingRafId = requestAnimationFrame(() => {
+      this.#draggingRafId = null
+      attachment.classList.add("lexxy-dragging")
+    })
+
+    return true
+  }
+
+  #onDragOver = (event) => {
+    if (!this.#draggedNodeKey) return
+
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+
+    if (!this.#dragOverRafId) {
+      this.#dragOverRafId = requestAnimationFrame(() => {
+        this.#dragOverRafId = null
+        this.#updateDropIndicator(event)
+      })
+    }
+  }
+
+  #onDragEnd = () => {
+    this.#cleanup()
+  }
+
+  #handleDrop(event) {
+    if (!this.#draggedNodeKey) return false
+
+    event.preventDefault()
+
+    const dropPoint = this.#resolveDropPoint(event)
+    const draggedKey = this.#draggedNodeKey
+    this.#cleanup()
+
+    if (dropPoint) {
+      this.#moveAttachment(draggedKey, dropPoint)
+    }
+
+    return true
+  }
+
+  #resolveDropPoint(event) {
+    const rootElement = this.#editor.getRootElement()
+    if (!rootElement) return null
+
+    const caret = caretFromPoint(event.clientX, event.clientY)
+    if (!caret || !rootElement.contains(caret.node)) return null
+
+    // A caret on the root itself points between blocks. Mentions behave like text:
+    // they only drop onto an existing line, so snap to the nearest one.
+    if (caret.node === rootElement) {
+      return this.#nearestLineCaret(rootElement, event.clientY)
+    } else {
+      return caret
+    }
+  }
+
+  #nearestLineCaret(rootElement, clientY) {
+    let nearestLine = null
+    let nearestDistance = Infinity
+
+    for (const line of rootElement.children) {
+      const rect = line.getBoundingClientRect()
+      const distance = Math.min(Math.abs(clientY - rect.top), Math.abs(clientY - rect.bottom))
+      if (distance < nearestDistance) {
+        nearestDistance = distance
+        nearestLine = line
+      }
+    }
+
+    if (!nearestLine) return null
+
+    const rect = nearestLine.getBoundingClientRect()
+    if (clientY < rect.top) {
+      return { node: nearestLine, offset: 0 }
+    } else {
+      return { node: nearestLine, offset: nearestLine.childNodes.length }
+    }
+  }
+
+  #moveAttachment(draggedKey, dropPoint) {
+    this.#editor.update(() => {
+      const draggedNode = $getNodeByKey(draggedKey)
+      if (!$isCustomActionTextAttachmentNode(draggedNode)) return
+
+      const selection = $createRangeSelectionFromDom({
+        anchorNode: dropPoint.node,
+        anchorOffset: dropPoint.offset,
+        focusNode: dropPoint.node,
+        focusOffset: dropPoint.offset
+      }, this.#editor)
+      if (!selection) return
+
+      $setSelection(selection)
+
+      draggedNode.remove()
+      selection.insertNodes([ draggedNode ])
+    })
+  }
+
+  #updateDropIndicator(event) {
+    this.#hideCaret()
+
+    const dropPoint = this.#resolveDropPoint(event)
+    if (dropPoint) this.#showCaret(this.#caretRectFor(dropPoint))
+  }
+
+  #caretRectFor({ node, offset }) {
+    const rect = caretRect(node, offset)
+    if (rect) return rect
+
+    // A blank line has no text to measure, so fall back to the line's own box.
+    const line = node.nodeType === Node.TEXT_NODE ? node.parentElement : node
+    if (!line) return null
+
+    const lineRect = line.getBoundingClientRect()
+    return { left: lineRect.left, top: lineRect.top, height: lineRect.height }
+  }
+
+  #showCaret(rect) {
+    if (!rect) return
+
+    const caret = this.#ensureCaretIndicator()
+    caret.style.blockSize = `${rect.height}px`
+    caret.style.insetInlineStart = `${rect.left}px`
+    caret.style.insetBlockStart = `${rect.top}px`
+  }
+
+  #ensureCaretIndicator() {
+    this.#dropIndicator ||= createElement("div", { className: "lexxy-drop-caret" })
+
+    this.#editorElement().appendChild(this.#dropIndicator)
+    this.#dropIndicator.style.display = "block"
+    return this.#dropIndicator
+  }
+
+  #editorElement() {
+    return this.#editor.getRootElement().closest("lexxy-editor")
+  }
+
+  #hideCaret() {
+    if (this.#dropIndicator) this.#dropIndicator.style.display = "none"
+  }
+
+  #customAttachmentElementFrom(target) {
+    return target?.closest?.("[data-lexxy-decorator][data-lexical-node-key]")
+  }
+
+  #cleanup() {
+    if (this.#draggedNodeKey) {
+      const rootElement = this.#editor.getRootElement()
+      const attachment = rootElement?.querySelector(`[data-lexical-node-key="${this.#draggedNodeKey}"]`)
+      attachment?.classList.remove("lexxy-dragging")
+    }
+
+    this.#hideCaret()
+    this.#draggedNodeKey = null
+
+    if (this.#draggingRafId) {
+      cancelAnimationFrame(this.#draggingRafId)
+      this.#draggingRafId = null
+    }
+
+    if (this.#dragOverRafId) {
+      cancelAnimationFrame(this.#dragOverRafId)
+      this.#dragOverRafId = null
+    }
+  }
+}

--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -417,7 +417,7 @@ export class CommandDispatcher {
   }
 
   #isInternalDrag(event) {
-    return event.dataTransfer?.types.includes("application/x-lexxy-node-key")
+    return event.dataTransfer?.types.some((type) => type.startsWith("application/x-lexxy-"))
   }
 
   #handleTabKey(event) {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -41,6 +41,7 @@ import { AttachmentsExtension } from "../extensions/attachments_extension.js"
 import { FormatEscapeExtension } from "../extensions/format_escape_extension.js"
 import { LinkOpenerExtension } from "../extensions/link_opener_extension.js"
 import { PreventLexicalTripleClickExtension } from "../extensions/prevent_lexical_triple_click_extension.js"
+import { CustomAttachmentDragAndDropExtension } from "../extensions/custom_attachment_drag_and_drop_extension.js"
 import { nextFrame } from "../helpers/timing_helper.js"
 
 
@@ -194,7 +195,8 @@ export class LexicalEditorElement extends HTMLElement {
       AttachmentsExtension,
       FormatEscapeExtension,
       LinkOpenerExtension,
-      PreventLexicalTripleClickExtension
+      PreventLexicalTripleClickExtension,
+      CustomAttachmentDragAndDropExtension
     ]
   }
 

--- a/src/extensions/custom_attachment_drag_and_drop_extension.js
+++ b/src/extensions/custom_attachment_drag_and_drop_extension.js
@@ -1,0 +1,19 @@
+import { defineExtension } from "lexical"
+import { CustomAttachmentDragAndDrop } from "../editor/attachments/custom/drag_and_drop"
+import LexxyExtension from "./lexxy_extension"
+
+export class CustomAttachmentDragAndDropExtension extends LexxyExtension {
+  get enabled() {
+    return this.editorElement.supportsRichText
+  }
+
+  get lexicalExtension() {
+    return defineExtension({
+      name: "lexxy/custom-attachment-drag-and-drop",
+      register: (editor) => {
+        const dragAndDrop = new CustomAttachmentDragAndDrop(editor)
+        return () => dragAndDrop.destroy()
+      }
+    })
+  }
+}

--- a/src/helpers/caret_helpers.js
+++ b/src/helpers/caret_helpers.js
@@ -1,0 +1,24 @@
+export function caretRect(node, offset) {
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+
+  const rect = range.getBoundingClientRect()
+  if (rect.height > 0) {
+    return rect
+  } else {
+    return null
+  }
+}
+
+export function caretFromPoint(clientX, clientY) {
+  if (document.caretPositionFromPoint) {
+    const position = document.caretPositionFromPoint(clientX, clientY)
+    if (position) return { node: position.offsetNode, offset: position.offset }
+  } else if (document.caretRangeFromPoint) {
+    const range = document.caretRangeFromPoint(clientX, clientY)
+    if (range) return { node: range.startContainer, offset: range.startOffset }
+  }
+
+  return null
+}

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -73,7 +73,8 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
   }
 
   createDOM() {
-    const figure = createElement(this.tagName, { "content-type": this.contentType, "data-lexxy-decorator": true })
+    const figure = createElement(this.tagName, { "content-type": this.contentType, "data-lexxy-decorator": true, draggable: true })
+    figure.dataset.lexicalNodeKey = this.__key
 
     figure.insertAdjacentHTML("beforeend", sanitize(this.innerHtml))
 
@@ -124,4 +125,8 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
   decorate() {
     return null
   }
+}
+
+export function $isCustomActionTextAttachmentNode(node) {
+  return node instanceof CustomActionTextAttachmentNode
 }

--- a/test/browser/tests/prompts/mention_drag_reorder.test.js
+++ b/test/browser/tests/prompts/mention_drag_reorder.test.js
@@ -1,0 +1,73 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Mention drag reorder", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("a mention can be dragged to a new position within a line", async ({ page, editor }) => {
+    await insertMention(page, editor)
+
+    await editor.send(" says hello")
+    await editor.flush()
+
+    expect(await editor.plainTextValue()).toContain("Zacharias")
+
+    const mention = editor.content.locator("action-text-attachment").first()
+    await expect(mention).toBeVisible()
+    expect(await mentionIsDraggable(mention)).toBe(true)
+
+    await dragMentionToEndOfLine(editor)
+    await editor.flush()
+
+    // After the drag, the mention should sit at the end of the sentence rather than the start.
+    const value = await editor.value()
+    const mentionPosition = value.indexOf("action-text-attachment")
+    const textPosition = value.indexOf("says hello")
+    expect(mentionPosition).toBeGreaterThan(textPosition)
+  })
+})
+
+async function insertMention(page, editor) {
+  await editor.send("@")
+
+  const popover = page.locator(".lexxy-prompt-menu--visible")
+  await expect(popover).toBeVisible({ timeout: 5_000 })
+
+  await editor.send("Enter")
+  await editor.flush()
+
+  await expect(editor.content.locator("action-text-attachment")).toBeVisible({ timeout: 5_000 })
+}
+
+async function mentionIsDraggable(mention) {
+  return mention.evaluate((el) => el.draggable === true)
+}
+
+async function dragMentionToEndOfLine(editor) {
+  await editor.content.evaluate((root) => {
+    const mention = root.querySelector("action-text-attachment")
+    const paragraph = mention.closest("p") || root
+    const targetRect = paragraph.getBoundingClientRect()
+    const dropX = targetRect.right - 2
+    const dropY = targetRect.top + targetRect.height / 2
+
+    const dataTransfer = new DataTransfer()
+
+    const dispatch = (type, target, clientX, clientY) => {
+      const event = new DragEvent(type, { bubbles: true, cancelable: true, clientX, clientY })
+      Object.defineProperty(event, "dataTransfer", { value: dataTransfer })
+      target.dispatchEvent(event)
+    }
+
+    const startRect = mention.getBoundingClientRect()
+    dispatch("dragstart", mention, startRect.left + 2, startRect.top + startRect.height / 2)
+
+    const dropTarget = document.elementFromPoint(dropX, dropY) || root
+    dispatch("dragover", dropTarget, dropX, dropY)
+    dispatch("drop", dropTarget, dropX, dropY)
+    dispatch("dragend", mention, dropX, dropY)
+  })
+}


### PR DESCRIPTION
## What

Fixes Basecamp card 9974786701 — "[Mentions] Can no longer re-arrange mentions in chat".

In Basecamp 4 (Trix) you could drag a @mention around a chat line while editing to reposition it within the sentence. In Basecamp 5 (Lexxy) mentions could not be dragged at all.

## Root cause

Mentions render as inline `CustomActionTextAttachmentNode` decorator nodes (`<action-text-attachment data-lexxy-decorator>`). Two things prevented dragging:

1. The mention DOM was never marked `draggable`, and carried no `data-lexical-node-key`, so a drag couldn't start or be resolved back to a node.
2. The existing `AttachmentDragAndDrop` only handles block-level `figure.attachment` nodes — gallery merges and between-block insertion. It bails for inline mentions and has no notion of dropping at a text caret within a line.

## Fix

- Mark the mention DOM `draggable` and tag it with `data-lexical-node-key` in `CustomActionTextAttachmentNode#createDOM`.
- Add a `MentionDragAndDrop` controller (and a `MentionDragAndDropExtension`, enabled when the editor supports rich text) that handles `DRAGSTART`/`DROP` for inline mentions at HIGH priority. On drop it resolves the text caret from the drop point and places the mention there using Lexical's `$createRangeSelectionFromDom`.
- Add grab-cursor / dragging-opacity styles for inline decorator attachments.

The block attachment handler still bails for mentions (they aren't `figure.attachment`), so the two handlers coexist without conflict.

## Tests

Added `test/browser/tests/prompts/mention_drag_reorder.test.js`, which inserts a mention, asserts it is draggable, drags it to the end of the line, and asserts the serialized order changed. Confirmed failing before the fix (mention not draggable) and passing after.

Full Playwright suite passes on chromium and firefox. (webkit can't launch in this sandbox; one unrelated `link_opener` test requires real network access to `example.com`.)