### PR TITLE
Strip foreign <style> blocks from pasted content (Excel dark-mode table text)

### DIFF
--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -4,11 +4,24 @@ export default class PastedContentFormatter {
   }
 
   format() {
+    this.#stripStyleElements()
     this.#unwrapPlaceholderAnchors()
     this.#stripTableCellColorStyles()
     this.#nestStrayListChildren()
     this.#stripStrayListChildren()
     return this.doc
+  }
+
+  // Spreadsheets (e.g. Excel) copy a <style> block whose rules (td { color:
+  // black }, .xlNN { ... }) cascade onto the imported text. That color rides
+  // in through the cascade rather than an inline style, so it slips past both
+  // the cell-level stripping below and the paste style canonicalizer, leaving
+  // pasted tables with foreign text colors that don't adapt to the theme. Drop
+  // foreign style sheets so nothing cascades into imported content.
+  #stripStyleElements() {
+    for (const style of this.doc.querySelectorAll("style")) {
+      style.remove()
+    }
   }
 
   // Anchors with non-meaningful hrefs (e.g. "#", "") appear in content copied

--- a/test/browser/tests/paste/table_cell_styles.test.js
+++ b/test/browser/tests/paste/table_cell_styles.test.js
@@ -178,6 +178,77 @@ test.describe("Paste — Table cell color styles", () => {
     })
   })
 
+  // Excel doesn't color cells inline: it ships a <style> block whose rules
+  // (td { color: black }, .xlNN { color: ... }) cascade onto the cells by
+  // element and class. That cascaded color rides past the inline-style
+  // stripping and the paste canonicalizer, so pasted table text kept a
+  // hardcoded color that didn't adapt to the theme. Stripping the foreign
+  // <style> block fixes it. The markup below is a real Excel clipboard paste.
+  test("strips cascaded text color from a real Excel paste", async ({
+    editor,
+  }) => {
+    const excelHtml = `<html xmlns:o="urn:schemas-microsoft-com:office:office"
+xmlns:x="urn:schemas-microsoft-com:office:excel"
+xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=ProgId content=Excel.Sheet>
+<meta name=Generator content="Microsoft Excel 15">
+<link id=Main-File rel=Main-File href="file:///C:/Users/Gabriel/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
+<link rel=File-List href="file:///C:/Users/Gabriel/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
+<style>
+<!--table
+	{mso-displayed-decimal-separator:"\\.";
+	mso-displayed-thousand-separator:"\\,";}
+td
+	{padding-top:1px;
+	padding-right:1px;
+	padding-left:1px;
+	mso-ignore:padding;
+	color:black;
+	font-size:11.0pt;
+	font-weight:400;
+	font-family:Calibri, sans-serif;
+	text-align:general;
+	vertical-align:bottom;
+	border:none;
+	white-space:nowrap;}
+.xl63
+	{color:#1F4E78;}
+.xl64
+	{color:red;}
+-->
+</style>
+</head>
+<body link="#0563C1" vlink="#954F72">
+<table border=0 cellpadding=0 cellspacing=0 width=128 style='border-collapse:collapse;width:96pt'>
+ <col width=64 span=2 style='width:48pt'>
+ <tr height=20 style='height:15.0pt'>
+<!--StartFragment-->
+  <td height=20 class=xl63 width=64 style='height:15.0pt;width:48pt'>BLUE</td>
+  <td class=xl64 width=64 style='width:48pt'>RED</td>
+<!--EndFragment-->
+ </tr>
+</table>
+</body>
+</html>`
+
+    await editor.paste("BLUE\tRED", { html: excelHtml })
+
+    await assertEditorContent(editor, async (content) => {
+      const cells = content.locator("table td")
+      await expect(cells).toHaveCount(2)
+
+      for (const cell of await cells.all()) {
+        const color = await cell.evaluate((el) => el.style.color)
+        expect(color).toBe("")
+      }
+
+      const coloredText = content.locator('table td [style*="color"]')
+      await expect(coloredText).toHaveCount(0)
+    })
+  })
+
   // Shading survives as TableCellNode state, so it reappears when previously
   // stored content is loaded back into the editor — a path the paste-time
   // formatter never sees. Normalize it away on load too.


### PR DESCRIPTION
## Card

[[BC5] Excel table text doesn't adapt to Basecamp's dark mode when pasted](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10045653710)

## Problem

Text pasted from an Excel table into Basecamp in dark mode stays its original color (e.g. black) and unreadable. Earlier rounds on this card stripped cell **background** shading (and inline text colors) on paste, but Gabriel's production testing showed the **text color** still survived — the original report.

The color never arrives as an inline style, which is why the earlier stripping missed it. Excel copies a `<style>` block whose rules cascade onto the cells by element and class. From the real clipboard paste Gabriel captured on the card:

```html
<style>
td   { ...; color:black; ... }
.xl63{ color:#1F4E78; }
.xl64{ color:red; }
</style>
...
<td class=xl63>BLUE</td>
<td class=xl64>RED</td>
```

Lexical resolves that cascade onto the imported text. Because the color is cascaded rather than inline, it slips past both `PastedContentFormatter`'s cell-level color stripping **and** the paste style canonicalizer (which only canonicalizes text nodes flagged as "pasted" — a flag set on the inline `<span>`/`<mark>` import path, not this one). The pasted table keeps a foreign text color that doesn't adapt to the theme, e.g. `<td><p><mark style="color: black;">…</mark></p></td>`.

Reproduced end-to-end through the real paste pipeline: with Excel's `<style>` block the color survives; remove the `<style>` block and it's gone.

## Fix

Drop foreign `<style>` elements from the pasted document before import, in `PastedContentFormatter`, so nothing cascades into the imported content. A pasted style sheet is never something the editor should honor — styling is managed through the editor's own model and palette — so this also closes the door on other paste sources leaking colors the same way.

## Tests

The existing table-cell tests only exercised **inline** styles (which the canonicalizer already caught), which is why they stayed green while production was broken. Added a regression test built from the **real Excel clipboard paste** on the card (BLUE/RED cells, colors carried by `td`/`.xlNN` rules in a `<style>` block) and assert no color survives on the table text. Verified it fails without the fix (both cells keep their color) and passes with it. Full paste suite (120 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)