### PR TITLE
Drop mentions beside adjacent mentions instead of inside them

### DIFF
--- a/src/editor/attachments/custom/drag_and_drop.js
+++ b/src/editor/attachments/custom/drag_and_drop.js
@@ -115,6 +115,15 @@ export class CustomAttachmentDragAndDrop {
     // they only drop onto an existing line, so snap to the nearest one.
     if (caret.node === rootElement) {
       return this.#nearestLineCaret(rootElement, event.clientY)
+    }
+
+    // When mentions sit next to each other with no text between them, the caret
+    // lands inside the neighbouring decorator's DOM. Lexical can't resolve a point
+    // inside a decorator to an editable position, and the cursor has no business
+    // showing there anyway, so snap to just before or after that mention.
+    const decorator = this.#decoratorElementContaining(caret.node)
+    if (decorator) {
+      return this.#dropPointBesideDecorator(decorator, event.clientX)
     } else {
       return caret
     }
@@ -143,24 +152,55 @@ export class CustomAttachmentDragAndDrop {
     }
   }
 
+  #decoratorElementContaining(node) {
+    const element = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement
+    return element?.closest("[data-lexxy-decorator][data-lexical-node-key]")
+  }
+
+  #dropPointBesideDecorator(decorator, clientX) {
+    const rect = decorator.getBoundingClientRect()
+    const placement = clientX > rect.left + rect.width / 2 ? "after" : "before"
+    return { decoratorKey: decorator.dataset.lexicalNodeKey, placement }
+  }
+
   #moveAttachment(draggedKey, dropPoint) {
     this.#editor.update(() => {
       const draggedNode = $getNodeByKey(draggedKey)
       if (!$isCustomActionTextAttachmentNode(draggedNode)) return
 
-      const selection = $createRangeSelectionFromDom({
-        anchorNode: dropPoint.node,
-        anchorOffset: dropPoint.offset,
-        focusNode: dropPoint.node,
-        focusOffset: dropPoint.offset
-      }, this.#editor)
-      if (!selection) return
-
-      $setSelection(selection)
-
-      draggedNode.remove()
-      selection.insertNodes([ draggedNode ])
+      if (dropPoint.decoratorKey) {
+        this.#moveBesideNode(draggedNode, dropPoint)
+      } else {
+        this.#moveToCaret(draggedNode, dropPoint)
+      }
     })
+  }
+
+  #moveBesideNode(draggedNode, { decoratorKey, placement }) {
+    const targetNode = $getNodeByKey(decoratorKey)
+    if (!targetNode || targetNode === draggedNode) return
+
+    draggedNode.remove()
+    if (placement === "after") {
+      targetNode.insertAfter(draggedNode)
+    } else {
+      targetNode.insertBefore(draggedNode)
+    }
+  }
+
+  #moveToCaret(draggedNode, dropPoint) {
+    const selection = $createRangeSelectionFromDom({
+      anchorNode: dropPoint.node,
+      anchorOffset: dropPoint.offset,
+      focusNode: dropPoint.node,
+      focusOffset: dropPoint.offset
+    }, this.#editor)
+    if (!selection) return
+
+    $setSelection(selection)
+
+    draggedNode.remove()
+    selection.insertNodes([ draggedNode ])
   }
 
   #updateDropIndicator(event) {
@@ -170,7 +210,12 @@ export class CustomAttachmentDragAndDrop {
     if (dropPoint) this.#showCaret(this.#caretRectFor(dropPoint))
   }
 
-  #caretRectFor({ node, offset }) {
+  #caretRectFor(dropPoint) {
+    if (dropPoint.decoratorKey) {
+      return this.#decoratorEdgeRect(dropPoint)
+    }
+
+    const { node, offset } = dropPoint
     const rect = caretRect(node, offset)
     if (rect) return rect
 
@@ -180,6 +225,15 @@ export class CustomAttachmentDragAndDrop {
 
     const lineRect = line.getBoundingClientRect()
     return { left: lineRect.left, top: lineRect.top, height: lineRect.height }
+  }
+
+  #decoratorEdgeRect({ decoratorKey, placement }) {
+    const decorator = this.#editor.getRootElement()?.querySelector(`[data-lexical-node-key="${decoratorKey}"]`)
+    if (!decorator) return null
+
+    const rect = decorator.getBoundingClientRect()
+    const left = placement === "after" ? rect.right : rect.left
+    return { left, top: rect.top, height: rect.height }
   }
 
   #showCaret(rect) {

