### PR TITLE
Code block and quote grab the block above the selection

### DIFF
--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -227,6 +227,7 @@ export function $splitSelectedParagraphsAtInnerLineBreaks(selection) {
 
 export function $expandSelectionToLineBreaksAndSplitAtEdges(selection, fallbackAncestor = (node) => node.getTopLevelElement()) {
   $ensureForwardRangeSelection(selection)
+  $shrinkSelectionPastBlockEdges(selection)
 
   const focusCaret = $caretFromPoint(selection.focus, "next")
   const anchorCaret = $caretFromPoint(selection.anchor, "previous")
@@ -256,6 +257,52 @@ export function $expandSelectionToLineBreaksAndSplitAtEdges(selection, fallbackA
       "next",
     ),
   ))
+}
+
+// A selection whose anchor sits at the very end of one block while its focus
+// lives in a later block (e.g. selecting a pasted paragraph when the browser
+// anchors at the end of the line above) contributes nothing from the anchor's
+// block. Pull each endpoint that is flush against a block edge into the block
+// that actually holds the selected content, so we don't wrap the empty edge
+// block too.
+function $shrinkSelectionPastBlockEdges(selection) {
+  if (selection.isCollapsed()) return
+
+  const anchorBlock = selection.anchor.getNode().getTopLevelElement()
+  const focusBlock = selection.focus.getNode().getTopLevelElement()
+  if (!anchorBlock || !focusBlock || anchorBlock.is(focusBlock)) return
+
+  if ($isAtBlockEnd(selection.anchor, anchorBlock)) {
+    const nextBlock = anchorBlock.getNextSibling()
+    if (nextBlock) selection.anchor.set(nextBlock.getKey(), 0, "element")
+  }
+
+  if ($isAtBlockStart(selection.focus, focusBlock)) {
+    const previousBlock = focusBlock.getPreviousSibling()
+    if (previousBlock) selection.focus.set(previousBlock.getKey(), previousBlock.getChildrenSize(), "element")
+  }
+}
+
+function $isAtBlockEnd(point, block) {
+  return $isAtBlockBoundary($caretFromPoint(point, "next"), block)
+}
+
+function $isAtBlockStart(point, block) {
+  return $isAtBlockBoundary($caretFromPoint(point, "previous"), block)
+}
+
+// A text point sitting mid-node still has content ahead of it in the caret's
+// direction, even though that content is not a sibling node. $getNodeAtCaret
+// only sees siblings, so check the text edge before walking the block.
+function $isAtBlockBoundary(caret, block) {
+  if ($isTextPointCaret(caret) && $isExtendableTextPointCaret(caret)) return false
+
+  let cursor = $normalizeCaret(caret)
+  while (cursor && block.isParentOf(cursor.origin)) {
+    if (cursor.getNodeAtCaret()) return false
+    cursor = cursor.getParentCaret()
+  }
+  return true
 }
 
 function $getCaretAtLineBreakBoundary(caret, skipInwardEdge = false) {

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -351,6 +351,33 @@ test.describe("Block formatting", () => {
     )
   })
 
+  test("quote does not absorb the paragraph above when the selection anchors at its end", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue("<p>ABCD:</p><p>pasted one<br>pasted two</p>")
+
+    await editor.content.evaluate((el) => {
+      const paragraphs = el.querySelectorAll("p")
+      const range = document.createRange()
+      range.setStart(paragraphs[0], paragraphs[0].childNodes.length)
+      const walker = document.createTreeWalker(paragraphs[1], NodeFilter.SHOW_TEXT)
+      let lastTextNode, node
+      while ((node = walker.nextNode())) lastTextNode = node
+      range.setEnd(lastTextNode, lastTextNode.nodeValue.length)
+      const selection = window.getSelection()
+      selection.removeAllRanges()
+      selection.addRange(range)
+    })
+
+    await page.getByRole("button", { name: "Quote" }).click()
+
+    await assertEditorHtml(
+      editor,
+      "<p>ABCD:</p><blockquote><p>pasted one<br>pasted two</p></blockquote>",
+    )
+  })
+
   test("bullet list only the selected line from soft line breaks", async ({
     page,
     editor,

--- a/test/browser/tests/formatting/code_block_format.test.js
+++ b/test/browser/tests/formatting/code_block_format.test.js
@@ -1,0 +1,57 @@
+import { test } from "../../test_helper.js"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+import { clickToolbarButton } from "../../helpers/toolbar.js"
+
+test.describe("Code block formatting", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("does not absorb the block above when the selection anchors at its end", async ({ page, editor }) => {
+    await editor.setValue("<p>ABCD:</p><p>pasted one<br>pasted two</p>")
+
+    await editor.content.evaluate((el) => {
+      const paragraphs = el.querySelectorAll("p")
+      const range = document.createRange()
+      range.setStart(paragraphs[0], paragraphs[0].childNodes.length)
+      const walker = document.createTreeWalker(paragraphs[1], NodeFilter.SHOW_TEXT)
+      let lastTextNode, node
+      while ((node = walker.nextNode())) lastTextNode = node
+      range.setEnd(lastTextNode, lastTextNode.nodeValue.length)
+      const selection = window.getSelection()
+      selection.removeAllRanges()
+      selection.addRange(range)
+    })
+    await editor.flush()
+
+    await clickToolbarButton(page, "insertCodeBlock")
+
+    await assertEditorHtml(editor, '<p>ABCD:</p><pre data-language="plain" data-highlight-language="plain">pasted one<br>pasted two</pre>')
+  })
+
+  test("converts a selection spanning multiple paragraphs", async ({ page, editor }) => {
+    await editor.setValue("<p>before</p><p>one</p><p>two</p>")
+
+    await editor.content.evaluate((el) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let startNode, endNode, node
+      while ((node = walker.nextNode())) {
+        if (node.nodeValue === "one") startNode = node
+        if (node.nodeValue === "two") endNode = node
+      }
+      const range = document.createRange()
+      range.setStart(startNode, 0)
+      range.setEnd(endNode, endNode.nodeValue.length)
+      const selection = window.getSelection()
+      selection.removeAllRanges()
+      selection.addRange(range)
+    })
+    await editor.flush()
+
+    await clickToolbarButton(page, "insertCodeBlock")
+
+    await assertEditorHtml(editor, '<p>before</p><pre data-language="plain" data-highlight-language="plain">one<br>two</pre>')
+  })
+})


### PR DESCRIPTION
Converting existing content into a code block could swallow the block sitting *above* the selection. Write a title line like `ABCD:`, paste a few lines beneath it, select only the pasted text, and hit the code-block button — the title line gets pulled into the code block too. The same thing happened when wrapping that selection in a quote.

The trouble shows up when the browser anchors the selection at the *end* of the line above rather than at the start of the selected content — a very common shape when you select text you just pasted below a heading or title. It mostly surfaced in comment composers, where that selection shape is easy to produce.

While expanding a selection out to its line/block boundaries, an endpoint flush against a block edge was attributed to that edge block even though it contributed no actual content. The expansion then wrapped the empty edge block along with the real selection. Now each endpoint that sits against a block edge is first pulled into the block that actually holds the selected content, so only the intended blocks are wrapped.

The boundary-handling this touches was last reshaped in "Rename split helper and extract sibling helper".

Fixes [Basecamp card #10018915941](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/10018915941): Code block grabs more than it should
