### PR TITLE
Preserve blank lines between paragraphs in pasted blockquotes

### DIFF
--- a/src/helpers/html_helper.js
+++ b/src/helpers/html_helper.js
@@ -45,8 +45,8 @@ export function dispatch(element, eventName, detail = null, cancelable = false) 
 }
 
 export function addBlockSpacing(doc) {
-  const blocks = doc.querySelectorAll("body > :not(h1, h2, h3, h4, h5, h6) + *")
-  for (const block of blocks) {
+  const selector = "body > :not(h1, h2, h3, h4, h5, h6) + *, blockquote > :not(h1, h2, h3, h4, h5, h6) + *"
+  for (const block of doc.querySelectorAll(selector)) {
     const spacer = doc.createElement("p")
     spacer.appendChild(doc.createElement("br"))
     block.before(spacer)

--- a/test/browser/tests/paste/markdown.test.js
+++ b/test/browser/tests/paste/markdown.test.js
@@ -36,4 +36,52 @@ test.describe("Paste — Markdown", () => {
     await editor.paste("Hello **there**")
     await assertEditorHtml(editor, "<p>Hello **there**</p>")
   })
+
+  test("keep blank lines between paragraphs in a blockquote as separate paragraphs", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    await editor.paste(
+      "> First paragraph of the quote.\n>\n> Second paragraph of the quote.",
+    )
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("blockquote")).toHaveCount(1)
+      await expect(content.locator("blockquote > p")).toHaveCount(2)
+      await expect(content.locator("blockquote > p").nth(0)).toHaveText(
+        "First paragraph of the quote.",
+      )
+      await expect(content.locator("blockquote > p").nth(1)).toHaveText(
+        "Second paragraph of the quote.",
+      )
+    })
+  })
+
+  test("addBlockSpacing keeps the gap between paragraphs inside a blockquote", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+
+    await page.evaluate(() => {
+      document
+        .querySelector("lexxy-editor")
+        .addEventListener("lexxy:insert-markdown", (event) => {
+          event.detail.addBlockSpacing()
+        })
+    })
+
+    await editor.paste(
+      "> First paragraph of the quote.\n>\n> Second paragraph of the quote.",
+    )
+
+    await assertEditorHtml(
+      editor,
+      "<blockquote><p>First paragraph of the quote.</p><p><br></p><p>Second paragraph of the quote.</p></blockquote>",
+    )
+  })
 })

--- a/test/dummy/app/views/posts/_form.html.erb
+++ b/test/dummy/app/views/posts/_form.html.erb
@@ -19,6 +19,14 @@
   </script>
 <% end %>
 
+<% if params.key?("add-block-spacing") %>
+  <script type="module">
+    document.addEventListener("lexxy:insert-markdown", (event) => {
+      event.detail.addBlockSpacing()
+    })
+  </script>
+<% end %>
+
 <%= form_with model: post, data: { controller: "events-logger file-acceptance unfurl-link",
   file_acceptance_type_value: params[:attachment_type],
   action: "lexxy:focus->events-logger#log lexxy:blur->events-logger#log lexxy:change->events-logger#log lexxy:insert-link->events-logger#log lexxy:insert-link->unfurl-link#unfurl lexxy:insert-markdown->events-logger#log lexxy:file-accept->file-acceptance#acceptFile lexxy:upload-start->events-logger#log lexxy:upload-progress->events-logger#log lexxy:upload-end->events-logger#log"  } do |form| %>

--- a/test/javascript/unit/helpers/html_helper.test.js
+++ b/test/javascript/unit/helpers/html_helper.test.js
@@ -65,6 +65,12 @@ test("only operates on top-level children, not nested elements", () => {
   expect(bodyHtml(doc)).toBe("<ul><li>one</li><li>two</li></ul><p><br></p><p>after</p>")
 })
 
+test("inserts spacing between paragraphs inside a blockquote", () => {
+  const doc = parseHtml("<blockquote><p>a</p><p>b</p></blockquote>")
+  addBlockSpacing(doc)
+  expect(bodyHtml(doc)).toBe("<blockquote><p>a</p><p><br></p><p>b</p></blockquote>")
+})
+
 test("does not add leading spacer", () => {
   const doc = parseHtml("<p>a</p><p>b</p>")
   addBlockSpacing(doc)


### PR DESCRIPTION
## Summary

- Pasting a multi-paragraph Markdown blockquote (paragraphs separated by a blank `>` line) collapsed the gap between the quoted paragraphs, even though the same blank line between top-level paragraphs rendered with a visible gap.
- Root cause: `addBlockSpacing` (used by surfaces like BC5 via the `lexxy:insert-markdown` event) inserts spacer paragraphs between adjacent blocks, but its selector only matched direct children of `<body>`. The two `<p>` that `marked` emits inside a `<blockquote>` are nested, so they never received a spacer.
- Fix: extend the selector to also match adjacent block children inside a `<blockquote>`, mirroring the existing heading exclusion. The editor already preserves multiple paragraphs inside a blockquote; this restores the spacing host apps rely on.
- Tests: added a Playwright test asserting the pasted blockquote keeps two separate paragraphs, a Playwright test asserting `addBlockSpacing` inserts the spacer inside the blockquote, and a unit test for `addBlockSpacing`.

Fixes [Basecamp card #9935969865](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9935969865): Markdown blockquotes collapse blank lines between paragraphs