### PR TITLE
Fix prompt popover positioning after Turbo history navigation

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -1079,7 +1079,7 @@
   }
 }
 
-:where(.lexxy-prompt-menu--visible) {
+:where(.lexxy-prompt-menu--visible[data-anchored]) {
   visibility: initial;
 }
 

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -38,14 +38,14 @@ export default class Selection {
   }
 
   get cursorPosition() {
-    let position = { x: 0, y: 0 }
+    let position = null
 
     this.editor.getEditorState().read(() => {
       const range = this.#getValidSelectionRange()
       if (!range) return
 
       const rect = this.#getReliableRectFromRange(range)
-      if (!rect) return
+      if (this.#isRectUnreliable(rect)) return
 
       position = this.#calculateCursorPosition(rect, range)
     })

--- a/src/elements/prompt.js
+++ b/src/elements/prompt.js
@@ -162,7 +162,9 @@ export class LexicalPromptElement extends HTMLElement {
         if (!node) return
 
         if (this.#cursorIsTypingSearchTerm(node, offset)) {
-          return
+          if (!this.popoverElement.hasAttribute("data-anchored")) {
+            this.#positionPopover()
+          }
         } else {
           this.#hidePopover()
         }
@@ -293,8 +295,16 @@ export class LexicalPromptElement extends HTMLElement {
     }
   }
 
+  // Right after a Turbo history restore the editor reconnects before the DOM selection
+  // is re-established, so the cursor geometry is momentarily unavailable. Anchoring then
+  // would pin the menu to the editor's left edge for the rest of the open cycle, so we
+  // skip it and let a later reposition anchor it once the selection is ready. The menu
+  // stays hidden until anchored (see the `[data-anchored]` rule in the stylesheet).
   #positionPopover() {
-    const { x, y, fontSize } = this.#selection.cursorPosition
+    const cursorPosition = this.#selection.cursorPosition
+    if (!cursorPosition) return
+
+    const { x, y, fontSize } = cursorPosition
     const editorRect = this.#editorElement.getBoundingClientRect()
     const contentRect = this.#editorContentElement.getBoundingClientRect()
     const verticalOffset = contentRect.top - editorRect.top

--- a/test/browser/tests/prompts/prompt_position_after_navigation.test.js
+++ b/test/browser/tests/prompts/prompt_position_after_navigation.test.js
@@ -1,0 +1,43 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Prompt popover positioning when the cursor geometry is unavailable", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  // Right after a Turbo history restore the editor reconnects before it is laid out,
+  // so the cursor rect measures as 0×0. The menu used to anchor at x = 0 — pinned to
+  // the editor's left edge (the "far left of the screen" report) and locked there for
+  // the rest of the open cycle. The cursor position must report as unavailable in that
+  // state so the menu stays unanchored until the geometry is reliable.
+  test("reports no cursor position when the cursor rect is unreliable", async ({ page, editor }) => {
+    await editor.send("hello @world")
+
+    const positionWithLayout = await page.locator("lexxy-editor").evaluate((el) => el.selection.cursorPosition)
+    expect(positionWithLayout).not.toBeNull()
+    expect(positionWithLayout.x).toBeGreaterThan(0)
+
+    const positionWithoutLayout = await page.locator("lexxy-editor").evaluate((el) => {
+      const zeroRect = { x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, toJSON() {} }
+      const originalRangeRect = Range.prototype.getBoundingClientRect
+      const originalElementRect = Element.prototype.getBoundingClientRect
+
+      Range.prototype.getBoundingClientRect = () => zeroRect
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.tagName === "SPAN" && this.style.width === "1px") return zeroRect
+        return originalElementRect.call(this)
+      }
+
+      try {
+        return el.selection.cursorPosition
+      } finally {
+        Range.prototype.getBoundingClientRect = originalRangeRect
+        Element.prototype.getBoundingClientRect = originalElementRect
+      }
+    })
+
+    expect(positionWithoutLayout).toBeNull()
+  })
+})


### PR DESCRIPTION
Follow-up to #1121 (Basecamp card 9941487393).

PR #1121 tore the @mentions popover down before Turbo caches the page, so after a history back/forward the menu is correctly gone. QA (Gabriel Monette) then found a positioning regression: after a Turbo restore, when you start typing a name the menu renders at the **far left of the screen** instead of anchored to the cursor. It reproduces in chat, the Add a Card modal, New Message, and New Document.

## Root cause

Right after a Turbo history restore the editor reconnects before the DOM selection is re-established, so the cursor rect briefly measures as `0x0`. `Selection#cursorPosition` silently fell back to `{ x: 0, y: 0 }` in that state. `#positionPopover` then anchored the menu at `x = 0` — pinned to the editor's left edge (the "far left of the screen" report) — and set `data-anchored`, locking that bad position for the rest of the open cycle.

## Fix

- `Selection#cursorPosition` now returns `null` when the cursor rect is unreliable, instead of a misleading `{ x: 0, y: 0 }`.
- The prompt skips anchoring while the position is unavailable, keeps the menu hidden until it's anchored (`.lexxy-prompt-menu--visible[data-anchored]`), and re-anchors on the next cursor update once the selection is ready.

PR #1121's behavior is intact: the popover is still removed before Turbo caches and on disconnect.

## Verification

- New Playwright test `test/browser/tests/prompts/prompt_position_after_navigation.test.js` asserts `cursorPosition` reports unavailable when the cursor rect is unreliable (and a real position otherwise). Confirmed it fails on the pre-fix code and passes with the fix.
- Full Playwright prompts suite (38) green; full browser suite green except a pre-existing `link_opener` failure unrelated to this change. Vitest (103) green. System tests `prompts_test`, `page_refreshes_test`, `mention_round_trip_test` green.
- Manually validated in the dummy app via real Turbo back/forward + retype: menu still torn down on restore, and anchors next to the cursor (not the left edge) on retype.