### PR TITLE
Preserve code block whitespace and highlight offsets when rendering

### DIFF
--- a/src/helpers/code_highlighting_helper.js
+++ b/src/helpers/code_highlighting_helper.js
@@ -12,7 +12,6 @@ export function highlightElement(preElement) {
   if (preElement.dataset.highlighted === "true") return
 
   const language = preElement.getAttribute("data-language")
-  let code = preElement.innerHTML.replace(/<br\s*\/?>/gi, "\n")
 
   const grammar = Prism.languages?.[language]
   if (!grammar) return
@@ -20,8 +19,11 @@ export function highlightElement(preElement) {
   // Extract highlight ranges before Prism destroys <mark> elements
   const highlights = extractHighlightRanges(preElement)
 
-  // unescape HTML entities in the code block
-  code = new DOMParser().parseFromString(code, "text/html").body.textContent || ""
+  // Build the code string by walking the same nodes extractHighlightRanges
+  // counts, so character offsets line up and leading whitespace survives.
+  // Reading textContent through DOMParser would collapse leading whitespace
+  // and shift every highlight range, re-indenting the rendered block.
+  const code = extractCode(preElement)
 
   const highlightedHtml = Prism.highlight(code, grammar, language)
   preElement.innerHTML = highlightedHtml
@@ -31,6 +33,36 @@ export function highlightElement(preElement) {
   }
 
   preElement.dataset.highlighted = "true"
+}
+
+// Build the plain-text source for Prism by walking the same nodes
+// extractHighlightRanges counts: text node contents verbatim and a newline
+// per <br>. This keeps the offsets in both walks identical and avoids the
+// whitespace normalization that HTML parsing applies to a document body.
+function extractCode(preElement) {
+  const root = preElement.querySelector("code") || preElement
+
+  let code = ""
+
+  function walk(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      code += node.textContent
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      if (node.tagName === "BR") {
+        code += "\n"
+      } else {
+        for (const child of node.childNodes) {
+          walk(child)
+        }
+      }
+    }
+  }
+
+  for (const child of root.childNodes) {
+    walk(child)
+  }
+
+  return code
 }
 
 // Walk the DOM tree inside a <pre> element and build a list of

