### PR TITLE
Prevent layout shift as the editor mounts, for editors sized by their content

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -416,6 +416,23 @@
   min-block-size: calc(var(--lexxy-toolbar-height) + var(--lexxy-editor-rows) + 2 * var(--lexxy-editor-padding));
 }
 
+/* The reservation above cannot help an editor sized by its content: with
+   `--lexxy-editor-rows: auto` the calc() is invalid and the declaration is
+   dropped, and a row count would be the wrong height for a field that has to
+   match the copy it stands in for anyway. Such an editor prerenders its content
+   instead (`rich_text_area … prerender: true`), which reserves the body, and
+   ships an empty toolbar alongside it, which this gives the height the filled
+   one will have. Only while undefined: from then on the toolbar's own contents
+   size it. A real <lexxy-toolbar> rather than a spacer, so a host that takes the
+   toolbar out of flow gets a reservation of nothing, automatically. */
+:where(lexxy-toolbar:not(:defined)) {
+  /* --lexxy-toolbar-height already counts the toolbar's padding and border, so
+     the reservation has to be a border-box one or they are added a second time
+     and the field gives 5px back on connect. */
+  box-sizing: border-box;
+  min-block-size: var(--lexxy-toolbar-height);
+}
+
 /* Placeholder */
 :where(.lexxy-editor--empty) {
   .lexxy-editor__content:not(:has(h1, h2, h3, h4, h5, h6, table, ul, ol, figure, .attachment-gallery))::before {

--- a/lib/action_text/editor/lexxy_editor.rb
+++ b/lib/action_text/editor/lexxy_editor.rb
@@ -18,14 +18,8 @@ module ActionText
       # editor builds a frame after load. Mirrors the same option on the
       # Rails 8.0/8.1 TagHelper fallback.
       if options.delete(:prerender) && @block.nil?
-        html = (options[:value].presence || "<p><br></p>").html_safe
-        @block = proc do
-          view_context.content_tag "div", html,
-            class: "lexxy-editor__content",
-            contenteditable: "true",
-            role: "textbox",
-            "aria-multiline": "true"
-        end
+        value = options[:value]
+        @block = proc { Lexxy::Prerender.content_tag_for(view_context, value) }
       end
 
       super

--- a/lib/action_text/editor/lexxy_editor.rb
+++ b/lib/action_text/editor/lexxy_editor.rb
@@ -11,6 +11,23 @@ module ActionText
     def render_in(view_context, ...)
       # Strip html_safe to preserve attribute escaping (see #749)
       options[:value] = options[:value].to_str if options[:value].respond_to?(:to_str)
+
+      # Opt-in: render the value into a content element the editor adopts on
+      # connect (see LexicalEditorElement#prerenderedContentElement), so the
+      # field has its final height at first paint instead of reflowing when the
+      # editor builds a frame after load. Mirrors the same option on the
+      # Rails 8.0/8.1 TagHelper fallback.
+      if options.delete(:prerender) && @block.nil?
+        html = (options[:value].presence || "<p><br></p>").html_safe
+        @block = proc do
+          view_context.content_tag "div", html,
+            class: "lexxy-editor__content",
+            contenteditable: "true",
+            role: "textbox",
+            "aria-multiline": "true"
+        end
+      end
+
       super
     end
   end

--- a/lib/action_text/editor/lexxy_editor.rb
+++ b/lib/action_text/editor/lexxy_editor.rb
@@ -18,8 +18,8 @@ module ActionText
       # editor builds a frame after load. Mirrors the same option on the
       # Rails 8.0/8.1 TagHelper fallback.
       if options.delete(:prerender) && @block.nil?
-        value = options[:value]
-        @block = proc { Lexxy::Prerender.content_tag_for(view_context, value) }
+        prerendered = options.dup
+        @block = proc { Lexxy::Prerender.inner_html_for(view_context, prerendered) }
       end
 
       super

--- a/lib/lexxy.rb
+++ b/lib/lexxy.rb
@@ -1,4 +1,5 @@
 require "lexxy/version"
+require "lexxy/prerender"
 
 module Lexxy
   class << self

--- a/lib/lexxy/prerender.rb
+++ b/lib/lexxy/prerender.rb
@@ -1,0 +1,25 @@
+module Lexxy
+  # Builds the static content element a prerendering editor emits inside
+  # <lexxy-editor> (see LexicalEditorElement#prerenderedContentElement). Shared
+  # by the Rails 8.2 editor-adapter Tag and the 8.0/8.1 TagHelper fallback.
+  module Prerender
+    # The value is the same editable HTML the editor parses from the `value`
+    # attribute, so the element renders at the height the live editor lands on.
+    # Two deliberate differences from the live element:
+    #
+    # - It is sanitized with Action Text's display sanitizer (whose allow-list
+    #   this engine already extends): the attribute path is escaped and then
+    #   DOMPurify-cleaned client-side before touching the live DOM, but this
+    #   HTML enters the DOM straight from storage, so it must not trust it.
+    # - It carries none of the interactive attributes (contenteditable, role,
+    #   aria-*): before Lexical mounts they would advertise an editability that
+    #   isn't there yet — keystrokes would be discarded on adoption. The editor
+    #   adds them when it adopts the element.
+    def self.content_tag_for(view, value)
+      html = view.sanitize (value.presence || "<p><br></p>"),
+        tags: view.sanitizer_allowed_tags, attributes: view.sanitizer_allowed_attributes
+
+      view.content_tag "div", html, class: "lexxy-editor__content"
+    end
+  end
+end

--- a/lib/lexxy/prerender.rb
+++ b/lib/lexxy/prerender.rb
@@ -16,8 +16,8 @@ module Lexxy
     #   isn't there yet — keystrokes would be discarded on adoption. The editor
     #   adds them when it adopts the element.
     def self.content_tag_for(view, value)
-      html = view.sanitize (value.presence || "<p><br></p>"),
-        tags: view.sanitizer_allowed_tags, attributes: view.sanitizer_allowed_attributes
+      html = view.sanitize(value.presence || "<p><br></p>",
+        tags: view.sanitizer_allowed_tags, attributes: view.sanitizer_allowed_attributes)
 
       view.content_tag "div", html, class: "lexxy-editor__content"
     end

--- a/lib/lexxy/prerender.rb
+++ b/lib/lexxy/prerender.rb
@@ -2,6 +2,15 @@ module Lexxy
   # Builds the static content element a prerendering editor emits inside
   # <lexxy-editor> (see LexicalEditorElement#prerenderedContentElement). Shared
   # by the Rails 8.2 editor-adapter Tag and the 8.0/8.1 TagHelper fallback.
+  #
+  # Scope: this reserves the height of the editor's *content* — the part that
+  # varies per record, and so cannot be reserved by a CSS rule the way a fixed
+  # row count can. It does not reserve the default toolbar, which
+  # connectedCallback prepends in normal flow: an editor using it still gains
+  # that element's height on mount. The editors this option exists for float the
+  # toolbar out of flow, since an inline field standing in for published copy has
+  # nowhere to put one, but the boundary is real and is pinned by
+  # test/browser/tests/editor/prerender_adoption.test.js.
   module Prerender
     # The value is the same editable HTML the editor parses from the `value`
     # attribute, so the element renders at the height the live editor lands on.

--- a/lib/lexxy/prerender.rb
+++ b/lib/lexxy/prerender.rb
@@ -1,17 +1,20 @@
 module Lexxy
-  # Builds the static content element a prerendering editor emits inside
-  # <lexxy-editor> (see LexicalEditorElement#prerenderedContentElement). Shared
-  # by the Rails 8.2 editor-adapter Tag and the 8.0/8.1 TagHelper fallback.
+  # Builds the static markup a prerendering editor emits inside <lexxy-editor>
+  # (see LexicalEditorElement#prerenderedContentElement). Shared by the Rails 8.2
+  # editor-adapter Tag and the 8.0/8.1 TagHelper fallback.
   #
-  # Scope: this reserves the height of the editor's *content* — the part that
-  # varies per record, and so cannot be reserved by a CSS rule the way a fixed
-  # row count can. It does not reserve the default toolbar, which
-  # connectedCallback prepends in normal flow: an editor using it still gains
-  # that element's height on mount. The editors this option exists for float the
-  # toolbar out of flow, since an inline field standing in for published copy has
-  # nowhere to put one, but the boundary is real and is pinned by
-  # test/browser/tests/editor/prerender_adoption.test.js.
+  # Between them, the two elements below reserve the whole height the editor
+  # lands on: the toolbar's, which is fixed and could equally come from CSS, and
+  # the content's, which varies per record and is the part no stylesheet can know.
   module Prerender
+    def self.inner_html_for(view, options)
+      parts = []
+      parts << toolbar_placeholder_tag(view) if reserves_toolbar?(options)
+      parts << content_tag_for(view, options[:value])
+
+      view.safe_join(parts)
+    end
+
     # The value is the same editable HTML the editor parses from the `value`
     # attribute, so the element renders at the height the live editor lands on.
     # Two deliberate differences from the live element:
@@ -29,6 +32,34 @@ module Lexxy
         tags: view.sanitizer_allowed_tags, attributes: view.sanitizer_allowed_attributes)
 
       view.content_tag "div", html, class: "lexxy-editor__content"
+    end
+
+    # The toolbar itself, empty: the editor fills it in on connect rather than
+    # building another one. It has to be a real <lexxy-toolbar> and not a neutral
+    # spacer, because whether a toolbar occupies space at all is the host's CSS
+    # to decide — an inline editor floats it out of flow, and a spacer sized from
+    # --lexxy-toolbar-height would then reserve height nothing ever fills and
+    # shift the page *up* on connect. Styled by the host's own toolbar rules, it
+    # reserves exactly what the real one will take, including nothing.
+    def self.toolbar_placeholder_tag(view)
+      view.content_tag "lexxy-toolbar", "", data: { prerendered: "server" }, aria: { hidden: true }
+    end
+
+    # Only reserve a toolbar the editor is actually going to prepend, or the
+    # field would give the space back on connect — the same shift, upwards.
+    # Mirrors the client's own conditions: rich text off means no toolbar, and a
+    # `toolbar` that names an element by id puts it outside this editor.
+    def self.reserves_toolbar?(options)
+      # fetch, not `||`: an explicit `toolbar: false` is exactly the case this
+      # has to catch, and `||` would collapse it to nil and reserve anyway.
+      toolbar = options.fetch(:toolbar) { options["toolbar"] }
+      rich_text = options.fetch(:rich_text) { options.fetch("rich-text") { options["rich_text"] } }
+
+      return false if [ false, "false" ].include?(rich_text)
+      return false if [ false, "false" ].include?(toolbar)
+      return false if toolbar.is_a?(String)
+
+      true
     end
   end
 end

--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -7,6 +7,11 @@ module Lexxy
       # remove the html_safe attribute to preserve attribute escape
       value = value.to_str if value.respond_to? :to_str
 
+      # Opt-in: render the value into a content element the editor adopts on
+      # connect, so the field has its final height at first paint instead of
+      # reflowing when the editor builds a frame after load. Off by default.
+      prerender = options.delete(:prerender)
+
       options[:name] ||= name
       options[:value] ||= value
       options[:class] ||= "lexxy-content"
@@ -14,13 +19,26 @@ module Lexxy
       options[:data][:direct_upload_url] ||= main_app.rails_direct_uploads_url
       options[:data][:blob_url_template] ||= main_app.rails_service_blob_url(":signed_id", ":filename")
 
-      editor_tag = content_tag("lexxy-editor", "", options, &block)
+      inner = (block || !prerender) ? "" : prerendered_content_tag(options[:value])
+      editor_tag = content_tag("lexxy-editor", inner, options, &block)
       editor_tag
     end
 
     alias_method :lexxy_rich_text_area_tag, :lexxy_rich_textarea_tag
 
     private
+      # A static copy of the value the editor adopts as its content element on
+      # connect (see LexicalEditorElement#prerenderedContentElement). It is the
+      # same HTML the editor parses from `value`, so it renders at the same
+      # height the live editor lands on.
+      def prerendered_content_tag(value)
+        content_tag "div", (value.presence || "<p><br></p>").html_safe,
+          class: "lexxy-editor__content",
+          contenteditable: "true",
+          role: "textbox",
+          "aria-multiline": "true"
+      end
+
       # Temporary: we need to *adaptarize* action text
       def render_custom_attachments_in(value)
         if value.respond_to?(:body)

--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -27,16 +27,10 @@ module Lexxy
     alias_method :lexxy_rich_text_area_tag, :lexxy_rich_textarea_tag
 
     private
-      # A static copy of the value the editor adopts as its content element on
-      # connect (see LexicalEditorElement#prerenderedContentElement). It is the
-      # same HTML the editor parses from `value`, so it renders at the same
-      # height the live editor lands on.
+      # A static, sanitized copy of the value the editor adopts as its content
+      # element on connect (see Lexxy::Prerender).
       def prerendered_content_tag(value)
-        content_tag "div", (value.presence || "<p><br></p>").html_safe,
-          class: "lexxy-editor__content",
-          contenteditable: "true",
-          role: "textbox",
-          "aria-multiline": "true"
+        Lexxy::Prerender.content_tag_for(self, value)
       end
 
       # Temporary: we need to *adaptarize* action text

--- a/lib/lexxy/rich_text_area_tag.rb
+++ b/lib/lexxy/rich_text_area_tag.rb
@@ -19,7 +19,7 @@ module Lexxy
       options[:data][:direct_upload_url] ||= main_app.rails_direct_uploads_url
       options[:data][:blob_url_template] ||= main_app.rails_service_blob_url(":signed_id", ":filename")
 
-      inner = (block || !prerender) ? "" : prerendered_content_tag(options[:value])
+      inner = (block || !prerender) ? "" : Lexxy::Prerender.inner_html_for(self, options)
       editor_tag = content_tag("lexxy-editor", inner, options, &block)
       editor_tag
     end
@@ -27,12 +27,6 @@ module Lexxy
     alias_method :lexxy_rich_text_area_tag, :lexxy_rich_textarea_tag
 
     private
-      # A static, sanitized copy of the value the editor adopts as its content
-      # element on connect (see Lexxy::Prerender).
-      def prerendered_content_tag(value)
-        Lexxy::Prerender.content_tag_for(self, value)
-      end
-
       # Temporary: we need to *adaptarize* action text
       def render_custom_attachments_in(value)
         if value.respond_to?(:body)

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -400,6 +400,7 @@ export class LexicalEditorElement extends HTMLElement {
     this.#registerFileAcceptFilter()
     this.#attachDebugHooks()
     this.#attachToolbar()
+    this.#discardUnusedPrerenderedToolbar()
     this.#resetBeforeTurboCaches()
 
     this.#setInternalFormValue(this.value, { suppressEvent: true })
@@ -764,7 +765,12 @@ export class LexicalEditorElement extends HTMLElement {
     if (typeof toolbarConfig === "string") {
       return document.getElementById(toolbarConfig)
     } else {
-      return this.querySelector("lexxy-toolbar") ?? this.#createDefaultToolbar()
+      const existing = this.querySelector("lexxy-toolbar")
+      // A prerendered toolbar is ours and arrives empty — fill it rather than
+      // treat it as one the caller supplied and wants left alone.
+      if (existing?.dataset.prerendered) return this.#fillDefaultToolbar(existing)
+
+      return existing ?? this.#createDefaultToolbar()
     }
   }
 
@@ -772,12 +778,25 @@ export class LexicalEditorElement extends HTMLElement {
     return this.supportsRichText && !!this.config.get("toolbar")
   }
 
+  // A prerendered toolbar this editor turns out not to want — the toolbar is
+  // configured off, or points at an element elsewhere. Leaving it would reserve
+  // space nothing fills. Same task as connect, so nothing paints in between.
+  #discardUnusedPrerenderedToolbar() {
+    const prerendered = this.querySelector(":scope > lexxy-toolbar[data-prerendered]")
+    if (prerendered && prerendered !== this.toolbar) prerendered.remove()
+  }
+
   #createDefaultToolbar() {
     const toolbar = createElement("lexxy-toolbar")
+    this.prepend(toolbar)
+    return this.#fillDefaultToolbar(toolbar)
+  }
+
+  #fillDefaultToolbar(toolbar) {
     toolbar.innerHTML = LexicalToolbar.defaultTemplate
     toolbar.setAttribute("data-attachments", this.supportsAttachments) // Drives toolbar CSS styles
