### PR TITLE
Fix plain text paste being ignored without markdown

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -4,7 +4,6 @@ import { nextFrame } from "../helpers/timing_helper"
 import { addBlockSpacing, dispatch, parseHtml } from "../helpers/html_helper"
 import { $isCodeNode } from "@lexical/code"
 import { $createTextNode, $getSelection, $isParagraphNode, $isRangeSelection, $onUpdate, COMMAND_PRIORITY_NORMAL, PASTE_COMMAND, PASTE_TAG, SELECTION_INSERT_CLIPBOARD_NODES_COMMAND } from "lexical"
-import { $insertDataTransferForRichText } from "@lexical/clipboard"
 import { $createLinkNode, $isLinkNode, $toggleLink } from "@lexical/link"
 import { ListenerBin } from "../helpers/listener_helper"
 import NodeInserter from "./contents/node_inserter"
@@ -148,7 +147,7 @@ export default class Clipboard {
       } else if (this.editorElement.supportsMarkdown) {
         this.#pasteMarkdown(text)
       } else {
-        this.#pasteRichText(clipboardData)
+        this.contents.insertText(text, { tag: PASTE_TAG })
       }
     })
   }
@@ -224,13 +223,6 @@ export default class Clipboard {
     const paragraph = elements[0]
     return paragraph.nodeName === "P"
       && Array.from(paragraph.childNodes).every((node) => node.nodeType === Node.TEXT_NODE || node.nodeName === "BR")
-  }
-
-  #pasteRichText(clipboardData) {
-    this.editor.update(() => {
-      const selection = $getSelection()
-      $insertDataTransferForRichText(clipboardData, selection, this.editor)
-    }, { tag: PASTE_TAG })
   }
 
   #handlePastedFiles(clipboardData) {

--- a/test/system/plain_text_paste_test.rb
+++ b/test/system/plain_text_paste_test.rb
@@ -1,0 +1,38 @@
+require "application_system_test_case"
+
+class PlainTextPasteTest < ApplicationSystemTestCase
+  PASTED_TEXT = "Plain text pasted from the clipboard"
+  MODIFIER = RUBY_PLATFORM.include?("darwin") ? :command : :control
+
+  test "pastes plain text when markdown is disabled" do
+    visit new_post_path(markdown_disabled: 1)
+    paste_from_clipboard PASTED_TEXT
+
+    find_editor.within_contents do
+      assert_text PASTED_TEXT
+    end
+  end
+
+  test "pastes plain text in a plain-text-only editor" do
+    visit new_post_path(rich_text_disabled: 1)
+    paste_from_clipboard PASTED_TEXT
+
+    find_editor.within_contents do
+      assert_text PASTED_TEXT
+    end
+  end
+
+  private
+    def paste_from_clipboard(text)
+      copy_to_clipboard text
+
+      find_editor.click
+      find_editor.content_element.send_keys [ MODIFIER, "v" ]
+    end
+
+    def copy_to_clipboard(text)
+      title = find_field("Post title")
+      title.set text
+      title.send_keys [ MODIFIER, "a" ], [ MODIFIER, "c" ]
+    end
+end


### PR DESCRIPTION
Closes #1055

Pasting plain, non-URL text did nothing whenever `supportsMarkdown` was false, which happens with `markdown: false` or in a plain-text-only editor (`richText: false`).

`#pastePlainTextOrURL` resolves the clipboard text through the asynchronous `item.getAsString` callback. The non-markdown branch ignored that resolved text and handed the whole `clipboardData` to `$insertDataTransferForRichText` instead. By the time the callback ran, the paste event was over, so that DataTransfer read back empty and nothing got inserted. The URL and Markdown branches worked because they already used the resolved text string.

This PR inserts the resolved text in the non-markdown branch too, rather than re-reading the stale clipboard, and drops the now-unused rich-text path.

A Playwright regression (`programmatic_insert_fallback`) showed why the earlier synchronous-read approach was wrong: the URL paste path relies on `item.getAsString` running after the paste command handler, so the `lexxy:insert-link` replacement fires correctly. The async callback is kept intact; only the non-markdown branch changed.