--- a/test/browser/tests/prompts/mention_drag_reorder.test.js
+++ b/test/browser/tests/prompts/mention_drag_reorder.test.js
@@ -28,6 +28,19 @@ test.describe("Mention drag reorder", () => {
     const textPosition = value.indexOf("says hello")
     expect(mentionPosition).toBeGreaterThan(textPosition)
   })
+
+  test("a mention can be dragged between two adjacent mentions with no spaces", async ({ editor }) => {
+    await editor.setValue(threeAdjacentMentions())
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(3)
+    expect(sgidOrder(await editor.value())).toEqual([ "zacharias", "alice", "bob" ])
+
+    await dragMentionBeforeSibling(editor, 2, 1)
+    await editor.flush()
+
+    expect(sgidOrder(await editor.value())).toEqual([ "zacharias", "bob", "alice" ])
+  })
 })
 
 async function insertMention(page, editor) {
@@ -42,8 +55,50 @@ async function insertMention(page, editor) {
   await expect(editor.content.locator("action-text-attachment")).toBeVisible({ timeout: 5_000 })
 }
 
+function threeAdjacentMentions() {
+  return `<p>${mentionHtml("zacharias", "Zacharias")}${mentionHtml("alice", "Alice")}${mentionHtml("bob", "Bob")}</p>`
+}
+
+function mentionHtml(sgid, name) {
+  const content = `<span class=&quot;person person--inline&quot;><span class=&quot;person--name&quot;>${name}</span></span>`
+  return `<action-text-attachment sgid="test-sgid-${sgid}" content="${content}" content-type="application/vnd.actiontext.mention"></action-text-attachment>`
+}
+
 async function mentionIsDraggable(mention) {
   return mention.evaluate((el) => el.draggable === true)
+}
+
+function sgidOrder(value) {
+  return [ ...value.matchAll(/sgid="test-sgid-([^"]+)"/g) ].map((match) => match[1])
+}
+
+// Drag the mention at sourceIndex and drop it just before the mention at targetIndex.
+async function dragMentionBeforeSibling(editor, sourceIndex, targetIndex) {
+  await editor.content.evaluate((root, { sourceIndex, targetIndex }) => {
+    const mentions = root.querySelectorAll("action-text-attachment")
+    const source = mentions[sourceIndex]
+    const target = mentions[targetIndex]
+
+    const targetRect = target.getBoundingClientRect()
+    const dropX = targetRect.left + 2
+    const dropY = targetRect.top + targetRect.height / 2
+
+    const dataTransfer = new DataTransfer()
+
+    const dispatch = (type, element, clientX, clientY) => {
+      const event = new DragEvent(type, { bubbles: true, cancelable: true, clientX, clientY })
+      Object.defineProperty(event, "dataTransfer", { value: dataTransfer })
+      element.dispatchEvent(event)
+    }
+
+    const startRect = source.getBoundingClientRect()
+    dispatch("dragstart", source, startRect.left + 2, startRect.top + startRect.height / 2)
+
+    const dropTarget = document.elementFromPoint(dropX, dropY) || root
+    dispatch("dragover", dropTarget, dropX, dropY)
+    dispatch("drop", dropTarget, dropX, dropY)
+    dispatch("dragend", source, dropX, dropY)
+  }, { sourceIndex, targetIndex })
 }
 
 async function dragMentionToEndOfLine(editor) {


### PR DESCRIPTION
Dragging a @mention to reorder it within a line works as long as there is text around it — but breaks down when mentions sit right next to each other. With two or more adjacent mentions and no spaces between them, trying to move one between the others does nothing: the mention stays put. While dragging, the drop cursor also appears *inside* a mention's text, even though there is no valid place to drop a mention in the middle of another one.

This is a follow-up to [Allow dragging mentions to reorder them within a line](https://github.com/basecamp/lexxy/pull/1136), which restored mention dragging but only handled drops that land on real text. Reported on [\[Mentions\] Can no longer re-arrange mentions in chat](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9974786701).

The cause is how the drop location is resolved. When the pointer is over a gap between adjacent mentions, the browser reports a caret *inside* the neighbouring mention's rendered DOM. Lexical can't turn a point inside a decorator into an editable position, so the move was quietly abandoned, and the drop indicator was drawn at that meaningless spot.

Now, when a drop lands on a mention, it snaps to just before or after that mention depending on which half the pointer is over, and the dragged mention is moved with Lexical's own node API rather than a reconstructed text selection. The drop indicator follows the same rule, so it only ever shows at a mention's edge — never in the middle of one.