### PR TITLE
Guard editor configuration against an unknown preset

### DIFF
--- a/src/editor/configuration.js
+++ b/src/editor/configuration.js
@@ -10,13 +10,25 @@ export default class EditorConfiguration {
     this.#editorElement = editorElement
     this.#config = new Configuration(
       Lexxy.presets.get("default"),
-      Lexxy.presets.get(editorElement.preset),
+      this.#presetConfig,
       this.#overrides
     )
   }
 
   get(path) {
     return this.#config.get(path)
+  }
+
+  get #presetConfig() {
+    const preset = this.#editorElement.preset
+    const config = Lexxy.presets.get(preset)
+
+    if (config) {
+      return config
+    } else {
+      console.warn(`Unknown Lexxy preset "${preset}". Falling back to the default preset.`)
+      return {}
+    }
   }
 
   get #overrides() {

--- a/test/browser/fixtures/unknown-preset.html
+++ b/test/browser/fixtures/unknown-preset.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Unknown Preset</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" preset="not-registered" placeholder="Write something..."></lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/editor/unknown_preset.test.js
+++ b/test/browser/tests/editor/unknown_preset.test.js
@@ -1,0 +1,23 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Editor with an unregistered preset", () => {
+  test("connects without crashing and warns about the unknown preset", async ({ page }) => {
+    const pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error))
+
+    const warnings = []
+    page.on("console", (message) => {
+      if (message.type() === "warning") warnings.push(message.text())
+    })
+
+    await page.goto("/unknown-preset.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    // It connected (no crash in connectedCallback) and falls back to defaults.
+    await expect(page.locator("lexxy-editor")).toHaveAttribute("connected", "")
+
+    expect(pageErrors, pageErrors.map((e) => e.stack).join("\n\n")).toHaveLength(0)
+    expect(warnings.some((text) => text.includes('Unknown Lexxy preset "not-registered"'))).toBe(true)
+  })
+})


### PR DESCRIPTION
If a `<lexxy-editor>` is initialized with an unregistered preset, it throws `TypeError: Cannot convert undefined or null to object` from `connectedCallback`: `Lexxy.presets.get(preset)` returns undefined, and `deepMerge` then runs `Object.entries` on it.

This PR handles the missing preset in `EditorConfiguration`: an unknown preset falls back to an empty object, so the default preset and attribute overrides still apply, and it logs a warning so a typo or a late `Lexxy.configure` call is easy to spot.

Fixes #1167