### PR TITLE
Improve table toolbar accessibility follow-ups

### DIFF
--- a/src/elements/table/table_tools.js
+++ b/src/elements/table/table_tools.js
@@ -152,7 +152,9 @@ export class TableTools extends HTMLElement {
   #focusToolbarOnAltF10 = (event) => {
     if (this.#hasSelectedTable && event.altKey && event.key === "F10") {
       event.preventDefault()
-      this.#tableToolsButtons[0]?.focus()
+      // Ask for the ring explicitly: a programmatic focus coming from a mouse-focused
+      // editor otherwise inherits the mouse modality and paints no focus ring.
+      this.#tableToolsButtons[0]?.focus({ focusVisible: true })
       return true
     } else {
       return false

--- a/src/elements/table/table_tools.js
+++ b/src/elements/table/table_tools.js
@@ -146,11 +146,11 @@ export class TableTools extends HTMLElement {
   }
 
   #registerKeyboardShortcuts() {
-    this.#listeners.track(this.#editor.registerCommand(KEY_DOWN_COMMAND, this.#focusToolbarOnShortcut, COMMAND_PRIORITY_HIGH))
+    this.#listeners.track(this.#editor.registerCommand(KEY_DOWN_COMMAND, this.#focusToolbarOnAltF10, COMMAND_PRIORITY_HIGH))
   }
 
-  #focusToolbarOnShortcut = (event) => {
-    if (this.#hasSelectedTable && this.#isFocusToolbarShortcut(event)) {
+  #focusToolbarOnAltF10 = (event) => {
+    if (this.#hasSelectedTable && event.altKey && event.key === "F10") {
       event.preventDefault()
       this.#tableToolsButtons[0]?.focus()
       return true
@@ -161,11 +161,6 @@ export class TableTools extends HTMLElement {
 
   get #hasSelectedTable() {
     return this.tableController?.currentTableNodeKey != null
-  }
-
-  #isFocusToolbarShortcut(event) {
-    if (event.key !== "F10") return false
-    return event.altKey || ((event.ctrlKey || event.metaKey) && event.shiftKey)
   }
 
   #handleToolsKeydown = (event) => {

--- a/test/browser/tests/tables/toolbar.test.js
+++ b/test/browser/tests/tables/toolbar.test.js
@@ -18,6 +18,14 @@ test.describe("Tables — Toolbar accessibility", () => {
     ).toBeFocused()
   })
 
+  test("Alt+F10 shows a visible focus ring on the first table tool", async ({ page, editor }) => {
+    await page.keyboard.press("Alt+F10")
+
+    const firstTool = editor.locator.locator("lexxy-table-tools button[aria-label='Remove row']").first()
+    await expect(firstTool).toBeFocused()
+    await expect.poll(() => firstTool.evaluate(element => element.matches(":focus-visible"))).toBe(true)
+  })
+
   test("arrow keys move focus between table tools", async ({ page, editor }) => {
     await page.keyboard.press("Alt+F10")
     await page.keyboard.press("ArrowRight")

--- a/test/browser/tests/tables/toolbar.test.js
+++ b/test/browser/tests/tables/toolbar.test.js
@@ -18,14 +18,6 @@ test.describe("Tables — Toolbar accessibility", () => {
     ).toBeFocused()
   })
 
-  test("Control+Shift+F10 also moves focus to the first table tool", async ({ page, editor }) => {
-    await page.keyboard.press("Control+Shift+F10")
-
-    await expect(
-      editor.locator.locator("lexxy-table-tools button[aria-label='Remove row']").first()
-    ).toBeFocused()
-  })
-
   test("arrow keys move focus between table tools", async ({ page, editor }) => {
     await page.keyboard.press("Alt+F10")
     await page.keyboard.press("ArrowRight")


### PR DESCRIPTION
Two follow-ups to the table toolbar accessibility work, both from @bergatron's review.

Dropping the second shortcut: the toolbar could be focused with either Alt+F10 or Ctrl/Cmd+Shift+F10. Alt+F10 is the shortcut for focusing an editor toolbar across the major rich text editors (TinyMCE, CKEditor, Froala, Syncfusion), while Ctrl/Cmd+Shift+F10 matched no convention and was only added for accessibility. On Windows Shift+F10 already opens the context menu, so reusing F10 that way was confusing. Michael confirmed there's no reason to keep it.

The focus ring: the first time you enter the toolbar with Alt+F10 right after clicking the table with the mouse, the first button gets focus but no visible focus ring, so you can't tell where you are. A plain `focus()` moving in from a mouse-focused editor inherits the mouse modality, so the browser paints no ring until a keyboard interaction happens (leaving with Esc and coming back makes it show). Passing `focusVisible` asks for the ring explicitly on the first entry. Verified in Chromium, Firefox and WebKit; browsers without the option ignore it and keep the current behavior.

So this PR:

- Removes the Ctrl/Cmd+Shift+F10 shortcut, leaving Alt+F10.
- Passes `focusVisible` when focusing the first tool so the ring shows on the first Alt+F10 entry.
/- Updates the browser tests: drops the Ctrl/Cmd+Shift+F10 case and adds one for the focus ring.
