### PR TITLE
Prevent layout shift as the editor mounts

### DIFF
--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -10,6 +10,9 @@
   --lexxy-toolbar-gap: 2px;
   --lexxy-toolbar-spacing: 0.5ch;
 
+  /* Button row + 2px vertical padding + 1px bottom border. */
+  --lexxy-toolbar-height: calc(var(--lexxy-toolbar-button-size) + 4px + 1px);
+
   border: 1px solid var(--lexxy-color-ink-lighter);
   border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
   background-color: var(--lexxy-color-canvas);
@@ -406,6 +409,14 @@
       }
     }
   }
+}
+
+/* Reserve the mounted height before JS upgrades the element, so mounting the
+   toolbar and content doesn't shift surrounding layout. Scoped to :not(:defined)
+   so it only applies during the pre-upgrade window and never competes with the
+   mounted editor's own sizing (or a consumer's content-level override). */
+:where(lexxy-editor:not(:defined)) {
+  min-block-size: calc(var(--lexxy-toolbar-height) + var(--lexxy-editor-rows) + 2 * var(--lexxy-editor-padding));
 }
 
 /* Placeholder */

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -9,9 +9,9 @@
   }
   --lexxy-toolbar-gap: 2px;
   --lexxy-toolbar-spacing: 0.5ch;
-
-  /* Button row + 2px vertical padding + 1px bottom border. */
-  --lexxy-toolbar-height: calc(var(--lexxy-toolbar-button-size) + 4px + 1px);
+  --lexxy-toolbar-padding: 2px;
+  --lexxy-toolbar-border-size: 1px;
+  --lexxy-toolbar-height: calc(var(--lexxy-toolbar-button-size) + 2 * var(--lexxy-toolbar-padding) + var(--lexxy-toolbar-border-size));
 
   border: 1px solid var(--lexxy-color-ink-lighter);
   border-radius: calc(var(--lexxy-radius) + var(--lexxy-toolbar-gap));
@@ -411,10 +411,7 @@
   }
 }
 
-/* Reserve the mounted height before JS upgrades the element, so mounting the
-   toolbar and content doesn't shift surrounding layout. Scoped to :not(:defined)
-   so it only applies during the pre-upgrade window and never competes with the
-   mounted editor's own sizing (or a consumer's content-level override). */
+/* Reserve the mounted height before upgrade so it doesn't shift layout on mount. */
 :where(lexxy-editor:not(:defined)) {
   min-block-size: calc(var(--lexxy-toolbar-height) + var(--lexxy-editor-rows) + 2 * var(--lexxy-editor-padding));
 }
@@ -472,13 +469,13 @@
 :where(lexxy-toolbar) {
   --lexxy-toolbar-icon-size: 1.125em;
 
-  border-block-end: 1px solid var(--lexxy-color-ink-lighter);
+  border-block-end: var(--lexxy-toolbar-border-size) solid var(--lexxy-color-ink-lighter);
   color: currentColor;
   display: flex;
   font-size: inherit;
   gap: var(--lexxy-toolbar-gap);
   max-inline-size: 100%;
-  padding: 2px;
+  padding: var(--lexxy-toolbar-padding);
   position: relative;
 
   @container (width < 300px) {


### PR DESCRIPTION
Loading lexxy.dev shows a noticeable layout shift as the editor and toolbar snap in. Chrome DevTools measures **CLS 0.15 (lab) / 0.16 (field)** on the home page, driven by a single 0.147 shift when the editor mounts.

## Cause

Before JavaScript upgrades `<lexxy-editor>`, the host has `min-block-size: 0` and its only child is the (hidden) `<lexxy-prompt>`, so it collapses to its 1px borders (~2px tall). When JS mounts the toolbar and the `.lexxy-editor__content` contenteditable, the element jumps to its full height and shoves the content below it down.

The existing `min-block-size: var(--lexxy-editor-rows)` lives on `.lexxy-editor__content`, which doesn't exist until after JS runs — so it can't reserve space during the pre-upgrade window.

## Fix

Reserve the mounted height on the host up front, scoped to `:not(:defined)` so it only applies during the pre-upgrade window:

```css
:where(lexxy-editor:not(:defined)) {
  min-block-size: calc(var(--lexxy-toolbar-height) + var(--lexxy-editor-rows) + 2 * var(--lexxy-editor-padding));
}
```

Once the custom element is defined, the reservation releases and the mounted editor's own sizing takes over — so it never competes with the mounted layout or with a consumer that sizes the editor via a content-level `min-block-size` override.

It's derived from the same variables the mounted editor uses, so per-instance overrides reserve the right amount automatically — the sandbox's taller editor (`--lexxy-editor-rows: 30lh`) reserves proportionally more space with no extra CSS. Both the home and sandbox editors load this shared stylesheet, so the fix covers both.

## Measurement

| | Pre-JS host height | Mounted height | CLS |
|---|---|---|---|
| Before | ~2px (borders only) | 226px | 0.15 / 0.16 (lab/field, lexxy.dev) |
| After | 226px (reserved) | 226px | **0.00** |

Verified locally by serving the built stylesheet + editor bundle: with the fix the un-upgraded host already reserves 226px, exactly matching the 226px mounted height, and a `layout-shift` PerformanceObserver records zero shifts through mount. The sandbox's 30lh editor reserves 666px pre-JS, matching its mounted height.

`yarn lint`, `yarn test` (120 tests), and the full Playwright browser suite (`--project=firefox`, 566 tests) pass.
