### PR TITLE
Release version 0.9.19

### DIFF
--- a/lib/lexxy/version.rb
+++ b/lib/lexxy/version.rb
@@ -1,3 +1,3 @@
 module Lexxy
-  VERSION = "0.9.19.alpha.3"
+  VERSION = "0.9.19"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@37signals/lexxy",
-  "version": "0.9.19-alpha.3",
+  "version": "0.9.19",
   "description": "Lexxy - A modern rich text editor for Rails.",
   "module": "dist/lexxy.esm.js",
   "type": "module",


### PR DESCRIPTION
Lexxy has been shipping under pre-release tags — betas, then alphas — for its entire history. This drops the pre-release suffix and ships the first official, non-pre-release version.

The editor has been stable in use for a while, so the `alpha` designation no longer reflects its state. Cutting an official `0.9.19` lets people depend on Lexxy without opting into a pre-release tag, while staying in `0.x` to signal the API may still evolve before `1.0`.

Bumps the version from `0.9.19-alpha.3` to `0.9.19` in both the gem (`version.rb`) and the npm package (`package.json`).

Publishing the gem, the npm package, and creating the GitHub release happen separately after this merges.