### PR TITLE
Preserve backslashes in plain text pasted across multiple lines

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -182,14 +182,16 @@ export default class Clipboard {
 
   // Markdown conversion collapses runs of whitespace and unescapes backslashes,
   // silently corrupting plain text such as Windows/UNC file paths. When the text
-  // carries no Markdown structure, paste it verbatim instead.
+  // carries no Markdown structure, paste it verbatim instead. A path that wrapped
+  // across lines renders as a single paragraph with <br> line breaks (marked runs
+  // with breaks: true), which is still plain text we should preserve untouched.
   #isPlainTextWithoutMarkdown(doc) {
     const elements = Array.from(doc.body.children)
     if (elements.length !== 1) return false
 
     const paragraph = elements[0]
     return paragraph.nodeName === "P"
-      && Array.from(paragraph.childNodes).every((node) => node.nodeType === Node.TEXT_NODE)
+      && Array.from(paragraph.childNodes).every((node) => node.nodeType === Node.TEXT_NODE || node.nodeName === "BR")
   }
 
   #pasteRichText(clipboardData) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -51,7 +51,11 @@ export default class Contents {
 
   insertText(text, { tag } = {}) {
     this.editor.update(() => {
-      const paragraph = $createParagraphNode().append($createTextNode(text))
+      const paragraph = $createParagraphNode()
+      text.split("\n").forEach((line, index) => {
+        if (index > 0) paragraph.append($createLineBreakNode())
+        paragraph.append($createTextNode(line))
+      })
       this.insertAtCursor(paragraph)
     }, { tag })
   }

--- a/test/browser/tests/paste/plain_text_paths.test.js
+++ b/test/browser/tests/paste/plain_text_paths.test.js
@@ -30,6 +30,17 @@ test.describe("Paste — Plain text paths and spacing", () => {
     expect(await editor.plainTextValue()).toBe(path)
   })
 
+  test("preserves leading backslashes when a UNC path spans multiple lines", async ({ editor }) => {
+    const path = "\\\\Arina-alvand\\alvand\\03 - ENGINEERING\n\\00. Input\\2026-06-17"
+
+    await editor.paste(path)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("a")).toHaveCount(0)
+    })
+    expect(await editor.plainTextValue()).toBe(path)
+  })
+
   test("preserves runs of consecutive spaces in plain text", async ({ editor }) => {
     const text = "path  with    multiple   spaces"
 


### PR DESCRIPTION
Pasting a Windows/UNC file path that spans more than one line silently dropped the first of its two leading backslashes — `\\server\share` came in as `\server\share`. It happened when the path was copied from somewhere it wrapped across lines, such as multi-line CLI output, or when pasting with "paste and match style". A single-line path pasted cleanly; only the multi-line case was affected.

Originally reported in [Local directory links being modified in Lexxy](https://app.basecamp.com/2914079/buckets/41746046/card_tables/cards/9942235640).

This is a follow-up to [Preserve plain text spacing and backslashes on paste](https://github.com/basecamp/lexxy/commit/52aaa34f568cd42b27120cb3036d7585b41dab1c), which fixed the same corruption for single-line paths. Plain text pasted without an HTML payload routes through the Markdown conversion path, which collapses whitespace and unescapes backslashes. That fix skipped Markdown and pasted verbatim only when the text rendered to a single paragraph of pure text nodes. A path that wrapped across lines renders as a paragraph with `<br>` line breaks (the Markdown converter runs with line breaks enabled), so it failed that check and fell back to the corrupting path.

Multi-line plain text with no Markdown structure is now recognized as plain text and pasted verbatim, with its line breaks preserved.