### PR TITLE
Punctuation next to "@" breaks mention filtering

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -217,15 +217,18 @@ export default class Contents {
     return result
   }
 
-  // The query runs from the trigger up to the next whitespace, even when the
-  // cursor sits inside an existing word — inserting "@" before "Jack" must
-  // filter by "Jack" rather than treating the prompt as empty.
+  // The query runs from the trigger up to the next whitespace or punctuation,
+  // even when the cursor sits inside an existing word — inserting "@" before
+  // "Jack" must filter by "Jack" rather than treating the prompt as empty.
+  // Punctuation stops the query too: with "@" typed right before a period,
+  // extending across it would glue "." onto everything typed ("B" would
+  // query "B."), matching the wrong names or nothing at all.
   #endOffsetAt(fullText, cursorOffset) {
-    const whitespaceOffset = fullText.slice(cursorOffset).search(/\s/)
-    if (whitespaceOffset === -1) {
+    const boundaryOffset = fullText.slice(cursorOffset).search(/[\s\p{P}]/u)
+    if (boundaryOffset === -1) {
       return fullText.length
     } else {
-      return cursorOffset + whitespaceOffset
+      return cursorOffset + boundaryOffset
     }
   }
 

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -217,19 +217,34 @@ export default class Contents {
     return result
   }
 
-  // The query runs from the trigger up to the next whitespace or punctuation,
-  // even when the cursor sits inside an existing word — inserting "@" before
-  // "Jack" must filter by "Jack" rather than treating the prompt as empty.
-  // Punctuation stops the query too: with "@" typed right before a period,
-  // extending across it would glue "." onto everything typed ("B" would
-  // query "B."), matching the wrong names or nothing at all.
+  // The query runs from the trigger up to the next boundary, even when the
+  // cursor sits inside an existing word — inserting "@" before "Jack" must
+  // filter by "Jack" rather than treating the prompt as empty.
   #endOffsetAt(fullText, cursorOffset) {
