### PR TITLE
Guard upload-request tracking against editor teardown

### DIFF
--- a/src/nodes/action_text_attachment_upload_node.js
+++ b/src/nodes/action_text_attachment_upload_node.js
@@ -184,11 +184,11 @@ export class ActionTextAttachmentUploadNode extends ActionTextAttachmentNode {
   }
 
   #forgetUploadRequest() {
-    this.#editorElement.uploadRequests.forget(this.getKey())
+    this.#editorElement?.uploadRequests.forget(this.getKey())
   }
 
   #rememberUploadRequest(request) {
-    this.#editorElement.uploadRequests.track(this.getKey(), request)
+    this.#editorElement?.uploadRequests.track(this.getKey(), request)
   }
 
   get #editorElement() {

--- a/test/browser/tests/attachments/upload_survives_teardown.test.js
+++ b/test/browser/tests/attachments/upload_survives_teardown.test.js
@@ -1,0 +1,52 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+// An in-flight direct upload can outlive the editor: teardown runs on
+// disconnect and on every turbo:before-cache, but the upload's ActiveStorage
+// callbacks still fire afterwards — #forgetUploadRequest when the store PUT
+// completes, #rememberUploadRequest when blob creation resolves — and both
+// dereference #editorElement on a torn-down editor.
+// Sentry: BC3-JS-N8HN, BC3-JS-N8HP.
+test.describe("Upload outliving editor teardown", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("file upload completing after teardown does not throw (forget path)", async ({ page, editor }) => {
+    await mockActiveStorageUploads(page, { uploadDelayMs: 1500 })
+
+    const pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error))
+
+    const diskUploadStarted = page.waitForRequest((request) =>
+      request.url().includes("/rails/active_storage/disk/") && request.method() === "PUT",
+    )
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await diskUploadStarted
+
+    await page.evaluate(() => document.querySelector("lexxy-editor").remove())
+
+    await page.waitForTimeout(2500)
+    expect(pageErrors.map(String)).toEqual([])
+  })
+
+  test("blob creation resolving after teardown does not throw (remember path)", async ({ page, editor }) => {
+    const calls = await mockActiveStorageUploads(page, { delayDirectUploadResponse: true })
+
+    const pageErrors = []
+    page.on("pageerror", (error) => pageErrors.push(error))
+
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await expect.poll(() => calls.blobCreations.length).toBeGreaterThan(0)
+
+    await page.evaluate(() => document.querySelector("lexxy-editor").remove())
+    await calls.releaseDirectUploadResponses()
+
+    await page.waitForTimeout(2000)
+    expect(pageErrors.map(String)).toEqual([])
+  })
+})

--- a/test/browser/tests/attachments/upload_survives_teardown.test.js
+++ b/test/browser/tests/attachments/upload_survives_teardown.test.js
@@ -15,22 +15,29 @@ test.describe("Upload outliving editor teardown", () => {
     await page.waitForSelector("lexxy-toolbar[connected]")
   })
 
+  const isDiskUpload = (request) =>
+    request.url().includes("/rails/active_storage/disk/") && request.method() === "PUT"
+
+  // The upload callbacks run in XHR event handlers after the network event, so
+  // give the page one macrotask turn before asserting no errors surfaced.
+  const settle = (page) => page.evaluate(() => new Promise((resolve) => setTimeout(resolve, 0)))
+
   test("file upload completing after teardown does not throw (forget path)", async ({ page, editor }) => {
-    await mockActiveStorageUploads(page, { uploadDelayMs: 1500 })
+    await mockActiveStorageUploads(page, { uploadDelayMs: 1000 })
 
     const pageErrors = []
     page.on("pageerror", (error) => pageErrors.push(error))
 
-    const diskUploadStarted = page.waitForRequest((request) =>
-      request.url().includes("/rails/active_storage/disk/") && request.method() === "PUT",
-    )
+    const diskUploadStarted = page.waitForRequest(isDiskUpload)
 
     await editor.uploadFile("test/fixtures/files/example.png")
     await diskUploadStarted
 
+    const diskUploadFinished = page.waitForEvent("requestfinished", isDiskUpload)
     await page.evaluate(() => document.querySelector("lexxy-editor").remove())
+    await diskUploadFinished
 
-    await page.waitForTimeout(2500)
+    await settle(page)
     expect(pageErrors.map(String)).toEqual([])
   })
 
@@ -44,9 +51,12 @@ test.describe("Upload outliving editor teardown", () => {
     await expect.poll(() => calls.blobCreations.length).toBeGreaterThan(0)
 
     await page.evaluate(() => document.querySelector("lexxy-editor").remove())
-    await calls.releaseDirectUploadResponses()
 
-    await page.waitForTimeout(2000)
+    const diskUploadFinished = page.waitForEvent("requestfinished", isDiskUpload)
+    await calls.releaseDirectUploadResponses()
+    await diskUploadFinished
+
+    await settle(page)
     expect(pageErrors.map(String)).toEqual([])
   })
 })


### PR DESCRIPTION
Fixes the highest-volume BC5 JS error: Sentry [BC3-JS-N8HN](https://basecamp.sentry.io/issues/7567796249/) (13.9k events / 9.8k users) and [BC3-JS-N8HP](https://basecamp.sentry.io/issues/7567802467/) (2.4k / 2.0k), both introduced by #1134 via the lexxy 0.9.19 bump in BC5 on Jun 22 (full causality analysis in [this comment](https://github.com/basecamp/lexxy/pull/1134#issuecomment-4994703869)).

### Mechanism

An in-flight direct upload outlives the editor. `#reset()` runs on `disconnectedCallback` **and on every `turbo:before-cache`** — any Turbo navigation while an upload is in flight. Teardown nulls the Lexical root, so `get #editorElement` returns `undefined` when the ActiveStorage callbacks land afterwards:

- store PUT completes → `create` callback → `#forgetUploadRequest()` → TypeError (BC3-JS-N8HN)
- blob-create POST resolves → `directUploadWillStoreFileWithXHR` → `#rememberUploadRequest()` → TypeError (BC3-JS-N8HP)

### Fix

Optional-chain both call sites. The rest of the completion callback is already teardown-safe — `#dispatchEvent` no-ops via `getElementByKey`, `editor.update` is inert without a root — verified empirically by the regression test asserting **zero** page errors, not just the absence of this one.

### Tests

New `upload_survives_teardown.test.js` reproduces both fingerprints deterministically using the existing ActiveStorage mock (`uploadDelayMs` lands the PUT after teardown; `delayDirectUploadResponse` holds blob creation until after teardown). Both red on main with the exact production message, green with the guards. `upload_abort_on_delete` (from #1134) stays green; vitest 118/118; chromium attachments suite 102 passed + 2 pre-existing flakes (`attachments.test.js:54`, `gallery.test.js:151`) that passed on retry and are untouched by this change.

### Not addressed here (follow-up candidate)

Teardown still leaks the upload itself: `#reset()` calls `#uploadRequests?.clear()`, which drops the map without aborting, so the store PUT keeps uploading into the void after navigation. An `abortAll()` on teardown would stop the waste — but it can't replace these guards, since the blob-create POST is never tracked. Kept out of this PR to stay minimal; noted on the tracking card.

Tracked as BC-10102903433 (T2).