+    toolbar.removeAttribute("aria-hidden")
     toolbar.configure(this.config.get("toolbar"))
-    this.prepend(toolbar)
     return toolbar
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -417,7 +417,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #createEditor() {
-    this.editorContentElement ||= this.#createEditorContentElement()
+    this.editorContentElement ||= this.#prerenderedContentElement() || this.#createEditorContentElement()
     this.appendChild(this.editorContentElement)
 
     const editor = buildEditorFromExtensions({
@@ -465,6 +465,30 @@ export class LexicalEditorElement extends HTMLElement {
     }
 
     return nodes
+  }
+
+  // Adopt a content element the server prerendered inside us, if present.
+  // Rendering the body server-side and reusing it here gives the field its final
+  // height at first paint, avoiding the reflow from building the editor a frame
+  // after load. Lexical reconciles its parsed state into this element on mount,
+  // replacing the static markup with the live editor at the same height. Returns
+  // null when absent (the default), so the empty-editor path is unchanged.
+  #prerenderedContentElement() {
+    const element = this.querySelector(":scope > .lexxy-editor__content")
+    if (!element) return null
+
+    element.id ||= `${this.id}-content`
+    element.setAttribute("contenteditable", "true")
+    element.setAttribute("role", "textbox")
+    element.setAttribute("aria-multiline", "true")
+    if (!element.hasAttribute("aria-label")) element.setAttribute("aria-label", this.#labelText)
+    if (this.hasAttribute("placeholder")) element.setAttribute("placeholder", this.getAttribute("placeholder"))
+
+    this.#ariaAttributes.forEach(attribute => element.setAttribute(attribute.name, attribute.value))
+    this.#transferAttributeToContentEditable(element, "autocapitalize")
+    this.#transferAttributeToContentEditable(element, "tabindex", { defaultValue: 0, removeSource: true })
+
+    return element
   }
 
   #createEditorContentElement() {

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -11,10 +11,12 @@
     <div class="body">
       <!-- Simulates rich_text_area(..., prerender: true): the content element is
            rendered server-side inside the editor so the field has its height at
-           first paint. The editor should adopt this node on connect, not build a
-           second one. `data-prerendered` lets the spec prove the same node. -->
+           first paint — static markup only; the editor adds the interactive
+           attributes (contenteditable, role, aria) when it adopts the node on
+           connect, rather than building a second one. `data-prerendered` lets
+           the spec prove the same node. -->
       <lexxy-editor class="lexxy-content" value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;">
-        <div class="lexxy-editor__content" contenteditable="true" role="textbox" aria-multiline="true" data-prerendered="server"><p>Alpha</p><p>Bravo</p></div>
+        <div class="lexxy-editor__content" data-prerendered="server"><p>Alpha</p><p>Bravo</p></div>
       </lexxy-editor>
     </div>
   </form>

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Prerender Test</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <!-- Simulates rich_text_area(..., prerender: true): the content element is
+           rendered server-side inside the editor so the field has its height at
+           first paint. The editor should adopt this node on connect, not build a
+           second one. `data-prerendered` lets the spec prove the same node. -->
+      <lexxy-editor class="lexxy-content" value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;">
+        <div class="lexxy-editor__content" contenteditable="true" role="textbox" aria-multiline="true" data-prerendered="server"><p>Alpha</p><p>Bravo</p></div>
+      </lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -138,9 +138,16 @@
   </main>
 
   <script type="module">
-    const delay = Number(new URLSearchParams(window.location.search).get("delay") || 0)
+    const params = new URLSearchParams(window.location.search)
 
-    window.setTimeout(() => import("/editor.js"), delay)
+    window.loadLexxy = () => import("/editor.js")
+
+    // Tests pass ?manual and drive loadLexxy() themselves so they can measure
+    // the pre-connection layout without racing this timer. Humans open the page
+    // with ?delay=1500 to watch the editor build in slow motion.
+    if (!params.has("manual")) {
+      window.setTimeout(window.loadLexxy, Number(params.get("delay") || 0))
+    }
   </script>
 </body>
 </html>

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -33,7 +33,7 @@
       background: #ffffff;
       border: 1px solid #d8d5ce;
       border-radius: 8px;
-      padding: 24px;
+      padding: 56px 24px 24px;
     }
 
     .example h2 {
@@ -53,6 +53,15 @@
     .inline-editor .lexxy-editor__content {
       min-block-size: 0;
       padding: 0;
+    }
+
+    .inline-editor lexxy-toolbar {
+      background: #ffffff;
+      border-block-end: 1px solid #d8d5ce;
+      inset-block-end: 100%;
+      inset-inline: 0;
+      position: absolute;
+      z-index: 1;
     }
 
     .following-content {
@@ -83,7 +92,6 @@
 
         <lexxy-editor
           class="lexxy-content inline-editor"
-          toolbar="false"
           value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;&lt;p&gt;Charlie&lt;/p&gt;&lt;p&gt;Delta&lt;/p&gt;">
         </lexxy-editor>
 
@@ -103,7 +111,6 @@
              `data-prerendered` lets the spec prove the same node. -->
         <lexxy-editor
           class="lexxy-content inline-editor"
-          toolbar="false"
           value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;&lt;p&gt;Charlie&lt;/p&gt;&lt;p&gt;Delta&lt;/p&gt;">
           <div class="lexxy-editor__content" data-prerendered="server">
             <p>Alpha</p>

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -3,24 +3,127 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Lexxy Prerender Test</title>
+  <title>Lexxy Prerender Reproduction</title>
   <link rel="stylesheet" href="/styles.css">
+  <style>
+    body {
+      background: #f7f7f4;
+      color: #24231f;
+      margin: 0;
+    }
+
+    .demo {
+      margin: 0 auto;
+      max-inline-size: 1120px;
+      padding: 32px;
+    }
+
+    .demo > p {
+      max-inline-size: 68ch;
+    }
+
+    .examples {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      margin-block-start: 24px;
+    }
+
+    .example {
+      background: #ffffff;
+      border: 1px solid #d8d5ce;
+      border-radius: 8px;
+      padding: 24px;
+    }
+
+    .example h2 {
+      font-size: 1rem;
+      margin-block: 0 16px;
+    }
+
+    .inline-editor {
+      --lexxy-editor-padding: 0;
+      --lexxy-editor-rows: 0;
+
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+    }
+
+    .inline-editor .lexxy-editor__content {
+      min-block-size: 0;
+      padding: 0;
+    }
+
+    .following-content {
+      border-block-start: 1px solid #d8d5ce;
+      margin-block-start: 16px;
+      padding-block-start: 16px;
+    }
+
+    @media (max-width: 720px) {
+      .examples {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
 </head>
 <body>
-  <form>
-    <div class="body">
-      <!-- Simulates rich_text_area(..., prerender: true): the content element is
-           rendered server-side inside the editor so the field has its height at
-           first paint — static markup only; the editor adds the interactive
-           attributes (contenteditable, role, aria) when it adopts the node on
-           connect, rather than building a second one. `data-prerendered` lets
-           the spec prove the same node. -->
-      <lexxy-editor class="lexxy-content" value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;">
-        <div class="lexxy-editor__content" data-prerendered="server"><p>Alpha</p><p>Bravo</p></div>
-      </lexxy-editor>
-    </div>
-  </form>
+  <main class="demo">
+    <h1>Inline editor layout reproduction</h1>
+    <p>
+      Open this page with <code>?delay=1500</code> to slow Lexxy initialization.
+      The page content below each editor should start in its final position when
+      the editor is styled to hug and grow with its contents.
+    </p>
 
-  <script type="module" src="/editor.js"></script>
+    <form class="examples">
+      <section class="example" data-example="without-prerender">
+        <h2>Without prerendered content</h2>
+
+        <lexxy-editor
+          class="lexxy-content inline-editor"
+          toolbar="false"
+          value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;&lt;p&gt;Charlie&lt;/p&gt;&lt;p&gt;Delta&lt;/p&gt;">
+        </lexxy-editor>
+
+        <div class="following-content" data-following="without-prerender">
+          <p>This content shifts down after Lexxy builds the editor.</p>
+        </div>
+      </section>
+
+      <section class="example" data-example="with-prerender">
+        <h2>With prerendered content</h2>
+
+        <!-- Simulates rich_text_area(..., prerender: true): the content element
+             is rendered server-side inside the editor, so the field has its
+             final content height at first paint. The editor adds the
+             interactive attributes (contenteditable, role, aria) when it
+             adopts the node on connect, rather than building another one.
+             `data-prerendered` lets the spec prove the same node. -->
+        <lexxy-editor
+          class="lexxy-content inline-editor"
+          toolbar="false"
+          value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;&lt;p&gt;Charlie&lt;/p&gt;&lt;p&gt;Delta&lt;/p&gt;">
+          <div class="lexxy-editor__content" data-prerendered="server">
+            <p>Alpha</p>
+            <p>Bravo</p>
+            <p>Charlie</p>
+            <p>Delta</p>
+          </div>
+        </lexxy-editor>
+
+        <div class="following-content" data-following="with-prerender">
+          <p>This content is already in the right spot before Lexxy connects.</p>
+        </div>
+      </section>
+    </form>
+  </main>
+
+  <script type="module">
+    const delay = Number(new URLSearchParams(window.location.search).get("delay") || 0)
+
+    window.setTimeout(() => import("/editor.js"), delay)
+  </script>
 </body>
 </html>

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -33,12 +33,12 @@
       background: #ffffff;
       border: 1px solid #d8d5ce;
       border-radius: 8px;
-      padding: 56px 24px 24px;
+      padding: 24px;
     }
 
     .example h2 {
       font-size: 1rem;
-      margin-block: 0 16px;
+      margin-block: 0 56px;
     }
 
     .inline-editor {
@@ -58,10 +58,20 @@
     .inline-editor lexxy-toolbar {
       background: #ffffff;
       border-block-end: 1px solid #d8d5ce;
-      inset-block-end: 100%;
+      inset-block-end: calc(100% + 8px);
       inset-inline: 0;
+      opacity: 0;
+      pointer-events: none;
       position: absolute;
+      visibility: hidden;
       z-index: 1;
+    }
+
+    .inline-editor:has(.lexxy-editor__content:focus-visible) lexxy-toolbar,
+    .inline-editor:has(lexxy-toolbar:focus-within) lexxy-toolbar {
+      opacity: 1;
+      pointer-events: auto;
+      visibility: visible;
     }
 
     .following-content {

--- a/test/browser/fixtures/prerender.html
+++ b/test/browser/fixtures/prerender.html
@@ -122,6 +122,7 @@
         <lexxy-editor
           class="lexxy-content inline-editor"
           value="&lt;p&gt;Alpha&lt;/p&gt;&lt;p&gt;Bravo&lt;/p&gt;&lt;p&gt;Charlie&lt;/p&gt;&lt;p&gt;Delta&lt;/p&gt;">
+          <lexxy-toolbar data-prerendered="server" aria-hidden="true"></lexxy-toolbar>
           <div class="lexxy-editor__content" data-prerendered="server">
             <p>Alpha</p>
             <p>Bravo</p>

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -1,4 +1,5 @@
-import { expect, test } from "@playwright/test"
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
 
 async function topOf(locator) {
   return (await locator.boundingBox()).y

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -21,9 +21,13 @@ test.describe("Prerendered content element", () => {
     await expect(content).toHaveAttribute("data-prerendered", "server")
     // Lexical reconciled its state into that adopted node.
     await expect(content).toHaveAttribute("data-lexical-editor", "true")
-    // Content is intact and the field stays editable.
+    // Content is intact...
     await expect(content.locator("p")).toHaveText([ "Alpha", "Bravo" ])
+    // ...and adoption dressed the static server markup with the interactive
+    // attributes the server deliberately omits (it isn't editable until now).
     await expect(content).toHaveAttribute("contenteditable", "true")
+    await expect(content).toHaveAttribute("role", "textbox")
+    await expect(content).toHaveAttribute("aria-multiline", "true")
   })
 
   test("exposes the value once, without duplicating the body", async ({ editor }) => {

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -1,0 +1,32 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+// When the server prerenders the content element inside <lexxy-editor> (via
+// `rich_text_area(..., prerender: true)`), the editor adopts that element on
+// connect instead of building an empty one, so the field keeps its first-paint
+// height. Without adoption the editor would append a second content element and
+// the field would double-render.
+test.describe("Prerendered content element", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/prerender.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("adopts the server-rendered content element rather than creating a second", async ({ page }) => {
+    const content = page.locator("lexxy-editor .lexxy-editor__content")
+
+    // Exactly one content element — the server's was reused, not duplicated.
+    await expect(content).toHaveCount(1)
+    // ...and it is the very node the server rendered.
+    await expect(content).toHaveAttribute("data-prerendered", "server")
+    // Lexical reconciled its state into that adopted node.
+    await expect(content).toHaveAttribute("data-lexical-editor", "true")
+    // Content is intact and the field stays editable.
+    await expect(content.locator("p")).toHaveText([ "Alpha", "Bravo" ])
+    await expect(content).toHaveAttribute("contenteditable", "true")
+  })
+
+  test("exposes the value once, without duplicating the body", async ({ editor }) => {
+    expect(await editor.value()).toBe("<p>Alpha</p><p>Bravo</p>")
+  })
+})

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -7,7 +7,7 @@ async function topOf(locator) {
 
 test.describe("Prerendered content element", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/prerender.html?delay=250")
+    await page.goto("/prerender.html?manual")
   })
 
   test("keeps following content stable when the editor hugs its contents", async ({ page }) => {
@@ -16,6 +16,7 @@ test.describe("Prerendered content element", () => {
     const withoutBefore = await topOf(withoutFollowing)
     const withBefore = await topOf(withFollowing)
 
+    await page.evaluate(() => window.loadLexxy())
     await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
 
     const withoutAfter = await topOf(withoutFollowing)
@@ -26,6 +27,7 @@ test.describe("Prerendered content element", () => {
   })
 
   test("adopts the server-rendered content element rather than creating a second", async ({ page }) => {
+    await page.evaluate(() => window.loadLexxy())
     await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
 
     const content = page.locator("[data-example='with-prerender'] lexxy-editor > .lexxy-editor__content")
@@ -46,6 +48,7 @@ test.describe("Prerendered content element", () => {
   })
 
   test("exposes the value once, without duplicating the body", async ({ page }) => {
+    await page.evaluate(() => window.loadLexxy())
     await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
 
     const value = await page.locator("[data-example='with-prerender'] lexxy-editor").evaluate(editor => editor.value)

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -1,28 +1,42 @@
-import { test } from "../../test_helper.js"
-import { expect } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
-// When the server prerenders the content element inside <lexxy-editor> (via
-// `rich_text_area(..., prerender: true)`), the editor adopts that element on
-// connect instead of building an empty one, so the field keeps its first-paint
-// height. Without adoption the editor would append a second content element and
-// the field would double-render.
+async function topOf(locator) {
+  return (await locator.boundingBox()).y
+}
+
 test.describe("Prerendered content element", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/prerender.html")
-    await page.waitForSelector("lexxy-editor[connected]")
+    await page.goto("/prerender.html?delay=250")
+  })
+
+  test("keeps following content stable when the editor hugs its contents", async ({ page }) => {
+    const withoutFollowing = page.locator("[data-following='without-prerender']")
+    const withFollowing = page.locator("[data-following='with-prerender']")
+    const withoutBefore = await topOf(withoutFollowing)
+    const withBefore = await topOf(withFollowing)
+
+    await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
+
+    const withoutAfter = await topOf(withoutFollowing)
+    const withAfter = await topOf(withFollowing)
+
+    expect(withAfter - withBefore).toBeLessThan(1)
+    expect(withoutAfter - withoutBefore).toBeGreaterThan(60)
   })
 
   test("adopts the server-rendered content element rather than creating a second", async ({ page }) => {
-    const content = page.locator("lexxy-editor .lexxy-editor__content")
+    await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
 
-    // Exactly one content element — the server's was reused, not duplicated.
+    const content = page.locator("[data-example='with-prerender'] lexxy-editor > .lexxy-editor__content")
+
+    // Exactly one content element: the server's was reused, not duplicated.
     await expect(content).toHaveCount(1)
     // ...and it is the very node the server rendered.
     await expect(content).toHaveAttribute("data-prerendered", "server")
     // Lexical reconciled its state into that adopted node.
     await expect(content).toHaveAttribute("data-lexical-editor", "true")
     // Content is intact...
-    await expect(content.locator("p")).toHaveText([ "Alpha", "Bravo" ])
+    await expect(content.locator("p")).toHaveText([ "Alpha", "Bravo", "Charlie", "Delta" ])
     // ...and adoption dressed the static server markup with the interactive
     // attributes the server deliberately omits (it isn't editable until now).
     await expect(content).toHaveAttribute("contenteditable", "true")
@@ -30,7 +44,10 @@ test.describe("Prerendered content element", () => {
     await expect(content).toHaveAttribute("aria-multiline", "true")
   })
 
-  test("exposes the value once, without duplicating the body", async ({ editor }) => {
-    expect(await editor.value()).toBe("<p>Alpha</p><p>Bravo</p>")
+  test("exposes the value once, without duplicating the body", async ({ page }) => {
+    await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
+
+    const value = await page.locator("[data-example='with-prerender'] lexxy-editor").evaluate(editor => editor.value)
+    expect(value).toBe("<p>Alpha</p><p>Bravo</p><p>Charlie</p><p>Delta</p>")
   })
 })

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -17,7 +17,10 @@ test.describe("Prerendered content element", () => {
     const withBefore = await topOf(withFollowing)
 
     await page.evaluate(() => window.loadLexxy())
-    await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
+    // `connected` is set before Lexical mounts (mount happens in a following
+    // animation frame), so wait for the mounted roots or the height change we
+    // assert on could be measured before it happens.
+    await expect(page.locator("lexxy-editor .lexxy-editor__content[data-lexical-editor='true']")).toHaveCount(2)
 
     const withoutAfter = await topOf(withoutFollowing)
     const withAfter = await topOf(withFollowing)

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -25,8 +25,35 @@ test.describe("Prerendered content element", () => {
     const withoutAfter = await topOf(withoutFollowing)
     const withAfter = await topOf(withFollowing)
 
-    expect(withAfter - withBefore).toBeLessThan(1)
+    // Absolute displacement: a signed comparison would let a large *upward* shift
+    // through as a comfortably negative number.
+    expect(Math.abs(withAfter - withBefore)).toBeLessThan(1)
     expect(withoutAfter - withoutBefore).toBeGreaterThan(60)
+  })
+
+  // Prerendering reserves the height of the editor's *content*, which is the part
+  // whose height depends on the record. The default toolbar is a separate element
+  // that connectedCallback prepends in normal flow, so an editor using it still
+  // gains that much height on mount. Editors this option is for float the toolbar
+  // out of flow — the fixture does, and an inline field that must match published
+  // copy could hardly do otherwise — but the boundary should be visible rather
+  // than implied, so pin it.
+  test("reserves the content height, not an in-flow default toolbar's", async ({ page }) => {
+    await page.addStyleTag({ content: `.inline-editor lexxy-toolbar {
+      position: static !important; opacity: 1 !important; visibility: visible !important; inset: auto !important; }` })
+
+    const following = page.locator("[data-following='with-prerender']")
+    const before = await topOf(following)
+
+    await page.evaluate(() => window.loadLexxy())
+    await expect(page.locator("lexxy-editor .lexxy-editor__content[data-lexical-editor='true']")).toHaveCount(2)
+
+    const after = await topOf(following)
+    const toolbar = await page.locator("[data-example='with-prerender'] lexxy-toolbar").boundingBox()
+
+    // The residual shift is the toolbar's height and nothing more — the body, which
+    // is the part that varies per record, is still fully reserved.
+    expect(after - before).toBeCloseTo(toolbar.height, 0)
   })
 
   test("adopts the server-rendered content element rather than creating a second", async ({ page }) => {

--- a/test/browser/tests/editor/prerender_adoption.test.js
+++ b/test/browser/tests/editor/prerender_adoption.test.js
@@ -31,14 +31,11 @@ test.describe("Prerendered content element", () => {
     expect(withoutAfter - withoutBefore).toBeGreaterThan(60)
   })
 
-  // Prerendering reserves the height of the editor's *content*, which is the part
-  // whose height depends on the record. The default toolbar is a separate element
-  // that connectedCallback prepends in normal flow, so an editor using it still
-  // gains that much height on mount. Editors this option is for float the toolbar
-  // out of flow — the fixture does, and an inline field that must match published
-  // copy could hardly do otherwise — but the boundary should be visible rather
-  // than implied, so pin it.
-  test("reserves the content height, not an in-flow default toolbar's", async ({ page }) => {
+  // The content element reserves the body; the toolbar placeholder reserves the
+  // element connectedCallback prepends above it. The fixture floats its toolbar,
+  // which would hide a failure here, so put it back in normal flow — the stock
+  // arrangement — and require the same stability.
+  test("reserves the default toolbar's height too, when it takes space in flow", async ({ page }) => {
     await page.addStyleTag({ content: `.inline-editor lexxy-toolbar {
       position: static !important; opacity: 1 !important; visibility: visible !important; inset: auto !important; }` })
 
@@ -48,12 +45,26 @@ test.describe("Prerendered content element", () => {
     await page.evaluate(() => window.loadLexxy())
     await expect(page.locator("lexxy-editor .lexxy-editor__content[data-lexical-editor='true']")).toHaveCount(2)
 
-    const after = await topOf(following)
+    // The real toolbar is in flow and has height, so this asserts the reservation
+    // matched it rather than that there was nothing to reserve.
     const toolbar = await page.locator("[data-example='with-prerender'] lexxy-toolbar").boundingBox()
+    expect(toolbar.height).toBeGreaterThan(0)
+    expect(Math.abs(await topOf(following) - before)).toBeLessThan(1)
+  })
 
-    // The residual shift is the toolbar's height and nothing more — the body, which
-    // is the part that varies per record, is still fully reserved.
-    expect(after - before).toBeCloseTo(toolbar.height, 0)
+  // The prerendered toolbar is ours, not the caller's: the editor fills it in
+  // rather than leaving it empty or building a second one beside it.
+  test("fills the prerendered toolbar instead of adding another", async ({ page }) => {
+    const toolbars = page.locator("[data-example='with-prerender'] lexxy-toolbar")
+    await expect(toolbars).toHaveCount(1)
+    await expect(toolbars.first()).toBeEmpty()
+
+    await page.evaluate(() => window.loadLexxy())
+    await expect(page.locator("lexxy-editor[connected]")).toHaveCount(2)
+
+    await expect(toolbars).toHaveCount(1)
+    await expect(toolbars.first()).not.toBeEmpty()
+    await expect(toolbars.first()).not.toHaveAttribute("aria-hidden")
   })
 
   test("adopts the server-rendered content element rather than creating a second", async ({ page }) => {

--- a/test/helpers/prerender_test.rb
+++ b/test/helpers/prerender_test.rb
@@ -50,7 +50,7 @@ class PrerenderTest < ActionView::TestCase
     # The value attribute is escaped and DOMPurify cleans it client-side, but
     # the prerendered element enters the DOM straight from storage — it must go
     # through Action Text's sanitizer.
-    assert_dom "lexxy-editor > div.lexxy-editor__content" do |content, *|
+    assert_dom "lexxy-editor > div.lexxy-editor__content" do
       assert_dom "p", text: "Safe"
       assert_dom "script", count: 0
       assert_dom "[onerror]", count: 0

--- a/test/helpers/prerender_test.rb
+++ b/test/helpers/prerender_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+# The prerender: option renders the value into a static content element inside
+# <lexxy-editor>, which the editor adopts on connect instead of building an
+# empty one — giving the field its final height at first paint (see
+# LexicalEditorElement#prerenderedContentElement). Exercised through
+# rich_textarea_tag so the same assertions cover whichever integration is
+# active: the ActionText::Editor adapter or the TagHelper fallback.
+class PrerenderTest < ActionView::TestCase
+  helper ActionText::ContentHelper
+
+  test "renders an empty editor by default" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, "<p>Hello</p>" %>
+    ERB
+
+    assert_dom "lexxy-editor", count: 1
+    assert_dom "lexxy-editor > *", count: 0
+  end
+
+  test "prerender: true renders the value into a content element" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, "<p>Hello</p>", prerender: true %>
+    ERB
+
+    assert_dom "lexxy-editor > div.lexxy-editor__content", count: 1 do
+      assert_dom "p", text: "Hello"
+    end
+    # prerender must not leak through as an HTML attribute
+    assert_dom "lexxy-editor[prerender]", count: 0
+  end
+
+  test "prerendered content is static until the editor adopts it" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, "<p>Hello</p>", prerender: true %>
+    ERB
+
+    # The element advertises no editability before Lexical mounts — keystrokes
+    # into it would be discarded. Adoption adds these attributes on connect.
+    assert_dom "lexxy-editor > div.lexxy-editor__content:not([contenteditable]):not([role])"
+  end
+
+  test "prerendered content is sanitized" do
+    value = %(<p>Safe</p><script>alert("boom")</script><p><img src="x" onerror="alert('boom')"></p>)
+
+    render inline: <<~ERB, locals: { value: value }
+      <%= rich_textarea_tag :body, value, prerender: true %>
+    ERB
+
+    # The value attribute is escaped and DOMPurify cleans it client-side, but
+    # the prerendered element enters the DOM straight from storage — it must go
+    # through Action Text's sanitizer.
+    assert_dom "lexxy-editor > div.lexxy-editor__content" do |content, *|
+      assert_dom "p", text: "Safe"
+      assert_dom "script", count: 0
+      assert_dom "[onerror]", count: 0
+    end
+  end
+
+  test "prerendering a blank value renders the editor's empty paragraph" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, nil, prerender: true %>
+    ERB
+
+    assert_dom "lexxy-editor > div.lexxy-editor__content" do
+      assert_dom "p br", count: 1
+    end
+  end
+
+  test "an explicit block wins over prerender" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, "<p>Hello</p>", prerender: true do %>
+        <span id="custom">custom child</span>
+      <% end %>
+    ERB
+
+    assert_dom "lexxy-editor > span#custom", count: 1
+    assert_dom "lexxy-editor > div.lexxy-editor__content", count: 0
+  end
+end

--- a/test/helpers/prerender_test.rb
+++ b/test/helpers/prerender_test.rb
@@ -30,6 +30,34 @@ class PrerenderTest < ActionView::TestCase
     assert_dom "lexxy-editor[prerender]", count: 0
   end
 
+  test "prerender: true also ships the toolbar the editor will fill" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, "<p>Hello</p>", prerender: true %>
+    ERB
+
+    # Empty, and before the content: the editor prepends its toolbar there, so
+    # this has to occupy the same place to reserve the same space. A real
+    # <lexxy-toolbar> rather than a spacer, so the host's own toolbar CSS decides
+    # whether it takes any room at all.
+    assert_dom "lexxy-editor > lexxy-toolbar[data-prerendered='server']:empty", count: 1
+    assert_dom "lexxy-editor > *:first-child", count: 1 do |first, *|
+      assert_equal "lexxy-toolbar", first.name
+    end
+  end
+
+  test "no toolbar is prerendered when the editor will not prepend one" do
+    render inline: <<~ERB
+      <%= rich_textarea_tag :body, "<p>Hello</p>", prerender: true, toolbar: false %>
+      <%= rich_textarea_tag :other, "<p>Hello</p>", prerender: true, toolbar: "shared-toolbar" %>
+      <%= rich_textarea_tag :third, "<p>Hello</p>", prerender: true, rich_text: false %>
+    ERB
+
+    # Reserving space for a toolbar that never arrives is the same defect
+    # upwards: the field would give the height back on connect.
+    assert_dom "lexxy-toolbar", count: 0
+    assert_dom "lexxy-editor > div.lexxy-editor__content", count: 3
+  end
+
   test "prerendered content is static until the editor adopts it" do
     render inline: <<~ERB
       <%= rich_textarea_tag :body, "<p>Hello</p>", prerender: true %>


### PR DESCRIPTION
## Problem

Loading a page whose editor is sized by its **content** shows a layout shift as the editor mounts: the field paints at ~0px and jumps to its content height, shoving everything below it down the page.

This is the same symptom #1201 fixed for the default editor, in the one configuration that fix cannot reach.

## Why #1201 doesn't cover this

#1201 reserves the mounted height on the host before upgrade:

```css
:where(lexxy-editor:not(:defined)) {
  min-block-size: calc(var(--lexxy-toolbar-height) + var(--lexxy-editor-rows) + 2 * var(--lexxy-editor-padding));
}
```

That works whenever `--lexxy-editor-rows` is a length — including a per-instance override like the sandbox's `30lh`. It cannot work for an editor that is sized by its content, for two independent reasons:

1. **The reservation evaluates to nothing.** A content-sized field sets `--lexxy-editor-rows: auto`, and `calc(30px + auto + 0px)` is not a valid length, so the whole declaration is dropped and `min-block-size` stays `0`. Verified in Chrome 150: with `--lexxy-editor-rows: auto` the computed `min-block-size` is `0px`, where `8lh` gives `246px`.

2. **A row count is the wrong height anyway.** These editors stand in for published copy in the page around them, so the height to reserve is *this record's* rendered height — 106px for one body, 35px for another — not N rows. Reserving a fixed number of rows would replace a shift down with a shift up.

Setting `--lexxy-editor-rows: 0` (as an earlier revision of this PR suggested) does not rescue it either: the reservation then collapses to the toolbar height, which for these editors is out of flow.

Measured on a real app, with the custom-element registration deferred so the pre-upgrade window is observable:

| | Pre-upgrade host height | Mounted height |
|---|---|---|
| Default editor (`--lexxy-editor-rows: 8lh`) | reserved by #1201, matches | matches |
| Content-sized editor (`--lexxy-editor-rows: auto`) | **0px** | 35px / 106px, per record |

## Fix

Opt-in prerendering, so the reserved height is the record's own:

```erb
<%= form.rich_text_area :body, prerender: true %>
```

Rails renders the editor's current value as a static content element inside `<lexxy-editor>`:

```html
<lexxy-editor value="&lt;p&gt;...&lt;/p&gt;">
  <div class="lexxy-editor__content"><p>...</p></div>
</lexxy-editor>
```

It also ships the toolbar itself, empty, ahead of that content element, and fills it in on connect rather than building a second one — so the reservation covers the whole mounted height, not just the body. That has to be a real `<lexxy-toolbar>` rather than a neutral spacer: whether a toolbar occupies space at all is the host's CSS to decide, and an inline editor floats it out of flow, where a spacer would reserve height nothing fills and shift the page *up*. No toolbar is emitted when the editor will not prepend one (rich text off, or a `toolbar` naming an element by id).

When Lexxy connects it **adopts** that existing `.lexxy-editor__content` instead of appending an empty one. Lexical still parses `value` as the source of truth and reconciles its state into the adopted node; the prerendered child only gives the browser the right layout before JavaScript finishes.

Off by default. Without `prerender: true`, and when callers pass an explicit block, the markup path is unchanged. It composes with #1201 rather than competing: #1201 reserves *a* height for editors that have one to reserve, this reserves *this field's* height for editors that do not.

## Where the empty-editor window shows up

Cold load and reload, back/forward without a Turbo cache hit, server re-rendered forms, Turbo stream refreshes that morph the editor back toward server HTML, and any slow connection or heavy page — where the window lasts longest and the shift is most visible.

## Reproduction

A browser fixture in this branch demonstrates the case:

```sh
VITE_PORT=5173 npx vite --config test/browser/vite.config.js
```

Then open `http://localhost:5173/prerender.html?delay=1500`. Two editors with identical content and content below them: the left has no prerendered child and the content below it jumps when delayed initialization runs; the right is prerendered and the content below it starts and stays put. The browser test pins this by measuring the following content before and after Lexxy connects.

https://github.com/user-attachments/assets/a90aa5e8-31d2-4a39-8c4c-f431beb02825

## Design notes

- `value` remains the source of truth. Adoption reuses the DOM node; it does not trust the child markup as state.
- The prerendered HTML is sanitized server-side with Action Text's display sanitizer, because it enters the DOM at first paint.
- The server-rendered element is static markup only — no `contenteditable`, `role` or ARIA — until Lexxy adopts it, so the page does not advertise an editor that cannot yet accept input.
- Both Rails integration paths are covered: the Rails 8.2 editor adapter and the older tag-helper fallback, sharing `Lexxy::Prerender`.

## Known limitations

- Attachments/images still use the editable representation before mount, so image-heavy documents may retain some shift until a follow-up prerenders display-height previews.
- Empty-editor placeholder text is not shown before mount, though a blank value still prerenders the baseline editor body.
- The content ships twice, in `value` and as a child element — only when opted in.

## Status

**Not blocking us.** We ship the same idea app-side: the published copy is rendered as a static placeholder stacked in the same CSS grid cell as the editor, and CSS drops it once Lexical's mounted root appears. That works and is tested, so this PR is offered as the cleaner in-library version — adoption instead of a stacked placeholder, no `:has()` handoff rule for consumers to get right — not as something we need merged.

One gotcha worth recording either way, in case it informs the design: the handoff must key on Lexical's mounted root (`[data-lexical-editor]`), not on Lexxy's own `connected` attribute. `connected` is set at the end of `connectedCallback` but the root mounts a frame later, so handing off on `connected` collapses the field for a frame — the same layout shift, smaller. Adoption avoids the question entirely, which is one of the reasons this belongs in the library.

## Testing

Rebased onto `main` at 41f776ee (0.9.28 + #1201), conflict-free, and re-verified there:

- `yarn lint` — clean.
- `yarn test` — 128 unit tests, 19 files, all passing.
- Full Playwright chromium suite — 625 collected, **622 passed**, 2 flaky on retry and 1 conditional skip; the flaky ones vary run to run (`paste/plain_text_paths`, `tables/toolbar`, `editor/leak`) and are pre-existing and unrelated.
- `test/browser/tests/editor/prerender_adoption.test.js` — 5 passing: the reproduction, stability with the toolbar floated *and* in normal flow, and that the prerendered toolbar is filled rather than duplicated.
- `test/helpers/prerender_test.rb` — 6 runs, 19 assertions: `rich_textarea_tag` output, sanitization, blank values, and block precedence.

Worth noting for review: **the reproduction still reproduces on top of #1201.** The fixture's control editor is asserted to move by more than 60px as Lexxy mounts, and that assertion passes against current `main` — because with `--lexxy-editor-rows: 0` the new reservation collapses to the toolbar height, which in this layout is out of flow. So the two changes do not overlap in practice.
