### PR TITLE
Keep text typed above a quote unformatted

### DIFF
--- a/src/extensions/format_escape_extension.js
+++ b/src/extensions/format_escape_extension.js
@@ -55,13 +55,15 @@ function $escapeBeforeBlockquoteStart() {
   if (!$isRangeSelection(selection) || !selection.isCollapsed() || selection.anchor.offset !== 0) return false
 
   const paragraph = $getNearestNodeOfType(selection.anchor.getNode(), ParagraphNode)
-  if (!paragraph || $isBlankNode(paragraph) || paragraph.getPreviousSibling()) return false
+  if (paragraph && !$isBlankNode(paragraph) && !paragraph.getPreviousSibling()) {
+    const blockquote = paragraph.getParent()
+    if ($isQuoteNode(blockquote)) {
+      blockquote.insertBefore($createParagraphNode())
+      return true
+    }
+  }
 
-  const blockquote = paragraph.getParent()
-  if (!blockquote || !$isQuoteNode(blockquote)) return false
-
-  blockquote.insertBefore($createParagraphNode())
-  return true
+  return false
 }
 
 function $escapeFromBlankBlockquoteParagraph() {
@@ -71,18 +73,20 @@ function $escapeFromBlankBlockquoteParagraph() {
   if (!paragraph || !$isBlankNode(paragraph)) return false
 
   const blockquote = paragraph.getParent()
-  if (!blockquote || !$isQuoteNode(blockquote)) return false
+  if ($isQuoteNode(blockquote)) {
+    const nonEmptySiblings = paragraph.getNextSiblings().filter(sibling => !$isBlankNode(sibling))
 
-  const nonEmptySiblings = paragraph.getNextSiblings().filter(sibling => !$isBlankNode(sibling))
+    if (nonEmptySiblings.length > 0) {
+      $splitQuoteNode(blockquote, paragraph)
+    } else {
+      blockquote.insertAfter(paragraph)
+      paragraph.selectStart()
+    }
 
-  if (nonEmptySiblings.length > 0) {
-    $splitQuoteNode(blockquote, paragraph)
-  } else {
-    blockquote.insertAfter(paragraph)
-    paragraph.selectStart()
+    return true
   }
 
-  return true
+  return false
 }
 
 function $splitQuoteNode(node, paragraph) {

--- a/src/extensions/format_escape_extension.js
+++ b/src/extensions/format_escape_extension.js
@@ -47,6 +47,24 @@ export class FormatEscapeExtension extends LexxyExtension {
 }
 
 function $escapeFromBlockquote() {
+  return $escapeBeforeBlockquoteStart() || $escapeFromBlankBlockquoteParagraph()
+}
+
+function $escapeBeforeBlockquoteStart() {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection) || !selection.isCollapsed() || selection.anchor.offset !== 0) return false
+
+  const paragraph = $getNearestNodeOfType(selection.anchor.getNode(), ParagraphNode)
+  if (!paragraph || $isBlankNode(paragraph) || paragraph.getPreviousSibling()) return false
+
+  const blockquote = paragraph.getParent()
+  if (!blockquote || !$isQuoteNode(blockquote)) return false
+
+  blockquote.insertBefore($createParagraphNode())
+  return true
+}
+
+function $escapeFromBlankBlockquoteParagraph() {
   const anchorNode = $getSelection().anchor.getNode()
 
   const paragraph = $getNearestNodeOfType(anchorNode, ParagraphNode)

--- a/test/browser/tests/formatting/format_bleed_above.test.js
+++ b/test/browser/tests/formatting/format_bleed_above.test.js
@@ -1,0 +1,46 @@
+import { test } from "../../test_helper.js"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Formatting does not bleed onto text typed above", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    await editor.focus()
+  })
+
+  test("Enter at the start of a blockquote then typing above stays plain", async ({ editor }) => {
+    await editor.setValue("<blockquote><p>Quoted</p></blockquote>")
+    await editor.click()
+
+    await editor.send("Home")
+    await editor.send("Enter")
+    await editor.send("ArrowUp")
+    await editor.send("plain text")
+
+    await assertEditorHtml(editor, "<p>plain text</p><blockquote><p>Quoted</p></blockquote>")
+  })
+
+  test("typing above bold text pushed down stays unformatted", async ({ editor }) => {
+    await editor.setValue("<p><strong>Bold</strong></p>")
+    await editor.click()
+
+    await editor.send("Home")
+    await editor.send("Enter")
+    await editor.send("ArrowUp")
+    await editor.send("plain text")
+
+    await assertEditorHtml(editor, "<p>plain text</p><p><strong>Bold</strong></p>")
+  })
+
+  test("typing above italic text pushed down stays unformatted", async ({ editor }) => {
+    await editor.setValue("<p><em>Italic</em></p>")
+    await editor.click()
+
+    await editor.send("Home")
+    await editor.send("Enter")
+    await editor.send("ArrowUp")
+    await editor.send("plain text")
+
+    await assertEditorHtml(editor, "<p>plain text</p><p><em>Italic</em></p>")
+  })
+})


### PR DESCRIPTION
## Summary

- Pressing Enter at the very start of a blockquote's first paragraph created a new empty paragraph *inside* the blockquote. After navigating up to that line and typing, the text became quoted — so any text added above formatted content at the top of a message inherited the formatting instead of staying plain.
- Now, when the caret is collapsed at offset 0 of the blockquote's first (non-blank) paragraph, we insert a plain paragraph **before** the blockquote and leave the quoted content untouched. This matches the BC4/Trix behavior where text typed above a quote is unformatted.
- The fix lives in the existing `INSERT_PARAGRAPH_COMMAND` handler in `src/extensions/format_escape_extension.js`, split into `$escapeBeforeBlockquoteStart` (new) and `$escapeFromBlankBlockquoteParagraph` (the prior logic).

## Tests

- New Playwright coverage in `test/browser/tests/formatting/format_bleed_above.test.js`:
  - Enter at the start of a blockquote then typing above stays plain (`<p>` before the blockquote).
  - Regression guards confirming inline **bold** and *italic* formatting does not bleed onto a line typed above it.
- Full Playwright (chromium) and Vitest suites pass; lint clean.

Fixes [Basecamp card #9985732711](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9985732711): Formatting being applied to text incorrectly if added before formatted text