### PR TITLE
Collaboration support - tolerate no-argument construction of attachment nodes

### DIFF
--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -84,7 +84,7 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     return Lexxy.global.get("attachmentTagName")
   }
 
-  constructor({ tagName, sgid, src, previewSrc, previewable, previewStatusUrl, pendingPreview, altText, caption, contentType, fileName, fileSize, width, height, uploadError }, key) {
+  constructor({ tagName, sgid, src, previewSrc, previewable, previewStatusUrl, pendingPreview, altText, caption, contentType, fileName, fileSize, width, height, uploadError } = {}, key) {
     super(key)
 
     this.tagName = tagName || ActionTextAttachmentNode.TAG_NAME

--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -22,7 +22,7 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
     return null
   }
 
-  constructor(node, key) {
+  constructor(node = {}, key) {
     const { file, uploadUrl, blobUrlTemplate, progress, width, height, uploadError, fileName, contentType } = node
     super({ ...node, contentType: file?.type ?? contentType }, key)
     this.file = file ?? null
@@ -116,9 +116,12 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
     const figcaption = createElement("figcaption", { className: "attachment__caption" })
 
     const nameSpan = createElement("span", { className: "attachment__name", textContent: this.caption || this.fileName || "" })
-    const sizeSpan = createElement("span", { className: "attachment__size", textContent: bytesToHumanSize(this.file?.size) })
     figcaption.appendChild(nameSpan)
-    figcaption.appendChild(sizeSpan)
+
+    if (this.file) {
+      const sizeSpan = createElement("span", { className: "attachment__size", textContent: bytesToHumanSize(this.file.size) })
+      figcaption.appendChild(sizeSpan)
+    }
 
     return figcaption
   }

--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -43,9 +43,10 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
     // node is reloaded from saved state such as from history.
     this.#startUploadIfNeeded()
 
-    // Bridge-managed uploads (uploadUrl is null) don't have file data to show
-    // an image preview, so always show the file icon during upload.
-    const canPreviewFile = this.isPreviewableAttachment && this.uploadUrl != null
+    // Bridge-managed uploads (uploadUrl is null) and restored or remote
+    // instances (no local File) don't have file data to show an image
+    // preview, so always show the file icon during upload.
+    const canPreviewFile = this.isPreviewableAttachment && this.uploadUrl != null && this.file != null
     const figure = this.createAttachmentFigure(canPreviewFile)
 
     if (canPreviewFile) {
@@ -143,6 +144,7 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
   async #startUploadIfNeeded() {
     if (this.#uploadStarted) return
     if (!this.uploadUrl) return // Bridge-managed upload — skip DirectUpload
+    if (!this.file) return // Restored or remote instance — no local File to upload
 
     this.#setUploadStarted()
 

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -60,7 +60,7 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
     return Lexxy.global.get("attachmentTagName")
   }
 
-  constructor({ tagName, sgid, contentType, innerHtml, plainText }, key) {
+  constructor({ tagName, sgid, contentType, innerHtml, plainText } = {}, key) {
     super(key)
 
     const contentTypeNamespace = Lexxy.global.get("attachmentContentTypeNamespace")

--- a/test/javascript/unit/editor/attachments/node_construction.test.js
+++ b/test/javascript/unit/editor/attachments/node_construction.test.js
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { createTestEditor, destroyTestEditor } from "../../helpers/editor_helper"
+import { ActionTextAttachmentNode } from "src/nodes/action_text_attachment_node"
+import { ActionTextAttachmentUploadNode } from "src/nodes/action_text_attachment_upload_node"
+import { CustomActionTextAttachmentNode } from "src/nodes/custom_action_text_attachment_node"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+function constructWithNoArguments(editorElement, nodeClass) {
+  editorElement.editor.update(() => {
+    new nodeClass() // eslint-disable-line no-new
+  }, { discrete: true })
+}
+
+// @lexical/yjs constructs registered node classes with no arguments (at bind
+// time and when materializing remote updates), so these must not throw.
+describe("attachment node construction", () => {
+  test("constructs every attachment node with no arguments", async () => {
+    editorElement = await createTestEditor()
+
+    expect(() => constructWithNoArguments(editorElement, ActionTextAttachmentNode)).not.toThrow()
+    expect(() => constructWithNoArguments(editorElement, ActionTextAttachmentUploadNode)).not.toThrow()
+    expect(() => constructWithNoArguments(editorElement, CustomActionTextAttachmentNode)).not.toThrow()
+  })
+})

--- a/test/javascript/unit/editor/attachments/upload_node_without_file.test.js
+++ b/test/javascript/unit/editor/attachments/upload_node_without_file.test.js
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { $getNodeByKey, $getRoot } from "lexical"
+import { createTestEditor, destroyTestEditor, tick } from "../../helpers/editor_helper"
+import { ActionTextAttachmentUploadNode } from "src/nodes/action_text_attachment_upload_node"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+function insertUploadNodeWithoutFile(editorElement) {
+  let key
+  editorElement.editor.update(() => {
+    const node = new ActionTextAttachmentUploadNode({ uploadUrl: "/direct_uploads", fileName: "photo.png", contentType: "image/png" })
+    $getRoot().append(node)
+    key = node.getKey()
+  }, { discrete: true })
+  return key
+}
+
+// importJSON and collaboration can materialize an upload node without its
+// local File; rendering one must not start an upload or read the missing file.
+describe("upload node without a file", () => {
+  test("renders the file icon and doesn't start an upload", async () => {
+    editorElement = await createTestEditor()
+
+    const key = insertUploadNodeWithoutFile(editorElement)
+    await tick()
+
+    expect(editorElement.querySelector("figure .attachment__icon")).not.toBeNull()
+    expect(editorElement.querySelector("figure img")).toBeNull()
+    expect(editorElement.editor.getEditorState().read(() => $getNodeByKey(key).progress)).toBeNull()
+  })
+})


### PR DESCRIPTION
Adding collaborative editing to a Lexxy editor breaks it ([lexxy-realtime](https://github.com/jpcamara/lexxy-realtime) fixes it today by monkey patching). Wire up Lexical's own collaboration binding (`@lexical/yjs`) to a stock editor and it throws before collaboration starts:

```
Cannot destructure property 'tagName' of 'undefined'
```

The document breaks on attachment components. Patch around the bind and a second failure appears: attachments created by one collaborator never render for anyone else — every remote update carrying one logs the same error, and the node is silently skipped while the peer's document data has it.

## Where it comes from

`@lexical/yjs` constructs registered node classes with no arguments in two situations. At bind time, `createBinding` snapshots every registered class's default property values ([Utils.ts](https://github.com/facebook/lexical/blob/main/packages/lexical-yjs/src/Utils.ts#L151)):

```js
editor._nodes.forEach(nodeInfo => {
  const node = new nodeInfo.klass();
  ...
});
```

And whenever a node materializes from a remote update, `$createOrUpdateNodeFromYElement`, `$createTextNodesFromYText`, and the collab node initializer all call `new nodeInfo.klass()`.

The three attachment node constructors destructure their first parameter:

```js
constructor({ tagName, sgid, contentType, innerHtml, plainText }, key) {
```

so a bare `new klass()` throws. `AttachmentsExtension` is one of the base extensions, which is why every editor is affected: the classes are always registered, and the bind-time snapshot constructs them whether or not the document has attachments.

Lexical's own nodes default every constructor parameter, which is what makes them safe to construct bare:

```js
constructor(text = '', key)                      // TextNode
constructor(tag = 'h1', key)                     // HeadingNode
constructor(listType = 'number', start = 1, key) // ListNode
constructor(url = '', attributes = {}, key)      // LinkNode
```

The attachment nodes are the only registered classes in a Lexxy editor that don't.

## The fix

Default the destructured parameter to `{}` in the three attachment nodes. Based on the lexxy-realtime monkey patching, a bare construction produces a valid blank node instead of throwing.

One follow-on: a bare instance has no `File`, and the upload caption formats `this.file?.size` into "NaN undefined". The size span now renders only when a file is present, matching the `fileSize` guard `ActionTextAttachmentNode` already uses.

`yarn vitest run` passes (120 tests). Verified in a real two-browser collaborative session on `lexical`/`@lexical/yjs` 0.44: the binding comes up without any runtime patching, and attachments created on one side render on the other.