### PR TITLE
Code blocks load unhighlighted from the initial value

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -8,7 +8,7 @@ import { HeadingNode, QuoteNode, registerRichText } from "@lexical/rich-text"
 import { $generateHtmlFromNodes, $generateNodesFromDOM as $generateLexicalNodesFromDOM } from "@lexical/html"
 import { filterDisallowedAttachmentNodes } from "../helpers/attachment_filter_helper"
 import { $convertInlineImageDataURIs } from "../helpers/inline_image_uri_helper"
-import { CodeHighlightNode, CodeNode, registerCodeHighlighting } from "@lexical/code"
+import { CodeHighlightNode, CodeNode } from "@lexical/code"
 import { TRANSFORMERS, registerMarkdownShortcuts } from "@lexical/markdown"
 import { HORIZONTAL_DIVIDER } from "../editor/markdown/horizontal_divider_transformer"
 import { registerMarkdownLeadingTagHandler } from "../editor/markdown/leading_tag_handler"
@@ -34,6 +34,7 @@ import { styleResolverRoot } from "../helpers/style_resolver_root"
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
 import { exportTextNodeDOM } from "../helpers/text_node_export_helper"
 import { ProvisionalParagraphExtension } from "../extensions/provisional_paragraph_extension"
+import { CodeHighlightingExtension } from "../extensions/code_highlighting_extension"
 import { HighlightExtension } from "../extensions/highlight_extension"
 import { TrixContentExtension } from "../extensions/trix_content_extension"
 import { TablesExtension } from "../extensions/tables_extension"
@@ -195,6 +196,7 @@ export class LexicalEditorElement extends HTMLElement {
   get baseExtensions() {
     return [
       ProvisionalParagraphExtension,
+      CodeHighlightingExtension,
       HighlightExtension,
       TrixContentExtension,
       TablesExtension,
@@ -602,7 +604,7 @@ export class LexicalEditorElement extends HTMLElement {
         registerList(this.editor)
       )
       this.#registerTableComponents()
-      this.#registerCodeHiglightingComponents()
+      this.#registerCodeLanguagePicker()
       if (this.supportsMarkdown) {
         const transformers = [ ...TRANSFORMERS, HORIZONTAL_DIVIDER ]
         registered.push(
@@ -624,8 +626,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.#disposables.push(tableTools)
   }
 
-  #registerCodeHiglightingComponents() {
-    registerCodeHighlighting(this.editor)
+  #registerCodeLanguagePicker() {
     let codeLanguagePicker = this.querySelector("lexxy-code-language-picker")
     codeLanguagePicker ??= createElement("lexxy-code-language-picker")
     this.append(codeLanguagePicker)

--- a/src/extensions/code_highlighting_extension.js
+++ b/src/extensions/code_highlighting_extension.js
@@ -1,0 +1,23 @@
+import { defineExtension } from "lexical"
+import { registerCodeHighlighting } from "@lexical/code"
+import LexxyExtension from "./lexxy_extension"
+
+// Registers code highlighting through the extension system so its node
+// transforms exist before the initial editor state is applied. Registering
+// after editor creation misses code blocks loaded from the initial value:
+// their transform pass has already run, and Lexical's catch-up dirtying
+// only sees the committed (still empty) state.
+export class CodeHighlightingExtension extends LexxyExtension {
+  get enabled() {
+    return this.editorElement.supportsRichText
+  }
+
+  get lexicalExtension() {
+    return defineExtension({
+      name: "lexxy/code-highlighting",
+      register(editor) {
+        return registerCodeHighlighting(editor)
+      }
+    })
+  }
+}

--- a/test/browser/fixtures/initial-value-code-block.html
+++ b/test/browser/fixtures/initial-value-code-block.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Initial Value Code Block</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..." value='<p>Some CSS:</p><pre data-language="css" data-highlight-language="css">body {<br>  font-size: 20px;<br>}</pre>'></lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/formatting/code_block_initial_value.test.js
+++ b/test/browser/tests/formatting/code_block_initial_value.test.js
@@ -1,0 +1,15 @@
+import { expect } from "@playwright/test"
+import { test } from "../../test_helper.js"
+
+test.describe("Code block loaded as initial value", () => {
+  test("highlights syntax on load without user interaction", async ({ page, editor }) => {
+    await page.goto("/initial-value-code-block.html")
+    await editor.waitForConnected()
+
+    const codeBlock = editor.content.locator('code[data-language="css"]')
+    await expect(codeBlock).toBeAttached()
+
+    const tokens = codeBlock.locator('[class*="code-token"]')
+    await expect(tokens.first()).toBeAttached()
+  })
+})


### PR DESCRIPTION
Code blocks loaded from the editor's initial `value` render without syntax highlighting. The language imports correctly (the toolbar picker even shows it), but the block stays plain until something touches it — e.g. re-selecting a language. Easy to see on the lexxy.dev sandbox, which loads a CSS block as part of the initial content.

## Where it came from

Regression from 30a7a37d ("Inject initial value at editor creation time", Jun 2), first released in **v0.9.16**. That commit moved initial-value parsing from `#initialize()` (which ran *after* `#registerComponents()`) into editor creation via `$initialEditorState`, which `@lexical/extension` applies in its `afterRegistration` phase — before `#registerComponents()` calls `registerCodeHighlighting()`.

Why that ordering matters:

1. Lexical only tokenizes code blocks through a node transform, and transforms only run on nodes marked dirty.
2. When the initial value is parsed, its transform pass runs immediately — but the code-highlighting transform isn't registered yet.
3. `registerCodeHighlighting()` registers next. Lexical's catch-up pass (`markNodesWithTypesAsDirty`) marks existing code nodes dirty so late-registered transforms run — but it reads the **committed** editor state, and the initial-value update is still pending (it commits on a microtask, later in the same task). It sees an empty document and marks nothing.
4. The content commits; transforms don't re-run on commit. The code block stays untokenized until some later edit dirties it — which is exactly what picking a language in the toolbar does.

Before 30a7a37d the registration ran first, so the initial value's own transform pass did the tokenizing. That's why apps pinned to older versions (e.g. Fizzy on 0.9.5.beta) don't show this.

## The fix

Register code highlighting through the extension system instead of after editor creation. Extension `register()` hooks run before `@lexical/extension` applies the initial state, restoring the ordering guarantee the old code had. As a side effect this also stops discarding `registerCodeHighlighting()`'s teardown function — the extension system now owns it.

The `lexxy-code-language-picker` element setup stays in the editor element, where it belongs (it needs the DOM).

Verified on the lexxy.dev sandbox running against this build: the CSS block tokenizes on first paint. The new browser test fails on `main` and passes here.