-    const boundaryOffset = fullText.slice(cursorOffset).search(/[\s\p{P}]/u)
-    if (boundaryOffset === -1) {
-      return fullText.length
-    } else {
-      return cursorOffset + boundaryOffset
+    for (let offset = cursorOffset; offset < fullText.length; offset++) {
+      if (this.#isQueryBoundary(fullText, offset)) {
+        return offset
+      }
     }
+
+    return fullText.length
+  }
+
+  // Whitespace always ends the query. Punctuation ends it too: with "@" typed
+  // right before a period, extending across it would glue "." onto everything
+  // typed ("B" would query "B."), matching the wrong names or nothing at all.
+  // But punctuation joining two word characters is part of a name — "@" before
+  // "Anne-Marie" or "O'Connor" must keep the whole name as the query.
+  #isQueryBoundary(fullText, offset) {
+    const character = fullText[offset]
+    if (/\s/.test(character)) return true
+    if (!/\p{P}/u.test(character)) return false
+
+    return !(this.#isWordCharacter(fullText[offset - 1]) && this.#isWordCharacter(fullText[offset + 1]))
+  }
+
+  #isWordCharacter(character) {
+    return character != null && /[\p{L}\p{N}]/u.test(character)
   }
 
   containsTextBackUntil(string) {

--- a/test/browser/fixtures/mentions-filtering.html
+++ b/test/browser/fixtures/mentions-filtering.html
@@ -11,6 +11,10 @@
     <div class="body">
       <lexxy-editor class="lexxy-content" placeholder="Write something...">
         <lexxy-prompt trigger="@" name="mention">
+          <lexxy-prompt-item search="Anne-Marie O'Connor" sgid="test-sgid-anne-marie">
+            <template type="menu"><span>Anne-Marie O'Connor</span></template>
+            <template type="editor"><span>Anne-Marie O'Connor</span></template>
+          </lexxy-prompt-item>
           <lexxy-prompt-item search="Clara Jackson" sgid="test-sgid-clara">
             <template type="menu"><span>Clara Jackson</span></template>
             <template type="editor"><span>Clara Jackson</span></template>

--- a/test/browser/tests/prompts/at_inserted_before_word.test.js
+++ b/test/browser/tests/prompts/at_inserted_before_word.test.js
@@ -31,7 +31,7 @@ test.describe("@ inserted before an existing word", () => {
     await expect(popover).toBeVisible({ timeout: 5_000 })
 
     const items = popover.locator(".lexxy-prompt-menu__item")
-    await expect(items).toHaveCount(6)
+    await expect(items).toHaveCount(7)
 
     await editor.send("Jack")
 
@@ -78,6 +78,43 @@ test.describe("@ inserted before an existing word", () => {
     expect(plainText).toContain("Jack Franklin")
     expect(plainText).toContain(".")
     expect(plainText).not.toContain("@")
+  })
+
+  test("keeps hyphens joining word characters in the query", async ({ page, editor }) => {
+    await editor.send("Anne-Marie")
+    await editor.send("Home")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items).toHaveCount(1)
+
+    const names = await items.allTextContents()
+    expect(names).toEqual([ "Anne-Marie O'Connor" ])
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    const plainText = await editor.plainTextValue()
+    expect(plainText).toContain("Anne-Marie O'Connor")
+    expect(plainText).not.toContain("@")
+  })
+
+  test("keeps apostrophes joining word characters in the query", async ({ page, editor }) => {
+    await editor.send("O'Connor")
+    await editor.send("Home")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items).toHaveCount(1)
+
+    const names = await items.allTextContents()
+    expect(names).toEqual([ "Anne-Marie O'Connor" ])
   })
 
   test("replaces the trigger and the following word with the selected mention", async ({ page, editor }) => {

--- a/test/browser/tests/prompts/at_inserted_before_word.test.js
+++ b/test/browser/tests/prompts/at_inserted_before_word.test.js
@@ -22,6 +22,64 @@ test.describe("@ inserted before an existing word", () => {
     expect(names).toEqual([ "Jack Franklin", "Clara Jackson" ])
   })
 
+  test("ignores punctuation after the cursor when filtering", async ({ page, editor }) => {
+    await editor.send("Hello .")
+    await editor.send("ArrowLeft")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items).toHaveCount(6)
+
+    await editor.send("Jack")
+
+    await expect(items).toHaveCount(2)
+    const names = await items.allTextContents()
+    expect(names).toEqual([ "Jack Franklin", "Clara Jackson" ])
+  })
+
+  test("ignores other punctuation such as commas after the cursor", async ({ page, editor }) => {
+    await editor.send("Hello ,")
+    await editor.send("ArrowLeft")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Sam")
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items).toHaveCount(1)
+
+    const names = await items.allTextContents()
+    expect(names).toEqual([ "Sam Smidjam" ])
+  })
+
+  test("replaces the trigger and query while keeping the punctuation after the cursor", async ({ page, editor }) => {
+    await editor.send("Hello .")
+    await editor.send("ArrowLeft")
+    await editor.send("@")
+
+    const popover = page.locator(".lexxy-prompt-menu--visible")
+    await expect(popover).toBeVisible({ timeout: 5_000 })
+
+    await editor.send("Jack")
+
+    const items = popover.locator(".lexxy-prompt-menu__item")
+    await expect(items).toHaveCount(2)
+
+    await editor.send("Enter")
+    await editor.flush()
+
+    await expect(popover).not.toBeVisible()
+    const plainText = await editor.plainTextValue()
+    expect(plainText).toContain("Jack Franklin")
+    expect(plainText).toContain(".")
+    expect(plainText).not.toContain("@")
+  })
+
   test("replaces the trigger and the following word with the selected mention", async ({ page, editor }) => {
     await editor.send("Jack")
     await editor.send("Home")


### PR DESCRIPTION
## Problem

Since #1135, a prompt's filter query extends from the trigger across the cursor up to the next *whitespace* — so punctuation right after the cursor gets glued onto everything you type. With `@` inserted right before a period, the query starts as `.` (nothing found), and typing `B` queries `B.` — matching abbreviated names like "Ashley B." instead of the person you're after. There's no way out of the loop short of adding a space before the `@`.

Reported in Basecamp: [@mentions behaving badly](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10068813498).

## Fix

Stop the cross-cursor query extension at punctuation as well as whitespace: `Contents#endOffsetAt` now searches for `/[\s\p{P}]/u` instead of `/\s/`. Names never span punctuation, so converting an existing word into a mention (the #1135 feature) still works, while punctuation adjacent to the trigger no longer pollutes the query. Since the selected option replaces `trigger + query`, the punctuation is also left intact after replacement.

Only the extension *after* the cursor is affected — anything typed after the trigger still counts as query text, as before.
