### PR TITLE
Build the site without a base path now that it lives at lexxy.dev

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -37,14 +37,12 @@ jobs:
           working-directory: home
 
       - name: Setup Pages
-        id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${STEPS_PAGES_OUTPUTS_BASE_PATH}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
-          STEPS_PAGES_OUTPUTS_BASE_PATH: ${{ steps.pages.outputs.base_path }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0


### PR DESCRIPTION
The Deploy Site workflow passed `configure-pages`' `base_path` output to `jekyll build --baseurl`, which prefixed every asset URL with `/lexxy`. Now that the site is served from the `lexxy.dev` custom domain root, that prefix 404s — e.g. `https://lexxy.dev/lexxy/assets/landing.css`.

`home/_config.yml` already sets `baseurl: ""`, which is correct for the custom domain, so this drops the build-time override and lets the config value apply. The `configure-pages` step stays since it registers the Pages configuration for the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9SbL4biGoAWdFZs4tqKSm