### PR TITLE
Move placeCaretInside onto the editor handle

### DIFF
--- a/test/browser/helpers/editor_handle.js
+++ b/test/browser/helpers/editor_handle.js
@@ -88,6 +88,29 @@ export class EditorHandle {
     await this.flush()
   }
 
+  // Collapses the caret inside the first text node containing `text`, `offset`
+  // characters past its start.
+  async placeCaretInside(text, offset) {
+    await this.#ensureFirstInteraction()
+    await this.content.evaluate((el, { text, offset }) => {
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+      let node
+      while ((node = walker.nextNode())) {
+        const index = node.nodeValue.indexOf(text)
+        if (index !== -1) {
+          const range = document.createRange()
+          range.setStart(node, index + offset)
+          range.collapse(true)
+          const sel = window.getSelection()
+          sel.removeAllRanges()
+          sel.addRange(range)
+          break
+        }
+      }
+    }, { text, offset })
+    await this.flush()
+  }
+
   // Selects the first block container (a quote) at an element point — a selection
   // state mouse/keyboard can't produce, since Lexical normalizes DOM selections to leaves.
   async placeCaretOnQuoteElement() {

--- a/test/browser/tests/formatting/toggle_code_block.test.js
+++ b/test/browser/tests/formatting/toggle_code_block.test.js
@@ -1,27 +1,6 @@
 import { test } from "../../test_helper.js"
 import { assertEditorHtml } from "../../helpers/assertions.js"
 
-async function placeCaretInside(editor, text, offset) {
-  await editor.click()
-  await editor.content.evaluate((el, { text, offset }) => {
-    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
-    let node
-    while ((node = walker.nextNode())) {
-      const index = node.nodeValue.indexOf(text)
-      if (index !== -1) {
-        const range = document.createRange()
-        range.setStart(node, index + offset)
-        range.collapse(true)
-        const selection = window.getSelection()
-        selection.removeAllRanges()
-        selection.addRange(range)
-        break
-      }
-    }
-  }, { text, offset })
-  await editor.flush()
-}
-
 test.describe("Toggle code block", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/")
@@ -40,7 +19,7 @@ test.describe("Toggle code block", () => {
 
   test("converts a nested list with the caret inside it without losing the selection", async ({ editor }) => {
     await editor.setValue("<ul><li>item one<ul><li>nested</li></ul></li></ul>")
-    await placeCaretInside(editor, "item one", 2)
+    await editor.placeCaretInside("item one", 2)
 
     await editor.clickToolbarButton("insertCodeBlock")
 


### PR DESCRIPTION
Follow-up to #1198: moves the `placeCaretInside` caret-positioning helper from a local function in `toggle_code_block.test.js` onto the `EditorHandle` as a method, per review feedback on that PR ("Moving this to the handle too separately.").

Since #1198, `clickToolbarButton` lives on the editor handle and acts on the real caret/selection. Caret placement is the other half of that interaction, so it belongs on the handle too. Tests now read `editor.placeCaretInside(text, offset)`, consistent with the handle's existing `select`, `selectAll`, and `placeCaretOnQuoteElement`.

- Added `placeCaretInside(text, offset)` to `EditorHandle`. The handle already knows its editor, so no editor argument is needed. It uses `#ensureFirstInteraction()` to guarantee focus, matching `select`/`selectAll`, rather than the bare `click()` the old helper used.
- Removed the redundant local helper from `toggle_code_block.test.js`, the only test that defined or used it.

Green locally: eslint, vitest (118), and the formatting browser suite on chromium + firefox (`toggle_code_block` and the full formatting directory).
