### PR TITLE
Fix mention insertion retroactively applying earlier formatting

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -244,14 +244,13 @@ export default class Contents {
   replaceTextBackUntil(stringToReplace, replacementNodes) {
     replacementNodes = Array.isArray(replacementNodes) ? replacementNodes : [ replacementNodes ]
 
-    const selection = $getSelection()
     const { anchorNode, offset } = this.#getTextAnchorData()
     if (!anchorNode) return
 
     const lastIndex = this.#findReplacementStart(anchorNode, offset, stringToReplace)
     if (lastIndex === -1) return
 
-    this.#performTextReplacement(anchorNode, selection, lastIndex, stringToReplace, replacementNodes)
+    this.#performTextReplacement(anchorNode, lastIndex, stringToReplace, replacementNodes)
   }
 
   uploadFiles(files, { selectLast } = {}) {
@@ -574,13 +573,13 @@ export default class Contents {
     }
   }
 
-  #performTextReplacement(anchorNode, selection, startIndex, stringToReplace, replacementNodes) {
+  #performTextReplacement(anchorNode, startIndex, stringToReplace, replacementNodes) {
     const fullText = anchorNode.getTextContent()
     const textBeforeString = fullText.slice(0, startIndex)
     const textAfterString = fullText.slice(startIndex + stringToReplace.length)
 
-    const textNodeBefore = this.#cloneTextNodeFormatting(anchorNode, selection, textBeforeString)
-    const textNodeAfter = this.#cloneTextNodeFormatting(anchorNode, selection, textAfterString || " ")
+    const textNodeBefore = this.#cloneTextNodeFormatting(anchorNode, textBeforeString)
+    const textNodeAfter = this.#cloneTextNodeFormatting(anchorNode, textAfterString || " ")
 
     anchorNode.replace(textNodeBefore)
 
@@ -592,18 +591,12 @@ export default class Contents {
     textNodeAfter.select(cursorOffset, cursorOffset)
   }
 
-  #cloneTextNodeFormatting(anchorNode, selection, text) {
-    const parent = anchorNode.getParent()
-    const fallbackFormat = parent?.getTextFormat?.() || 0
-    const fallbackStyle = parent?.getTextStyle?.() || ""
-    const format = $isRangeSelection(selection) && selection.format ? selection.format : (anchorNode.getFormat() || fallbackFormat)
-    const style = $isRangeSelection(selection) && selection.style ? selection.style : (anchorNode.getStyle() || fallbackStyle)
-
+  #cloneTextNodeFormatting(anchorNode, text) {
     return $createTextNode(text)
-      .setFormat(format)
+      .setFormat(anchorNode.getFormat())
       .setDetail(anchorNode.getDetail())
       .setMode(anchorNode.getMode())
-      .setStyle(style)
+      .setStyle(anchorNode.getStyle())
   }
 
   #insertReplacementNodes(startNode, replacementNodes) {

--- a/test/browser/tests/prompts/mention_formatting.test.js
+++ b/test/browser/tests/prompts/mention_formatting.test.js
@@ -1,0 +1,33 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Mentions preserve earlier formatting", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("inserting a mention does not apply the first word's format to plain text before it", async ({ page, editor }) => {
+    await editor.setValue("<p><em>Italics</em> not applied to words other than the first</p>")
+    await editor.focus()
+    await editor.send("End")
+    await editor.send(" ")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toBeVisible({ timeout: 5_000 })
+
+    // Only the first word ("Italics") should remain italic. The plain text that
+    // follows it must not inherit the italic format after inserting the mention.
+    const italicTexts = await editor.content.evaluate((el) => {
+      return Array.from(el.querySelectorAll("em, i")).map((node) => node.textContent.trim())
+    })
+
+    expect(italicTexts).toEqual([ "Italics" ])
+  })
+})


### PR DESCRIPTION
## Problem

Basecamp card 9741130457: when a line starts with a formatted word (bold, italic, etc.) followed by plain unformatted text, inserting an @mention into that sentence makes everything between the first word and the mention inherit the first word's formatting.

Example — before: "*Italics* not applied to words other than the first"; after adding a mention the whole span becomes italic: "*Italics not applied to words other than the first*".

## Root cause

Inserting a mention splits the anchor text node around the `@` trigger via `Contents#replaceTextBackUntil` → `#performTextReplacement` → `#cloneTextNodeFormatting`. Both halves hold text that already existed, so they should keep the anchor node's own format/style.

Instead, `#cloneTextNodeFormatting` preferred the live selection's typing format and, when the node format was `0`, fell back to the paragraph's text format (`parent.getTextFormat()`). Because a plain format is `0` (falsy), the `anchorNode.getFormat() || fallbackFormat` expression always fell through to the paragraph format, which here was italic. The reconstructed plain text was created as italic and merged with the leading `<em>` node, italicizing the whole line (the trailing spacer became italic too).

## Fix

`#cloneTextNodeFormatting` now copies the anchor node's actual `getFormat()` / `getStyle()` directly, with no selection-format preference and no falsy `0` fallback. The selection argument is no longer needed and was removed from the call chain.

## Test

Added `test/browser/tests/prompts/mention_preserves_earlier_formatting.test.js`, which sets up "*Italics* not applied to words other than the first", inserts a mention, and asserts only "Italics" remains italic. It fails before the fix and passes after.

Full Playwright suite passes on chromium (525 passing; the one unrelated `link_opener` failure is a pre-existing environment issue that also fails on `main`). `eslint` is clean.