### PR TITLE
Keep nested bullets when pasting lists

### DIFF
--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -6,6 +6,7 @@ export default class PastedContentFormatter {
   format() {
     this.#unwrapPlaceholderAnchors()
     this.#stripTableCellColorStyles()
+    this.#nestStrayListChildren()
     this.#stripStrayListChildren()
     return this.doc
   }
@@ -31,6 +32,22 @@ export default class PastedContentFormatter {
       cell.style.removeProperty("background-color")
       cell.style.removeProperty("background")
       cell.style.removeProperty("color")
+    }
+  }
+
+  // Some sources (e.g. Gmail) nest a sublist as a direct child of the parent
+  // <ol>/<ul> instead of inside a <li>. Move each nested list into its
+  // preceding <li> so the import preserves the nesting instead of dropping it.
+  #nestStrayListChildren() {
+    for (const list of this.doc.querySelectorAll("ol, ul")) {
+      for (const child of Array.from(list.children)) {
+        if (child.tagName !== "OL" && child.tagName !== "UL") continue
+
+        const previousItem = child.previousElementSibling
+        if (previousItem && previousItem.tagName === "LI") {
+          previousItem.appendChild(child)
+        }
+      }
     }
   }
 

--- a/test/browser/tests/paste/clean_invalid_pasted_list_html.test.js
+++ b/test/browser/tests/paste/clean_invalid_pasted_list_html.test.js
@@ -86,3 +86,51 @@ test.describe("Paste list with stray non-<li> children before the first item", (
     expect(page).toHaveNoErrors()
   })
 })
+
+test.describe("Paste list with a nested list as a direct child", () => {
+  test("keeps a nested <ul> placed directly inside its parent <ul>", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ul><li>First item</li><ul><li>Nested item</li></ul><li>Second item</li></ul>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ul><li value="1">First item<ul><li value="1">Nested item</li></ul></li><li value="2">Second item</li></ul>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+
+  test("keeps a nested <ol> placed directly inside its parent <ol>", async ({
+    page,
+    editor,
+  }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: "<ol><li>First item</li><ol><li>Nested item</li></ol><li>Second item</li></ol>",
+    })
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      '<ol><li value="1">First item<ol><li value="1">Nested item</li></ol></li><li value="2">Second item</li></ol>',
+    )
+    expect(page).toHaveNoErrors()
+  })
+})


### PR DESCRIPTION
Pasting text that contains nested (indented) bullet lists — for example copied out of Gmail — silently dropped the indented items. Only the top-level bullets survived; everything nested under them disappeared. Several customers reported it.

The regression came in with [Strip stray non-<li> children from pasted lists](https://github.com/basecamp/lexxy/pull/1119). That change removed any non-`<li>` direct child of a pasted list to fix a stray-`<br>` problem, on the assumption that `<li>` is the only valid direct child of a list. But some sources nest a sublist as a *direct child* of the parent list rather than inside the preceding `<li>`, so the cleanup threw the nested list away before it could be imported.

Now, before that stripping runs, a nested `<ol>`/`<ul>` that sits directly inside its parent list is moved into the `<li>` that precedes it. The nesting is preserved on paste and the stray-child cleanup still does its job for genuine junk.

## Summary

- Move a nested list found as a direct child of its parent list into the preceding `<li>` during paste formatting, instead of discarding it.
- Add Playwright coverage for nested `<ul>` and `<ol>` pasted with the sublist as a direct child.

Fixes [Basecamp card #10010840203](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/10010840203): [BC5] Copying and pasting text that includes indented bullets ignores the indented content