### PR TITLE
Strip leading empty list item when pasting numbered lists

### DIFF
--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -7,6 +7,7 @@ export default class PastedContentFormatter {
     this.#unwrapPlaceholderAnchors()
     this.#stripTableCellColorStyles()
     this.#stripStrayListChildren()
+    this.#stripLeadingEmptyListItems()
     return this.doc
   }
 
@@ -43,5 +44,22 @@ export default class PastedContentFormatter {
         list.removeChild(child)
       }
     }
+  }
+
+  // Editors such as HelpScout prefix a copied list with an empty first <li>,
+  // which renders as a spurious leading number (and line break) once imported.
+  // Drop empty items at the front while keeping intentional empty items further down.
+  #stripLeadingEmptyListItems() {
+    for (const list of this.doc.querySelectorAll("ol, ul")) {
+      let firstItem = list.querySelector(":scope > li")
+      while (firstItem && this.#isEmptyListItem(firstItem)) {
+        firstItem.remove()
+        firstItem = list.querySelector(":scope > li")
+      }
+    }
+  }
+
+  #isEmptyListItem(item) {
+    return item.querySelector("ol, ul") === null && item.textContent.trim() === ""
   }
 }

--- a/test/browser/tests/paste/clean_invalid_pasted_list_html.test.js
+++ b/test/browser/tests/paste/clean_invalid_pasted_list_html.test.js
@@ -66,6 +66,26 @@ test.describe("Paste list with stray non-<li> children before the first item", (
     expect(page).toHaveNoErrors()
   })
 
+  test("strips a leading empty <li> before the first item (HelpScout numbered list)", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ol><li><br></li><li>New For You</li><li>Bubbled Up</li><li>Previous Notifications</li></ol>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ol><li value="1">New For You</li><li value="2">Bubbled Up</li><li value="3">Previous Notifications</li></ol>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+
   test("keeps an empty <li> that is not leading", async ({ page, editor }) => {
     await page.goto("/")
     await editor.waitForConnected()


### PR DESCRIPTION
## What

Pasting a numbered (ordered) list copied from HelpScout into the Lexxy editor inserted a spurious extra `1.` and a line break before the actual list. The user's source list `New For You / Bubbled Up / Previous Notifications` came out renumbered, with an empty leading item.

## Root cause

HelpScout (and similar rich-text editors) prefix a copied ordered list with an empty first `<li>` (often containing only a `<br>`):

```html
<ol><li><br></li><li>New For You</li><li>Bubbled Up</li><li>Previous Notifications</li></ol>
```

`PastedContentFormatter#stripStrayListChildren` already dropped non-`<li>` children of a list, but an empty `<li>` is a valid child, so it survived. On import it became item `1.` (empty, with a line break), pushing every real item down by one.

## Fix

Added `PastedContentFormatter#stripLeadingEmptyListItems`, which drops empty `<li>` elements at the front of a pasted list. It preserves intentional empty items further down (existing behavior) and leaves a leading item alone if it only holds a nested sublist.

## Tests

Added a Playwright test in `test/browser/tests/paste/clean_invalid_pasted_list_html.test.js` reproducing the exact HelpScout shape and asserting the result is the three items with correct numbering and no empty leading item. Confirmed it failed before the fix.

Basecamp card 9939030998.