### PR TITLE
Fix prompt insertion for multi-character triggers like {{

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -579,18 +579,13 @@ export default class Contents {
     return { anchorNode, offset: anchor.offset }
   }
 
-  // The replaced span can straddle the cursor (e.g. "@Jack" when "@" was just
-  // inserted before "Jack"), so we anchor on the trigger before the cursor and
-  // verify the whole string matches there rather than searching text up to it.
+  // The replaced span must start before the cursor but can extend past it
+  // (e.g. "@Jack" when "@" was just inserted before "Jack"), so we bound the
+  // match's start with lastIndexOf's fromIndex rather than slicing the text.
   #findReplacementStart(anchorNode, offset, stringToReplace) {
-    const fullText = anchorNode.getTextContent()
-    const triggerIndex = fullText.slice(0, offset).lastIndexOf(stringToReplace[0])
+    if (offset === 0) return -1 // a negative fromIndex clamps to 0 and could match at the cursor
 
-    if (triggerIndex !== -1 && fullText.startsWith(stringToReplace, triggerIndex)) {
-      return triggerIndex
-    } else {
-      return -1
-    }
+    return anchorNode.getTextContent().lastIndexOf(stringToReplace, offset - 1)
   }
 
   #performTextReplacement(anchorNode, startIndex, stringToReplace, replacementNodes) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -583,9 +583,12 @@ export default class Contents {
   // (e.g. "@Jack" when "@" was just inserted before "Jack"), so we bound the
   // match's start with lastIndexOf's fromIndex rather than slicing the text.
   #findReplacementStart(anchorNode, offset, stringToReplace) {
-    if (offset === 0) return -1 // a negative fromIndex clamps to 0 and could match at the cursor
-
-    return anchorNode.getTextContent().lastIndexOf(stringToReplace, offset - 1)
+    if (offset === 0) {
+      // A negative fromIndex clamps to 0 and could match at the cursor
+      return -1
+    } else {
+      return anchorNode.getTextContent().lastIndexOf(stringToReplace, offset - 1)
+    }
   }
 
   #performTextReplacement(anchorNode, startIndex, stringToReplace, replacementNodes) {

--- a/test/javascript/unit/editor/replace_text_back_until.test.js
+++ b/test/javascript/unit/editor/replace_text_back_until.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest"
+import { $createTextNode } from "lexical"
+import { createTestEditor, destroyTestEditor, selectFirstText, setContent, tick } from "../helpers/editor_helper"
+
+function replaceTextBackUntil(editorElement, stringToReplace, replacementText) {
+  editorElement.editor.update(() => {
+    editorElement.contents.replaceTextBackUntil(stringToReplace, $createTextNode(replacementText))
+  }, { discrete: true })
+}
+
+describe("Contents#replaceTextBackUntil", () => {
+  test("replaces text starting with a single-character trigger", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello @Ali</p>")
+    selectFirstText(editorElement, "Hello @Ali".length)
+
+    replaceTextBackUntil(editorElement, "@Ali", "Alice")
+    await tick()
+
+    expect(editorElement.value).toContain("Hello Alice")
+    expect(editorElement.value).not.toContain("@Ali")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("replaces a string that straddles the cursor, as when @ was just inserted before an existing word", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello @Zacharias</p>")
+    selectFirstText(editorElement, "Hello @".length)
+
+    replaceTextBackUntil(editorElement, "@Zacharias", "Zacharias")
+    await tick()
+
+    expect(editorElement.value).toContain("Hello Zacharias")
+    expect(editorElement.value).not.toContain("@Zacharias")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("replaces text starting with a repeated-character trigger like {{", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello {{first</p>")
+    selectFirstText(editorElement, "Hello {{first".length)
+
+    replaceTextBackUntil(editorElement, "{{first", "{{ first_name }}")
+    await tick()
+
+    expect(editorElement.value).toContain("Hello {{ first_name }}")
+    expect(editorElement.value).not.toContain("{{first")
+
+    await destroyTestEditor(editorElement)
+  })
+})


### PR DESCRIPTION
If you used a multi-character trigger like `{{`, picking an item from the prompt menu did nothing. The typed text stayed put and nothing got inserted.

The problem is in how `#findReplacementStart` locates the text to replace. It anchors on the last occurrence of the string's first character before the cursor, then checks that the whole string matches from there. With `{{foo` the last `{` is the second brace, so that check fails and `replaceTextBackUntil` bails out. Single-character triggers never ran into this because the last occurrence of the trigger is always the start of the match.

This looks like an unintended side effect of 9d23f39 (#1135), which introduced #findReplacementStart to let the replaced span straddle the cursor. That change switched the anchor from `lastIndexOf(stringToReplace)` over the pre-cursor text to `lastIndexOf(stringToReplace[0])` plus a `startsWith` check. Anchoring on just the first character is what leaves multi-character triggers stranded on the wrong brace.

The fix is to search for the full string with `lastIndexOf`, using its `fromIndex` argument to bound where the match starts rather than slicing the text before the cursor. A match must start before the cursor but can extend past it, so single-character triggers work the same as before and strings that straddle the cursor (like an `@` typed just in front of an existing word) are still found.

This fixes #1165. The issue suggests reverting to the 0.9.18 approach, which used `lastIndexOf(stringToReplace)` over the text before the cursor. That approach doesn't seem to cover the straddling case, which is the reason 9d23f39 moved away from it. When `@` is typed just in front of an existing word, stringToReplace is `@Jack` while the cursor sits right after the `@`, so searching only the pre-cursor text would miss it — bounding the match's start with fromIndex instead of slicing handles both.