### PR TITLE
Autolink bare URLs pasted with an HTML companion

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -40,7 +40,7 @@ export default class Clipboard {
     }
 
     if (this.#isPlainTextOrURLPasted(clipboardData)) {
-      this.#pastePlainText(clipboardData)
+      this.#pastePlainTextOrURL(clipboardData)
       event.preventDefault()
       return true
     }
@@ -78,14 +78,34 @@ export default class Clipboard {
     return types.length === 1 && types[0] === "text/plain"
   }
 
+  // Browsers expose a copied URL in several shapes:
+  //   Safari          [ text/plain, text/uri-list ]
+  //   App ShareSheet  [ text/uri-list ]
+  //   Chromium macOS  [ text/plain, text/html, (?:text/link-preview) ]
   #isOnlyURLPasted(clipboardData) {
-    // Safari URLs are copied as a text/plain + text/uri-list object
-    // App ShareSheet URLs are copied as solo text/uri-list object
+    if (this.#isLexicalClipboardData(clipboardData)) return false
+
     const types = Array.from(clipboardData.types)
-    return types.length
-      && types.length <= 2
-      && types.includes("text/uri-list")
-      && (types.length < 2 || types.includes("text/plain"))
+    if (types.includes("text/uri-list")) {
+      return types.every(type => type === "text/plain" || type === "text/uri-list")
+    }
+
+    if (clipboardData.files.length) return false
+
+    const text = clipboardData.getData("text/plain").trim()
+    if (!isAutolinkableURL(text)) return false
+
+    const html = clipboardData.getData("text/html")
+    return !html || this.#htmlIsBareLinkToURL(html, text)
+  }
+
+  #htmlIsBareLinkToURL(html, url) {
+    const doc = parseHtml(html)
+    if (doc.body.textContent.trim() !== url) return false
+
+    const links = doc.body.querySelectorAll("a")
+    if (links.length === 0) return true
+    return links.length === 1 && links[0].getAttribute("href") === url
   }
 
   #isPastingIntoCodeBlock() {
@@ -119,20 +139,32 @@ export default class Clipboard {
     }, { tag: PASTE_TAG })
   }
 
-  #pastePlainText(clipboardData) {
-    const item = clipboardData.items[0]
+  #pastePlainTextOrURL(clipboardData) {
+    const item = this.#plainTextOrURLItem(clipboardData)
     item.getAsString((text) => {
-      if (isAutolinkableURL(text) && this.contents.hasSelectedText()) {
-        this.contents.createLinkWithSelectedText(text)
-      } else if (isAutolinkableURL(text)) {
-        const nodeKey = this.contents.createLink(text)
-        this.#dispatchLinkInsertEvent(nodeKey, { url: text })
+      const url = text.trim()
+      if (isAutolinkableURL(url)) {
+        this.#pasteURL(url)
       } else if (this.editorElement.supportsMarkdown) {
         this.#pasteMarkdown(text)
       } else {
         this.#pasteRichText(clipboardData)
       }
     })
+  }
+
+  #plainTextOrURLItem(clipboardData) {
+    const items = Array.from(clipboardData.items)
+    return items.find((item) => item.type === "text/plain") || items.find((item) => item.type === "text/uri-list")
+  }
+
+  #pasteURL(url) {
+    if (this.contents.hasSelectedText()) {
+      this.contents.createLinkWithSelectedText(url)
+    } else {
+      const nodeKey = this.contents.createLink(url)
+      this.#dispatchLinkInsertEvent(nodeKey, { url })
+    }
   }
 
   #insertSingleLinkAt(selection, url) {

--- a/test/browser/tests/paste/links.test.js
+++ b/test/browser/tests/paste/links.test.js
@@ -54,6 +54,42 @@ test.describe("Paste — Links", () => {
     )
   })
 
+  test("creates a link when pasting text/plain + text/html of the same bare URL (Chromium on macOS address bar)", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+
+    await editor.paste("https://37signals.com", { html: "https://37signals.com" })
+
+    await assertEditorHtml(
+      editor,
+      '<p>Hello everyone<a href="https://37signals.com">https://37signals.com</a></p>',
+    )
+  })
+
+  test("does not autolink when text/html carries more than the bare URL", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+
+    await editor.paste("https://37signals.com", {
+      html: '<p>Read <a href="https://37signals.com">our blog</a></p>',
+    })
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator('a[href="https://37signals.com"]')).toHaveText("our blog")
+    })
+  })
+
+  test("keeps the real target when text/html is an anchor whose href differs from its text", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello everyone</p>")
+
+    await editor.paste("https://37signals.com", {
+      html: '<a href="https://evil.example.com">https://37signals.com</a>',
+    })
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator('a[href="https://evil.example.com"]')).toHaveCount(1)
+      await expect(content.locator('a[href="https://37signals.com"]')).toHaveCount(0)
+    })
+  })
+
   test("create links when pasting URLs keeps formatting", async ({
     page,
     editor,


### PR DESCRIPTION
## Summary

Pasting a URL copied straight from the address bar in Chromium-based browsers on macOS (Edge in particular) didn't autolink.

## Root cause

A pasted URL lands on the clipboard in different shapes depending on where it was copied from:

- Safari: `[ text/plain, text/uri-list` ]
- App ShareSheet: `[ text/uri-list ]`
- Chromium on macOS: `[ text/plain, text/html, (?:text/link-preview) ]`

`#isOnlyURLPasted` depended on `text/uri-list` being present. Chromium on macOS omits `text/uri-list` and instead carries a `text/html` copy of the same bare URL. That didn't match any case, so the paste fell through to plain HTML insertion and wasn't autolinked.

A second, related problem: `#pastePlainText` read the URL from `clipboardData.items[0]`, but Chromium lists the `text/html` item first — so even once detected, the text would have been read from the wrong entry.

## Fix

- Treat a clipboard whose `text/plain` is a lone autolinkable URL — and whose `text/html`, if present, is just a copy of that URL — as a URL paste. The `text/html`-equals-`text/plain` guard keeps genuine rich pastes (a labeled link, a URL inside a sentence) on the HTML path.
- Read the URL from the `text/plain` (or `text/uri-list`) item explicitly rather than `items[0]`.

## Testing

- Two new browser tests in `paste/links.test.js`: the Chromium/macOS shape (`text/plain` + matching `text/html`) now autolinks; a `text/html` carrying more than the bare URL stays on the HTML path.
- Full paste suite green on Chromium, Firefox, and WebKit (345 tests).