### PR TITLE
Fix listing a blockquote that holds inline content directly

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -423,8 +423,26 @@ export default class Contents {
   }
 
   #insertListInsideQuote(listType) {
+    this.#wrapDirectInlineQuoteContentInParagraphs()
+
     for (const group of $consecutiveSiblingGroups(this.#quotedBlocksInSelection())) {
       this.#wrapBlocksInList(group, listType)
+    }
+  }
+
+  // A quote that holds inline content directly (e.g. legacy Trix content like
+  // <blockquote>text</blockquote>) has no inner block for the list to wrap.
+  // Move that content into a paragraph so it becomes a quoted block like any other.
+  #wrapDirectInlineQuoteContentInParagraphs() {
+    const selection = $getSelection()
+    if (!$isRangeSelection(selection)) return
+
+    for (const block of this.#outermostElements(this.#blockLevelElementsInSelection(selection))) {
+      if ($isQuoteNode(block)) {
+        const paragraph = $createParagraphNode()
+        paragraph.append(...block.getChildren())
+        block.append(paragraph)
+      }
     }
   }
 

--- a/test/browser/tests/formatting/bug_bullet_in_quote_erases_content.test.js
+++ b/test/browser/tests/formatting/bug_bullet_in_quote_erases_content.test.js
@@ -1,0 +1,25 @@
+import { test } from "../../test_helper.js"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Inserting a bullet inside a blockquote with inline content", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    await editor.focus()
+  })
+
+  test("lists a quote that holds text directly without losing the content", async ({ editor }) => {
+    await editor.setValue("<blockquote>First line</blockquote>")
+    await editor.flush()
+
+    await editor.content.click()
+    await editor.send("End")
+    await editor.clickToolbarButton("insertUnorderedList")
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><ul><li value=\"1\">First line</li></ul></blockquote>",
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Basecamp card #10005355930: "Selecting bullet inside blockquote erases previous content."

The headline symptom from the card — converting a quoted paragraph to a list swallowing the whole blockquote and dropping the content — was already fixed on `main` by #1122 ("Fix list editing inside blockquotes"). While reproducing, I found a remaining gap in the same feature:

When a blockquote holds its content as a **direct text node** rather than wrapped in a paragraph — e.g. legacy Trix/Action Text content like `<blockquote>text</blockquote>` — pressing the bullet or numbered list button did **nothing**. The quote had no inner block element for the list to wrap (`#quotedBlocksInSelection` filters for blocks whose parent is a quote, but here the quote *is* the block), so the conversion silently no-opped and the content stayed unlisted.

## Fix

Before wrapping quoted blocks in a list, move any inline content held directly by a quote into a paragraph. The direct-text quote then becomes a quoted block like any other and is listed in place, keeping the surrounding quote intact and preserving line breaks.

## Test

Added `test/browser/tests/formatting/bug_bullet_in_quote_erases_content.test.js`, which lists a `<blockquote>First line</blockquote>` and asserts the result is `<blockquote><ul><li value="1">First line</li></ul></blockquote>`. Confirmed it fails before the fix (quote left unchanged) and passes after.

The full Playwright suite passes on chromium (524 passing; the two unrelated failures — `link_opener`, which needs outbound network to example.com, and the flaky `leak` test — also fail/flake on clean `main` in this sandbox). `yarn lint` is clean.