### PR TITLE
Skip uploads into an empty node selection

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -390,9 +390,6 @@ export default class Contents {
     })
   }
 
-  // A node selection whose selected node is gone (e.g. removed before a late,
-  // document-level drop lands here) resolves to no nodes, so there is nothing to
-  // insert after. Fall back to the document end, like a missing selection.
   #insertableSelection() {
     const selection = $getSelection()
     if ($isNodeSelection(selection) && selection.getNodes().length === 0) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -1,6 +1,6 @@
 import {
   $createLineBreakNode, $createParagraphNode, $createTextNode, $getNodeByKey, $getRoot, $getSelection, $hasUpdateTag,
-  $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootOrShadowRoot, $isTextNode, $setSelection,
+  $isLineBreakNode, $isNodeSelection, $isParagraphNode, $isRangeSelection, $isRootOrShadowRoot, $isTextNode, $setSelection,
   HISTORY_MERGE_TAG, PASTE_TAG,
   SELECTION_INSERT_CLIPBOARD_NODES_COMMAND
 } from "lexical"
@@ -50,7 +50,7 @@ export default class Contents {
   }
 
   insertAtCursor(...nodes) {
-    const selection = $getSelection() ?? $getRoot().selectEnd()
+    const selection = this.#insertableSelection()
     const inserter = NodeInserter.for(selection)
 
     inserter.insertNodes(nodes)
@@ -388,6 +388,18 @@ export default class Contents {
       const newNode = options.attachment ? this.#createCustomAttachmentNodeWithHtml(html, options.attachment) : this.#createHtmlNodeWith(html)
       previousNode.insertAfter(newNode)
     })
+  }
+
+  // A node selection whose selected node is gone (e.g. removed before a late,
+  // document-level drop lands here) resolves to no nodes, so there is nothing to
+  // insert after. Fall back to the document end, like a missing selection.
+  #insertableSelection() {
+    const selection = $getSelection()
+    if ($isNodeSelection(selection) && selection.getNodes().length === 0) {
+      return $getRoot().selectEnd()
+    }
+
+    return selection ?? $getRoot().selectEnd()
   }
 
   #formatPastedDOM(doc) {

--- a/src/editor/contents/node_inserter/node_selection_node_inserter.js
+++ b/src/editor/contents/node_inserter/node_selection_node_inserter.js
@@ -4,7 +4,7 @@ import BaseNodeInserter from "./base_node_inserter"
 
 export default class NodeSelectionNodeInserter extends BaseNodeInserter {
   static handles(selection) {
-    return $isNodeSelection(selection)
+    return $isNodeSelection(selection) && selection.getNodes().length > 0
   }
 
   insertNodes(nodes) {

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -144,4 +144,39 @@ test.describe("Uploading into an unsupported selection", () => {
     await expect(editor.content.locator("figure.attachment")).toHaveCount(2, { timeout: 10_000 })
     expect(errors).toEqual([])
   })
+
+  // "Cannot read properties of undefined (reading 'is')" / "(reading 'insertAfter')":
+  // a node selection whose selected node is gone resolves to an empty getNodes(), so
+  // NodeSelectionNodeInserter started from an undefined lastNode. A document-level drop
+  // relayed through Contents#uploadFiles then crashed before inserting anything.
+  test("uploading a file with an empty node selection lands the file", async ({ page, editor }) => {
+    await editor.setValue("<p>hello world</p>")
+    await editor.flush()
+
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    const errorMessage = await page.evaluate(async () => {
+      const { $createNodeSelection, $setSelection } = await import("/@id/lexical")
+      const editorElement = document.querySelector("lexxy-editor")
+
+      editorElement.editor.update(() => {
+        const selection = $createNodeSelection()
+        selection.add("a-node-key-that-does-not-exist")
+        $setSelection(selection)
+      })
+
+      const file = new File([ "%PDF-1.4 dummy" ], "dropped.pdf", { type: "application/pdf" })
+      try {
+        editorElement.contents.uploadFiles([ file ])
+        return null
+      } catch (error) {
+        return error.message
+      }
+    })
+
+    expect(errorMessage).toBeNull()
+    expect(errors).toEqual([])
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(1, { timeout: 10_000 })
+  })
 })


### PR DESCRIPTION
## Problem

Basecamp card 9938322629 / Sentry [BC3-JS-N7D5](https://basecamp.sentry.io/issues/7507327343/). The issue groups a *family* of crashes that all originate from the document-level drop zone (`rich_text/behaviors/drop_zone`) relaying a file drop to `Contents#uploadFiles`:

- `null is not an object (evaluating 'this.editorElement.supportsAttachments')` — already fixed by the earlier "Skip uploads into a disposed editor" guard, shipped in 0.9.19-alpha.2.
- `Cannot read properties of undefined (reading 'is')` / `(reading 'insertAfter')` — **still active on the latest release** and the subject of this PR.

The drop zone relays a drop to whatever editor the cursor last sat in. If the previously selected node (e.g. an attachment) was removed before the drop lands, the editor is left holding a **node selection that resolves to no nodes**. `NodeSelectionNodeInserter.insertNodes` then started from `this.selection.getNodes().at(-1)` === `undefined` and crashed in `#insertsIntoRoot` (`node.is(...)`) — or on `lastNode.insertAfter(...)`, depending on the path.

## Root cause

`Contents#insertAtCursor` only fell back to the document end when `$getSelection()` was `null`. An empty node selection is non-null but provides no insertion target, so it slipped through and reached an inserter that assumed at least one selected node.

## Fix

- `Contents#insertAtCursor` now treats an empty node selection like a missing selection, falling back to `$getRoot().selectEnd()`. This is the single logical entry point that document-level drops, paste, and toolbar insertions all go through.
- `NodeSelectionNodeInserter.handles` no longer claims a node selection it can't act on (one with zero resolvable nodes), so dispatch stays honest.

The dropped file now lands at the end of the document instead of throwing. This follows STYLE.md's fail-fast guidance: an empty node selection is genuinely optional state (a stale selection left by a removed node), not a masked bug.

## Test

`test/browser/tests/attachments/upload_into_unsupported_selection.test.js` gains a case that builds an empty node selection (a node selection pointing at a removed key — exactly the stale-selection state) and drives `Contents#uploadFiles`, the same entry point document-level drop zones use. It fails on `main` with the production error and passes with the fix. It joins the existing family of unsupported-selection upload tests (`getNode`, `selectEnd`, `splice`).