### PR TITLE
Restructure configuration docs into three clear ways to configure

### DIFF
--- a/home/docs/configuration.md
+++ b/home/docs/configuration.md
@@ -36,6 +36,8 @@ Lexxy.configure({
 
 ### Presets
 
+Presets let you keep different editor setups organized. For example, you may want a simpler setup without rich text for a command line, alongside the full editor elsewhere.
+
 Define named presets, which extend the `default` preset, and opt in to them per editor with the `preset` attribute:
 
 ```js

--- a/home/docs/configuration.md
+++ b/home/docs/configuration.md
@@ -7,36 +7,55 @@ has_children: true
 
 # Configuration
 
-You can configure editors in two ways: using `Lexxy.configure` and element attributes.
+You configure editors with `Lexxy.configure` and with attributes on the editor element. Options resolve from least to most specific: the **default** options apply to every editor, a named **preset** extends the default, and **HTML attributes** override both on an individual editor.
 
 ```js
 import * as Lexxy from "lexxy"
+```
 
-// overriding default options will affect all editors
+{: .important }
+Call `Lexxy.configure` immediately after your import statement. Editor elements are registered after the import's call stack completes, so configuration must happen synchronously to take effect.
+
+## Ways to configure
+
+### Default options
+
+Override the `default` preset to change the behavior of every editor in your app:
+
+```js
 Lexxy.configure({
   default: {
     toolbar: false
   }
 })
-<lexxy-editor></lexxy-editor>
+```
 
-// you can also create new presets, which will extend the default preset
+```html
+<lexxy-editor></lexxy-editor>
+```
+
+### Presets
+
+Define named presets, which extend the `default` preset, and opt in to them per editor with the `preset` attribute:
+
+```js
 Lexxy.configure({
   simple: {
     richText: false
   }
 })
+```
+
+```html
 <lexxy-editor preset="simple"></lexxy-editor>
+```
 
-// you can override specific options with attributes on editor elements
+### HTML attributes
+
+Override individual options on a single editor with element attributes. These take precedence over both the preset and the default:
+
+```html
 <lexxy-editor preset="simple" rich-text="true"></lexxy-editor>
-
-// finally, some options can only be configured globally
-Lexxy.configure({
-  global: {
-    attachmentTagName: "bc-attachment"
-  }
-})
 ```
 
 ## Editor options
@@ -78,5 +97,12 @@ Global options apply to all editors in your app and are configured using `Lexxy.
 - `attachmentContentTypeNamespace`: The default content_type namespace for prompts. The default is `actiontext` which will result in `application/vnd.actiontext.[type]`.
 - `authenticatedUploads`: will set `withCredentials: true` for ActiveStorage upload requests if you are using authenticated upload contollers. Be sure to set cookie domain and server CORS/CSRF options accordingly.
 
-{: .important }
-When overriding configuration, call `Lexxy.configure` immediately after your import statement. Editor elements are registered after the import's call stack completes, so configuration must happen synchronously to take effect.
+Some options, like `attachmentTagName`, can only be set globally:
+
+```js
+Lexxy.configure({
+  global: {
+    attachmentTagName: "bc-attachment"
+  }
+})
+```

--- a/home/docs/configuration.md
+++ b/home/docs/configuration.md
@@ -36,7 +36,7 @@ Lexxy.configure({
 
 ### Presets
 
-Presets let you keep different editor setups organized. For example, you may want a simpler setup without rich text for a command line, alongside the full editor elsewhere.
+Presets let you keep alternative editor setups organized. For example, you may want a simpler setup without rich text for a command line, alongside the full editor elsewhere.
 
 Define named presets, which extend the `default` preset, and opt in to them per editor with the `preset` attribute:
 


### PR DESCRIPTION
The [configuration docs](https://lexxy.dev/docs/configuration.html) opened with a single code block that mixed four different concerns — overriding defaults, defining presets, setting element attributes, and global options — making it hard to see the distinct configuration paths at a glance.

This splits that example into a new **Ways to configure** section with three focused subsections:

- **Default options** — override the `default` preset for every editor
- **Presets** — define named presets and opt in per editor with `preset`
- **HTML attributes** — override individual options on a single editor

Each subsection pairs the relevant `Lexxy.configure` call with the matching `<lexxy-editor>` markup, and the intro now states the precedence order (default → preset → attributes) explicitly.

Also:
- Moved the "call `Lexxy.configure` immediately after import" callout up to the top where it's most relevant, removing the duplicate at the bottom.
- Moved the global-only example (`attachmentTagName`) into the existing **Global options** section where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)