### PR TITLE
Switch to esm.sh CDN

### DIFF
--- a/home/_layouts/landing.html
+++ b/home/_layouts/landing.html
@@ -16,9 +16,9 @@
   {% seo title=false %}
   <link rel="stylesheet" href="{{ "/assets/landing.css" | relative_url }}">
   {% if page.editor %}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@37signals/lexxy@latest/dist/stylesheets/lexxy.css">
+  <link rel="stylesheet" href="https://esm.sh/@37signals/lexxy@latest/dist/stylesheets/lexxy.css">
   <script type="module">
-    import * as Lexxy from "https://cdn.jsdelivr.net/npm/@37signals/lexxy@latest/+esm";
+    import * as Lexxy from "https://esm.sh/@37signals/lexxy@latest";
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker.register("{{ site.baseurl }}/attachments-sw.js");
     }


### PR DESCRIPTION
jsdelivr's `+esm` bundler broke the live site's editor: the bundle it generated for 0.9.23 references lexxy's direct dependencies by semver range (`lexical@^0.44.0/+esm`) while transitive imports pin exact versions (`lexical@0.44.0/+esm`). Two URLs means two copies of `lexical`, and editor construction fails with Lexical error #290 ("does not subclass LexicalNode from the lexical package used by this editor") in every browser. jsdelivr's `Link: rel=modulepreload` headers also spam the console with wrong-origin 404s in Safari.

Switching the JS import to esm.sh loads a single lexical instance and fixes both issues. The stylesheet moves to esm.sh too, so CSS and JS can't resolve `@latest` to different versions across two CDNs — esm.sh redirects `@latest` to a pinned version, keeping the stylesheet's `@imports` on the same release.

Verified on the built site in Chrome and WebKit, on both `/` and `/sandbox/`: editor and toolbar render, no page errors, no failed requests. This also matches the docs, which already tell people to use esm.sh.