### PR TITLE
Preserve plain text spacing and backslashes on paste

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -168,17 +168,16 @@ export default class Clipboard {
 
     if (this.#isPlainTextWithoutMarkdown(doc)) {
       this.contents.insertText(text, { tag: PASTE_TAG })
-      return
+    } else {
+      const detail = Object.freeze({
+        markdown: text,
+        document: doc,
+        addBlockSpacing: () => addBlockSpacing(doc)
+      })
+
+      dispatch(this.editorElement, "lexxy:insert-markdown", detail)
+      this.contents.insertDOM(doc, { tag: PASTE_TAG })
     }
-
-    const detail = Object.freeze({
-      markdown: text,
-      document: doc,
-      addBlockSpacing: () => addBlockSpacing(doc)
-    })
-
-    dispatch(this.editorElement, "lexxy:insert-markdown", detail)
-    this.contents.insertDOM(doc, { tag: PASTE_TAG })
   }
 
   // Markdown conversion collapses runs of whitespace and unescapes backslashes,

--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -165,6 +165,12 @@ export default class Clipboard {
   #pasteMarkdown(text) {
     const html = marked(text, { breaks: true })
     const doc = parseHtml(html)
+
+    if (this.#isPlainTextWithoutMarkdown(doc)) {
+      this.contents.insertText(text, { tag: PASTE_TAG })
+      return
+    }
+
     const detail = Object.freeze({
       markdown: text,
       document: doc,
@@ -173,6 +179,18 @@ export default class Clipboard {
 
     dispatch(this.editorElement, "lexxy:insert-markdown", detail)
     this.contents.insertDOM(doc, { tag: PASTE_TAG })
+  }
+
+  // Markdown conversion collapses runs of whitespace and unescapes backslashes,
+  // silently corrupting plain text such as Windows/UNC file paths. When the text
+  // carries no Markdown structure, paste it verbatim instead.
+  #isPlainTextWithoutMarkdown(doc) {
+    const elements = Array.from(doc.body.children)
+    if (elements.length !== 1) return false
+
+    const paragraph = elements[0]
+    return paragraph.nodeName === "P"
+      && Array.from(paragraph.childNodes).every((node) => node.nodeType === Node.TEXT_NODE)
   }
 
   #pasteRichText(clipboardData) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -49,6 +49,13 @@ export default class Contents {
     }, { tag })
   }
 
+  insertText(text, { tag } = {}) {
+    this.editor.update(() => {
+      const paragraph = $createParagraphNode().append($createTextNode(text))
+      this.insertAtCursor(paragraph)
+    }, { tag })
+  }
+
   insertAtCursor(...nodes) {
     const selection = $getSelection() ?? $getRoot().selectEnd()
     const inserter = NodeInserter.for(selection)

--- a/test/browser/tests/paste/plain_text_paths.test.js
+++ b/test/browser/tests/paste/plain_text_paths.test.js
@@ -19,6 +19,17 @@ test.describe("Paste — Plain text paths and spacing", () => {
     expect(await editor.plainTextValue()).toBe(path)
   })
 
+  test("preserves a UNC path with leading backslashes, single spaces, and parentheses", async ({ editor }) => {
+    const path = "\\\\Rlgokc-asfs01\\tmfl_Active\\Vonallmen Capital Partners\\10177.000-Vonallmen Capital Partners - General\\DRAF\\Consulting Agreement - Michael Shanks 05.22.2026(282407).docx"
+
+    await editor.paste(path)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("a")).toHaveCount(0)
+    })
+    expect(await editor.plainTextValue()).toBe(path)
+  })
+
   test("preserves runs of consecutive spaces in plain text", async ({ editor }) => {
     const text = "path  with    multiple   spaces"
 

--- a/test/browser/tests/paste/plain_text_paths.test.js
+++ b/test/browser/tests/paste/plain_text_paths.test.js
@@ -1,0 +1,37 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent } from "../../helpers/assertions.js"
+
+test.describe("Paste — Plain text paths and spacing", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+  })
+
+  test("preserves a UNC path with consecutive spaces and backslashes", async ({ editor }) => {
+    const path = "\\\\Arina-alvand\\alvand\\03 - ENGINEERING\\TN32 -NSC YAWATA\\00. Input\\00.Original\\2026-06-17"
+
+    await editor.paste(path)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("a")).toHaveCount(0)
+    })
+    expect(await editor.plainTextValue()).toBe(path)
+  })
+
+  test("preserves runs of consecutive spaces in plain text", async ({ editor }) => {
+    const text = "path  with    multiple   spaces"
+
+    await editor.paste(text)
+
+    expect(await editor.plainTextValue()).toBe(text)
+  })
+
+  test("still converts genuine markdown on paste", async ({ editor }) => {
+    await editor.paste("Hello **there**")
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("strong")).toHaveText("there")
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Pasting a plain-text Windows/UNC file path with more than one consecutive space (or backslashes) into Lexxy silently corrupts it: consecutive spaces collapse to one and leading backslashes are stripped.

Reported in Basecamp card 10006219528. Example pasted by the customer:

```
\\Arina-alvand\alvand\03 - ENGINEERING\TN32 -NSC YAWATA\00. Input\00.Original\2026-06-17
```

## Root cause

Plain text pasted without an HTML payload routes through the Markdown conversion path (`Clipboard#pasteMarkdown`). `marked()` + HTML insertion (a) collapses runs of whitespace per HTML whitespace rules and (b) unescapes backslashes (markdown escaping). For text that isn't actually Markdown, this rewrites the user's content.

## Fix

When the Markdown conversion produces nothing but a single text-only paragraph, there is no Markdown structure to honor, so we paste the original text verbatim via a new `Contents#insertText`. Genuine Markdown (formatting, headings, lists, links) is unaffected.

The new insert reuses the existing `NodeInserter` machinery (via `insertAtCursor`), so it continues to handle the quote-element-point edge cases that a raw `insertRawText` would crash on (#212 / #1109).

## Tests

Added `test/browser/tests/paste/plain_text_paths.test.js` covering:
- UNC path with consecutive spaces and backslashes is preserved (no autolink, exact characters)
- runs of consecutive spaces preserved
- genuine Markdown still converts

Full Playwright suite passes on chromium and firefox. (webkit can't launch in this sandbox; the only chromium failure, `link_opener` modifier+click, requires real network to example.com and also fails on a clean `main`.)