### PR TITLE
Don't bleed quote formatting into text typed above a blockquote

### DIFF
--- a/src/extensions/format_escape_extension.js
+++ b/src/extensions/format_escape_extension.js
@@ -47,6 +47,25 @@ export class FormatEscapeExtension extends LexxyExtension {
 }
 
 function $escapeFromBlockquote() {
+  return $escapeFromBlockquoteStart() || $escapeFromBlockquoteEnd()
+}
+
+function $escapeFromBlockquoteStart() {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection) || !selection.isCollapsed() || selection.anchor.offset !== 0) return false
+
+  const paragraph = $getNearestNodeOfType(selection.anchor.getNode(), ParagraphNode)
+  if (!paragraph || paragraph.getPreviousSibling() || $isBlankNode(paragraph)) return false
+
+  const blockquote = paragraph.getParent()
+  if (!blockquote || !$isQuoteNode(blockquote)) return false
+
+  blockquote.insertBefore($createParagraphNode())
+
+  return true
+}
+
+function $escapeFromBlockquoteEnd() {
   const anchorNode = $getSelection().anchor.getNode()
 
   const paragraph = $getNearestNodeOfType(anchorNode, ParagraphNode)

--- a/test/browser/tests/formatting/typing_above_formatted_content.test.js
+++ b/test/browser/tests/formatting/typing_above_formatted_content.test.js
@@ -1,0 +1,40 @@
+import { test } from "../../test_helper.js"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Typing above formatted content", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    await editor.focus()
+  })
+
+  test("Enter at the start of a blockquote, then typing above, stays unformatted", async ({ editor }) => {
+    await editor.setValue("<blockquote><p>Quoted</p></blockquote>")
+    await editor.send("Home")
+    await editor.send("Enter")
+    await editor.send("ArrowUp")
+    await editor.send("plain text")
+
+    await assertEditorHtml(editor, "<p>plain text</p><blockquote><p>Quoted</p></blockquote>")
+  })
+
+  test("Shift+Enter at the start of a blockquote, then typing above, stays unformatted", async ({ editor }) => {
+    await editor.setValue("<blockquote><p>Quoted</p></blockquote>")
+    await editor.send("Home")
+    await editor.send("Shift+Enter")
+    await editor.send("ArrowUp")
+    await editor.send("plain text")
+
+    await assertEditorHtml(editor, "<blockquote><p>plain text<br>Quoted</p></blockquote>")
+  })
+
+  test("typing above bold text inserted at the start stays unformatted", async ({ editor }) => {
+    await editor.setValue("<p><strong>Bold</strong></p>")
+    await editor.send("Home")
+    await editor.send("Enter")
+    await editor.send("ArrowUp")
+    await editor.send("plain text")
+
+    await assertEditorHtml(editor, "<p>plain text</p><p><strong>Bold</strong></p>")
+  })
+})


### PR DESCRIPTION
## Summary

- Pressing **Enter at the very start of a blockquote's first line** split the paragraph in place, leaving a new empty paragraph *inside* the blockquote. Text typed there inherited the quote formatting, so content added "above" the quote came out formatted instead of plain — diverging from Trix/BC4 behavior.
- The fix handles this in the `INSERT_PARAGRAPH` command: when the cursor is collapsed at offset 0 of a blockquote's first (non-blank) paragraph, we insert a fresh paragraph *before* the blockquote instead of splitting inside it. The quote is pushed down and the line above becomes a plain, unformatted paragraph.
- The existing "escape from the end/bottom of a blockquote" behavior is preserved (refactored into `$escapeFromBlockquoteEnd`).

## Test

Adds `test/browser/tests/formatting/typing_above_formatted_content.test.js` covering Enter and Shift+Enter at the start of a blockquote, plus typing above bold text. The Enter case fails without the fix (`<blockquote><p>plain text</p><p>Quoted</p></blockquote>`) and passes with it (`<p>plain text</p><blockquote><p>Quoted</p></blockquote>`). Full Playwright suite: 544 passed, 0 failures (1 pre-existing flaky).

Fixes [Basecamp card #9985732711](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9985732711): Formatting being applied to text incorrectly if added before formatted text
