### PR TITLE
Guard focus() against an uninitialized editor

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -317,7 +317,7 @@ export class LexicalEditorElement extends HTMLElement {
     // Skip if the contenteditable already owns focus — the update would be a
     // no-op but still triggers a full style/layout pass on pages with large
     // DOMs.
-    if (this.#isContentFocused) return
+    if (!this.editor || this.#isContentFocused) return
 
     this.editor.focus(() => this.#onFocus())
   }

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -317,9 +317,9 @@ export class LexicalEditorElement extends HTMLElement {
     // Skip if the contenteditable already owns focus — the update would be a
     // no-op but still triggers a full style/layout pass on pages with large
     // DOMs.
-    if (!this.editor || this.#isContentFocused) return
-
-    this.editor.focus(() => this.#onFocus())
+    if (this.editor && !this.#isContentFocused) {
+      this.editor.focus(() => this.#onFocus())
+    }
   }
 
   get #isContentFocused() {

--- a/test/browser/tests/editor/focus.test.js
+++ b/test/browser/tests/editor/focus.test.js
@@ -26,4 +26,21 @@ test.describe("Focus", () => {
 
     await expect(editor.content).toBeFocused()
   })
+
+  test("focus() on an uninitialized editor is a safe no-op", async ({ page }) => {
+    const thrown = await page.evaluate(async () => {
+      await customElements.whenDefined("lexxy-editor")
+
+      const editor = document.createElement("lexxy-editor")
+
+      try {
+        editor.focus()
+        return null
+      } catch (error) {
+        return error.message
+      }
+    })
+
+    expect(thrown).toBeNull()
+  })
 })


### PR DESCRIPTION
`focus()` reads `this.editor`, which is only assigned in connectedCallback. When `focus()` runs before the editor is initialized, the `#isContentFocused` guard evaluates to false and execution falls through to `this.editor.focus()`, throwing "undefined is not an object (evaluating 'this.editor.focus')".

This can happen when using Lexxy alongside Turbo and autofocus. Turbo can call `focus()` on the element before the editor is initialized, leading to an error.

This commit makes Lexxy return early when `this.editor` is not set. Autofocus still works through the element's own `#handleAutofocus`, which runs after the editor is created.