--- a/src/helpers/code_highlighting_helper.js
+++ b/src/helpers/code_highlighting_helper.js
@@ -16,14 +16,12 @@ export function highlightElement(preElement) {
   const grammar = Prism.languages?.[language]
   if (!grammar) return
 
-  // Extract highlight ranges before Prism destroys <mark> elements
-  const highlights = extractHighlightRanges(preElement)
-
-  // Build the code string by walking the same nodes extractHighlightRanges
-  // counts, so character offsets line up and leading whitespace survives.
-  // Reading textContent through DOMParser would collapse leading whitespace
-  // and shift every highlight range, re-indenting the rendered block.
-  const code = extractCode(preElement)
+  // Read the source text and <mark> ranges in a single walk, before Prism
+  // rewrites the element. Sharing one traversal keeps the highlight offsets
+  // aligned with the code string and preserves leading whitespace — deriving
+  // either of them separately (e.g. textContent through DOMParser) collapses
+  // leading whitespace and shifts every range, re-indenting the rendered block.
+  const { code, highlights } = extractCodeAndHighlights(preElement)
 
   const highlightedHtml = Prism.highlight(code, grammar, language)
   preElement.innerHTML = highlightedHtml
@@ -35,13 +33,15 @@ export function highlightElement(preElement) {
   preElement.dataset.highlighted = "true"
 }
 
-// Build the plain-text source for Prism by walking the same nodes
-// extractHighlightRanges counts: text node contents verbatim and a newline
-// per <br>. This keeps the offsets in both walks identical and avoids the
-// whitespace normalization that HTML parsing applies to a document body.
-function extractCode(preElement) {
+// Walk the <pre> once, building Prism's source text and the <mark> ranges
+// together: a text node contributes its text verbatim, a <br> contributes a
+// newline, and a <mark> records the slice of code it covers. Because both
+// outputs come from the same walk, every range offset is just a position in
+// `code` — so the highlights can't drift out of sync with the source, and the
+// block's leading whitespace survives (HTML parsing would collapse it).
+function extractCodeAndHighlights(preElement) {
   const root = preElement.querySelector("code") || preElement
-
+  const highlights = []
   let code = ""
 
   function walk(node) {
@@ -50,6 +50,15 @@ function extractCode(preElement) {
     } else if (node.nodeType === Node.ELEMENT_NODE) {
       if (node.tagName === "BR") {
         code += "\n"
+      } else if (node.tagName === "MARK") {
+        const start = code.length
+        for (const child of node.childNodes) {
+          walk(child)
+        }
+        const style = extractStyle(node)
+        if (style) {
+          highlights.push({ start, end: code.length, style })
+        }
       } else {
         for (const child of node.childNodes) {
           walk(child)
@@ -62,47 +71,7 @@ function extractCode(preElement) {
     walk(child)
   }
 
-  return code
-}
-
-// Walk the DOM tree inside a <pre> element and build a list of
-// { start, end, style } ranges for every <mark> element found.
-function extractHighlightRanges(preElement) {
-  const ranges = []
-  const root = preElement.querySelector("code") || preElement
-
-  let offset = 0
-
-  function walk(node) {
-    if (node.nodeType === Node.TEXT_NODE) {
-      offset += node.textContent.length
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-      if (node.tagName === "BR") {
-        offset += 1
-        return
-      }
-
-      const isMark = node.tagName === "MARK"
-      const start = offset
-
-      for (const child of node.childNodes) {
-        walk(child)
-      }
-
-      if (isMark) {
-        const style = extractStyle(node)
-        if (style) {
-          ranges.push({ start, end: offset, style })
-        }
-      }
-    }
-  }
-
-  for (const child of root.childNodes) {
-    walk(child)
-  }
-
-  return ranges
+  return { code, highlights }
 }
 
 function extractStyle(element) {

--- a/test/javascript/unit/helpers/code_highlighting_helper.test.js
+++ b/test/javascript/unit/helpers/code_highlighting_helper.test.js
@@ -91,6 +91,36 @@ test("highlightElement highlights a single pre element", () => {
   expect(pre.dataset.highlighted).toBe("true")
 })
 
+test("highlightElement preserves leading whitespace", () => {
+  const pre = appendPre("indented", "ruby", "    def hello")
+  document.body.appendChild(pre)
+
+  highlightElement(pre)
+
+  expect(pre.textContent).toBe("    def hello")
+})
+
+test("highlightElement preserves the alignment of an ASCII table with indented rows", () => {
+  const table = "+----+----+\n  | ab | cd |\n  |  e |  f |"
+  const pre = appendPre("ascii", "plain", table.replace(/\n/g, "<br>"))
+  document.body.appendChild(pre)
+
+  highlightElement(pre)
+
+  expect(pre.textContent).toBe(table)
+})
+
+test("highlightElement keeps color highlights on the right text when code is indented", () => {
+  const pre = appendPre("highlight", "ruby", "  def <mark style=\"background-color: yellow;\">hello</mark>")
+  document.body.appendChild(pre)
+
+  highlightElement(pre)
+
+  const mark = pre.querySelector("mark")
+  expect(mark.textContent).toBe("hello")
+  expect(mark.getAttribute("style")).toContain("background-color: yellow")
+})
+
 function appendPre(id, language, code) {
   const pre = document.createElement("pre")
   pre.id = id


### PR DESCRIPTION
## Summary

- Code blocks with leading whitespace (indented lines, ASCII/box-drawing tables) shifted after the editor → save → render round-trip, and color/background highlights inside code blocks drifted onto the wrong text.
- Root cause: `highlightElement` rebuilt the Prism source via `DOMParser().parseFromString(...).body.textContent`, which applies HTML whitespace normalization and strips the block's leading whitespace. Highlight `<mark>` offsets are computed from the un-normalized DOM, so applying them to the shorter, collapsed Prism text landed them on the wrong characters.
- Fix: build the Prism source by walking the same nodes `extractHighlightRanges` counts (text nodes verbatim, a newline per `<br>`), so both walks share an identical character stream. Whitespace survives and highlight ranges stay aligned.
- Added regression tests covering leading whitespace, indented ASCII tables, and highlight placement on indented code.

Fixes [Basecamp card #10018912693](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/10018912693): Code block randomly shifts contents around