### PR TITLE
Add HTML output to Sandbox page

### DIFF
--- a/home/assets/landing.css
+++ b/home/assets/landing.css
@@ -584,14 +584,24 @@ a:not(.btn) {
 
   .sandbox__toggle {
     align-items: center;
+    border-radius: var(--radius);
     cursor: pointer;
     display: inline-flex;
     gap: 0.5ch;
     margin-block-start: 1rem;
+    padding: 0.2em 0.6em;
     user-select: none;
 
     input {
-      display: none;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      opacity: 0;
+      position: absolute;
+    }
+
+    &:has(input:focus-visible) {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
 
     .sandbox__switch {
@@ -624,7 +634,6 @@ a:not(.btn) {
         }
       }
     }
-
 
     &:hover {
       .sandbox__switch {

--- a/home/assets/landing.css
+++ b/home/assets/landing.css
@@ -44,7 +44,7 @@
   }
 
   /* Editor dark mode colors */
-  lexxy-editor {
+  lexxy-editor, .lexxy-content {
     --lexxy-color-canvas: var(--bg);
 
     --lexxy-color-text: var(--ink);
@@ -582,19 +582,123 @@ a:not(.btn) {
     }
   }
 
-  .container {
-    max-width: 60rem;
+  .sandbox__toggle {
+    align-items: center;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 0.5ch;
+    margin-block-start: 1rem;
+    user-select: none;
+
+    input {
+      display: none;
+    }
+
+    .sandbox__switch {
+      --switch-spacing: 0.25rem;
+
+      background: var(--ink-light);
+      block-size: calc(var(--switch-spacing) * 5);
+      border-radius: 10rem;
+      inline-size: calc(var(--switch-spacing) * 8);
+      padding: var(--switch-spacing);
+      position: relative;
+      transition: all 0.15s ease-out;
+
+      &:after {
+        background: var(--bg);
+        border-radius: 10rem;
+        content: "";
+        inset-block: var(--switch-spacing);
+        inset-inline-start: var(--switch-spacing);
+        inline-size: calc(var(--switch-spacing) * 3);
+        position: absolute;
+        transition: all 0.15s ease-out;
+      }
+
+      input:checked + & {
+        background: var(--accent);
+
+        &:after {
+          inset-inline-start: calc(var(--switch-spacing) * 4);
+        }
+      }
+    }
+
+
+    &:hover {
+      .sandbox__switch {
+        background: var(--ink-medium);
+      }
+    }
+  }
+
+  .sandbox__editor {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    inline-size: 100%;
+    justify-content: center;
   }
 
   lexxy-editor {
     --lexxy-color-canvas: var(--bg);
     --lexxy-editor-rows: 30lh;
     font-size: 1em;
+    inline-size: 100%;
+    margin: 0 auto;
+    max-width: 60rem;
+    min-inline-size: 45%;
 
     lexxy-toolbar {
+      background: var(--bg);
       border-color: var(--ink-lighter);
+      border-start-end-radius: 0.35rem;
+      border-start-start-radius: 0.35rem;
       font-size: 0.8em;
       line-height: 1.25em;
+      inset-block-start: 0;
+      position: sticky;
+      z-index: 10;
+    }
+  }
+
+  .try__output {
+    background: var(--ink-lighter);
+    border-radius: var(--radius);
+    font-size: 0.8em;
+    inline-size: 100%;
+    overflow-x: auto;
+    margin: 0 0;
+    min-inline-size: 45%;
+    padding: 1.5rem;
+    transition: all 0.4s ease-out;
+
+    @starting-style {
+      inline-size: 0;
+      min-inline-size: 0;
+    }
+
+    code {
+      background: transparent;
+      color: var(--ink);
+    }
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .sandbox {
+    .sandbox__editor {
+      flex-direction: column;
+
+      lexxy-editor {
+        --lexxy-editor-rows: 20lh;
+      }
+    }
+
+    .try__output {
+      transition: none;
     }
   }
 }

--- a/home/sandbox.html
+++ b/home/sandbox.html
@@ -78,11 +78,11 @@ nav_exclude: true
     }
   }
 
-  editor.addEventListener("lexxy:change", () => {
+  editor.addEventListener("lexxy:change", debounce(() => {
     if (!output.hidden) {
       refresh()
     }
-  })
+  }, 150))
 
   async function refresh() {
     await loadFormattingDependencies()
@@ -116,5 +116,14 @@ nav_exclude: true
     })
 
     return formattedCode.replace(/<br\s*\/>/g, "<br/>") // Remove space before self-closing slash for br tags
+  }
+
+  function debounce(fn, wait) {
+    let timeout
+
+    return (...args) => {
+      clearTimeout(timeout)
+      timeout = setTimeout(() => fn(...args), wait)
+    }
   }
 </script>

--- a/home/sandbox.html
+++ b/home/sandbox.html
@@ -63,11 +63,18 @@ nav_exclude: true
 
   let prettier, htmlParser, Prism
 
-  toggle.checked = localStorage.getItem(STORAGE_KEY) === "true"
+  try {
+    toggle.checked = localStorage.getItem(STORAGE_KEY) === "true"
+  } catch {
+    toggle.checked = false
+  }
+
   updateOutputVisibility()
 
   toggle.addEventListener("change", () => {
-    localStorage.setItem(STORAGE_KEY, toggle.checked)
+    try {
+      localStorage.setItem(STORAGE_KEY, String(toggle.checked))
+    } catch {}
     updateOutputVisibility()
   })
 

--- a/home/sandbox.html
+++ b/home/sandbox.html
@@ -11,9 +11,16 @@ nav_exclude: true
     <div class="section__head">
       <h1>Try Lexxy in a Sandbox</h1>
       <p>Type, format, paste a link, or hit <code>:</code> to drop in an emoji.</p>
+
+      <label class="sandbox__toggle" for="html_output">
+        <input type="checkbox" id="html_output">
+        <div class="sandbox__switch"></div>
+        <span>Show HTML output</span>
+      </label>
     </div>
 
-    <div class="try__editor">
+    <div class="sandbox__editor">
+
       <lexxy-editor
         class="lexxy-content"
         placeholder="Write something…"
@@ -41,6 +48,49 @@ nav_exclude: true
           <lexxy-prompt-item search="crown king queen"><template type="menu">👑 Crown</template><template type="editor">👑</template></lexxy-prompt-item>
         </lexxy-prompt>
       </lexxy-editor>
+
+      <pre class="try__output lexxy-content" hidden></pre>
     </div>
   </div>
 </section>
+
+<script type="module">
+  import prettier from "https://esm.sh/prettier@3.6.2/standalone"
+  import htmlParser from "https://esm.sh/prettier@3.6.2/plugins/html"
+  import Prism from "https://esm.sh/prismjs@1.30.0"
+
+  const editor = document.querySelector("lexxy-editor")
+  const toggle = document.querySelector(".sandbox__toggle input")
+  const output = document.querySelector(".try__output")
+
+  toggle.addEventListener("change", () => {
+    output.hidden = !toggle.checked
+    if (toggle.checked) {
+      refresh()
+    }
+  })
+
+  editor.addEventListener("lexxy:change", () => {
+    if (!output.hidden) {
+      refresh()
+    }
+  })
+
+  async function refresh() {
+    const formattedCode = await formatHtml(editor.value.trim())
+    const highlightedCode = Prism.highlight(formattedCode, Prism.languages.html, "html")
+    output.innerHTML = `<code class="language-html">${highlightedCode}</code>`
+  }
+
+  async function formatHtml(code) {
+    const formattedCode = await prettier.format(code, {
+      parser: "html",
+      plugins: [ htmlParser ],
+      printWidth: 80,
+      tabWidth: 2,
+      useTabs: false
+    })
+
+    return formattedCode.replace(/<br\s*\/>/g, "<br/>") // Remove space before self-closing slash for br tags
+  }
+</script>

--- a/home/sandbox.html
+++ b/home/sandbox.html
@@ -55,15 +55,13 @@ nav_exclude: true
 </section>
 
 <script type="module">
-  import prettier from "https://esm.sh/prettier@3.6.2/standalone"
-  import htmlParser from "https://esm.sh/prettier@3.6.2/plugins/html"
-  import Prism from "https://esm.sh/prismjs@1.30.0"
-
   const STORAGE_KEY = "lexxy-sandbox-show-html-output"
 
   const editor = document.querySelector("lexxy-editor")
   const toggle = document.querySelector(".sandbox__toggle input")
   const output = document.querySelector(".try__output")
+
+  let prettier, htmlParser, Prism
 
   toggle.checked = localStorage.getItem(STORAGE_KEY) === "true"
   updateOutputVisibility()
@@ -87,9 +85,25 @@ nav_exclude: true
   })
 
   async function refresh() {
+    await loadFormattingDependencies()
+
     const formattedCode = await formatHtml(editor.value.trim())
     const highlightedCode = Prism.highlight(formattedCode, Prism.languages.html, "html")
     output.innerHTML = `<code class="language-html">${highlightedCode}</code>`
+  }
+
+  async function loadFormattingDependencies() {
+    if (!prettier) {
+      const modules = await Promise.all([
+        import("https://esm.sh/prettier@3.6.2/standalone"),
+        import("https://esm.sh/prettier@3.6.2/plugins/html"),
+        import("https://esm.sh/prismjs@1.30.0")
+      ])
+
+      prettier = modules[0].default
+      htmlParser = modules[1].default
+      Prism = modules[2].default
+    }
   }
 
   async function formatHtml(code) {

--- a/home/sandbox.html
+++ b/home/sandbox.html
@@ -59,16 +59,26 @@ nav_exclude: true
   import htmlParser from "https://esm.sh/prettier@3.6.2/plugins/html"
   import Prism from "https://esm.sh/prismjs@1.30.0"
 
+  const STORAGE_KEY = "lexxy-sandbox-show-html-output"
+
   const editor = document.querySelector("lexxy-editor")
   const toggle = document.querySelector(".sandbox__toggle input")
   const output = document.querySelector(".try__output")
 
+  toggle.checked = localStorage.getItem(STORAGE_KEY) === "true"
+  updateOutputVisibility()
+
   toggle.addEventListener("change", () => {
+    localStorage.setItem(STORAGE_KEY, toggle.checked)
+    updateOutputVisibility()
+  })
+
+  function updateOutputVisibility() {
     output.hidden = !toggle.checked
     if (toggle.checked) {
       refresh()
     }
-  })
+  }
 
   editor.addEventListener("lexxy:change", () => {
     if (!output.hidden) {


### PR DESCRIPTION
This PR brings the dummy app's sandbox output view to the public site, so visitors can see the HTML the editor produces as they type.

A "Show HTML output" switch above the editor toggles a pane alongside it. When visible, the pane re-renders on every `lexxy:change`: the editor's value is pretty-printed with prettier and syntax-highlighted with Prism. The toggle state persists in localStorage, so the pane comes back on reload.

Also includes some styling for the sandbox page: a proper switch control, a side-by-side editor/output layout that stacks on small screens, and a sticky toolbar while scrolling long documents.

<img width="1182" height="666" alt="image" src="https://github.com/user-attachments/assets/744cf914-cae8-4c05-b7cc-fd4f2baae303" />
