### PR TITLE
Strip foreign cell shading from pasted and loaded tables

### DIFF
--- a/src/extensions/tables_extension.js
+++ b/src/extensions/tables_extension.js
@@ -55,9 +55,13 @@ export class TablesExtension extends LexxyExtension {
             }
           }),
 
-          // Bug fix: Prevent hardcoded background color (Lexical #8089)
+          // A table in Lexxy is a Lexxy table: cell shading can't be set in the
+          // editor, so any cell background only ever comes from foreign content
+          // (pasted spreadsheets, loaded documents). Normalize every cell to no
+          // background so it adopts the current theme. This also clears
+          // Lexical's hardcoded default header background (Lexical #8089).
           editor.registerNodeTransform(TableCellNode, (node) => {
-            if (node.getBackgroundColor() === null) {
+            if (node.getBackgroundColor() !== "") {
               node.setBackgroundColor("")
             }
           }),

--- a/test/browser/tests/paste/table_cell_styles.test.js
+++ b/test/browser/tests/paste/table_cell_styles.test.js
@@ -113,4 +113,97 @@ test.describe("Paste — Table cell color styles", () => {
       }
     })
   })
+
+  // Excel puts hardcoded text colors on the inner spans/fonts of each cell, not
+  // just on the <td>. A Lexxy table adopts the current theme, so pasted foreign
+  // colors inside cells must be stripped along with the cell's own styles.
+  test("strips color from elements nested inside pasted table cells", async ({
+    editor,
+  }) => {
+    const tableHtml = `
+      <table>
+        <tr>
+          <td style="color: windowtext;"><span style="color: black;">First</span></td>
+          <td><font color="#000000"><span style="color: #000000;">Second</span></font></td>
+        </tr>
+      </table>
+    `
+
+    await editor.paste("First\tSecond", { html: tableHtml })
+
+    await assertEditorContent(editor, async (content) => {
+      const cells = content.locator("table td, table th")
+      for (const cell of await cells.all()) {
+        const color = await cell.evaluate((el) => el.style.color)
+        expect(color).toBe("")
+      }
+
+      const styledDescendants = content.locator(
+        'table td [style*="color"], table th [style*="color"]',
+      )
+      await expect(styledDescendants).toHaveCount(0)
+    })
+  })
+
+  // A cell shaded in Excel keeps a hardcoded background-color that survives the
+  // sanitizer. Cell shading can't be set in Lexxy, so strip it on paste.
+  test("strips shading and text color from an Excel-style shaded cell", async ({
+    editor,
+  }) => {
+    const tableHtml = `
+      <table>
+        <tr>
+          <td style="background-color: #ffff00; color: black;"><span style="color: black;">Shaded</span></td>
+        </tr>
+      </table>
+    `
+
+    await editor.paste("Shaded", { html: tableHtml })
+
+    await assertEditorContent(editor, async (content) => {
+      const cell = content.locator("table td")
+      await expect(cell).toHaveCount(1)
+
+      const styles = await cell.evaluate((el) => ({
+        background: el.style.background,
+        backgroundColor: el.style.backgroundColor,
+        color: el.style.color,
+      }))
+      expect(styles.background).toBe("")
+      expect(styles.backgroundColor).toBe("")
+      expect(styles.color).toBe("")
+
+      const styledDescendants = cell.locator('[style*="color"]')
+      await expect(styledDescendants).toHaveCount(0)
+    })
+  })
+
+  // Shading survives as TableCellNode state, so it reappears when previously
+  // stored content is loaded back into the editor — a path the paste-time
+  // formatter never sees. Normalize it away on load too.
+  test("strips shading from cells when loading stored content", async ({
+    editor,
+  }) => {
+    await editor.setValue(`
+      <table><tbody>
+        <tr>
+          <td style="background-color: rgb(255, 255, 0);">Shaded</td>
+          <td>Plain</td>
+        </tr>
+      </tbody></table>
+    `)
+
+    const value = await editor.value()
+    expect(value).not.toContain("background-color")
+
+    await assertEditorContent(editor, async (content) => {
+      const cells = content.locator("table td")
+      await expect(cells).toHaveCount(2)
+
+      for (const cell of await cells.all()) {
+        const bgColor = await cell.evaluate((el) => el.style.backgroundColor)
+        expect(bgColor).toBe("")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Root cause

Lexical stores a cell's `background-color` as `TableCellNode` state (read from the inline style during import). The paste-time `PastedContentFormatter` strips cell colors from the pasted DOM, but:

- it only runs on the **paste** path, not when stored content is loaded back into the editor (`setValue`), and
- the existing `TableCellNode` transform only cleared the background when it was `null` — a workaround for Lexical's hardcoded default header fill ([#8089](https://github.com/facebook/lexical/issues/8089)) — so a *foreign* color survived the whole editor → save → render → re-edit round-trip.

## Fix

Normalize every `TableCellNode` to no background regardless of its current value, in the existing cell transform. This covers paste, load, and re-edit uniformly, and still clears the Lexical default header fill. Palette text highlights live on inner nodes, so they're untouched.

## Tests

`test/browser/tests/paste/table_cell_styles.test.js`:
- New: shading stripped from a cell when **loading stored content** (the path the paste formatter never sees — fails without this fix).
- New: color stripped from elements **nested inside** pasted cells (Excel's inner spans/fonts).
- New: an Excel-style **shaded cell** loses both shading and foreign text color on paste.

Pre-existing failures in `clean_invalid_pasted_list_html.test.js` are unrelated (they fail on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)