### PR TITLE
Place the caret before an inline decorator when Gecko drops the selection

### DIFF
--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -9,6 +9,7 @@ import { $getListDepth, ListItemNode, ListNode } from "@lexical/list"
 import { $getTableCellNodeFromLexicalNode, TableCellNode } from "@lexical/table"
 import { CodeNode } from "@lexical/code"
 import { isSelectionHighlighted } from "../helpers/format_helper"
+import { caretFromPoint } from "../helpers/caret_helpers"
 import { getNonce } from "../helpers/csp_helper"
 import { $createNodeSelectionWith, $isListItemStructurallyEmpty, getListType } from "../helpers/lexical_helper"
 import { LinkNode } from "@lexical/link"
@@ -375,11 +376,16 @@ export default class Selection {
   }
 
   #listenForNodeSelections() {
-    this.#listeners.track(this.editor.registerCommand(CLICK_COMMAND, ({ target }) => {
+    this.#listeners.track(this.editor.registerCommand(CLICK_COMMAND, (event) => {
+      const { target } = event
       if (!isDOMNode(target)) return false
 
       const targetNode = $getNearestNodeFromDOMNode(target)
-      return $isDecoratorNode(targetNode) && this.#selectInLexical(targetNode)
+      if ($isDecoratorNode(targetNode)) {
+        return this.#selectInLexical(targetNode)
+      } else {
+        return this.#placeCaretBeforeInlineDecorator(event)
+      }
     }, COMMAND_PRIORITY_LOW))
 
     this.#listeners.track(
@@ -389,6 +395,26 @@ export default class Selection {
         }
       })
     )
+  }
+
+  // Gecko resolves a click just before an inline decorator to a text node inside
+  // its contenteditable="false" subtree, which maps to no selection at all, so
+  // typing is silently dropped. Place the caret before the decorator ourselves.
+  #placeCaretBeforeInlineDecorator(event) {
+    if ($getSelection() !== null) return false
+
+    const position = caretFromPoint(event.clientX, event.clientY)
+    if (!position) return false
+
+    const node = $getNearestNodeFromDOMNode(position.node)
+    if (!$isDecoratorNode(node) || !node.isInline()) return false
+
+    const parent = node.getParent()
+    if (!$isElementNode(parent)) return false
+
+    const index = node.getIndexWithinParent()
+    parent.select(index, index)
+    return true
   }
 
   #containEditorFocus() {

--- a/test/browser/tests/prompts/typing_before_mention.test.js
+++ b/test/browser/tests/prompts/typing_before_mention.test.js
@@ -1,0 +1,55 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+async function insertMention(page, editor) {
+  await editor.send("@")
+  await expect(page.locator(".lexxy-prompt-menu--visible")).toBeVisible({ timeout: 5_000 })
+  await editor.send("Enter")
+  await editor.flush()
+  await expect(editor.content.locator("action-text-attachment")).toBeVisible({ timeout: 5_000 })
+}
+
+async function clickAt(page, editor, clientX, clientY) {
+  await page.mouse.click(clientX, clientY)
+  await editor.flush()
+}
+
+test.describe("Typing beside a mention", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("clicking before a leading mention places the caret before it", async ({ page, editor }) => {
+    await insertMention(page, editor)
+
+    const mention = await editor.content.locator("action-text-attachment").boundingBox()
+    const content = await editor.content.boundingBox()
+    await clickAt(page, editor, content.x + 1, mention.y + mention.height / 2)
+
+    await editor.send("Hi")
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(1)
+    const value = await editor.value()
+    expect(value).toContain("Hi")
+    expect(value.indexOf("Hi")).toBeLessThan(value.indexOf("<action-text-attachment"))
+  })
+
+  test("clicking after a trailing mention places the caret after it", async ({ page, editor }) => {
+    await insertMention(page, editor)
+
+    // Well past the trailing space Lexxy inserts after a mention, so the click
+    // lands clearly after the mention rather than on that space.
+    const mention = await editor.content.locator("action-text-attachment").boundingBox()
+    await clickAt(page, editor, mention.x + mention.width + 40, mention.y + mention.height / 2)
+
+    await editor.send("Hi")
+    await editor.flush()
+
+    await expect(editor.content.locator("action-text-attachment")).toHaveCount(1)
+    const value = await editor.value()
+    expect(value).toContain("Hi")
+    expect(value.indexOf("Hi")).toBeGreaterThan(value.indexOf("<action-text-attachment"))
+  })
+})


### PR DESCRIPTION
Fixes #1149.

### The bug

With a mention at the start of a paragraph, clicking just before it and typing did nothing in Firefox. The keystrokes were silently dropped.

### Why

The click leaves the editor with **no selection at all**, so there is nothing for typing to act on. `document.caretPositionFromPoint()` at the same coordinates explains why:

| | resolves to | resulting selection |
|---|---|---|
| Blink | `P @0` — the paragraph itself | `RangeSelection`, element point, offset 0 |
| Gecko | `#text:"Zacharias" @0` — inside the mention | **`null`** (`rangeCount: 0`) |

Gecko descends into the decorator's `contenteditable="false"` subtree. That text node is rendered by the decorator and is not part of the editor state, so no selection point maps to it and Lexical ends up with none. There is no text node before the mention to hold a caret, so nothing recovers it.

### The fix

`CLICK_COMMAND` already handles clicks that land *on* a decorator. This adds the neighbouring case: when a click leaves us with no selection and the clicked point resolves inside an inline decorator, place the caret at that decorator's index in its parent — the same element point Blink produces natively.

The guard is `$getSelection() !== null`, so Blink and WebKit never reach this path.

### Scope

Deliberately limited to **inline** decorators (mentions), which is the reported bug. Block attachments (e.g. an uploaded file) have an analogous Gecko caret-drop at their vertical boundary, but the correct before/after placement there depends on the click's Y position rather than X, so it is a separate change rather than something to fold in here. The `isInline()` guard makes the boundary explicit, and the method is named `#placeCaretBeforeInlineDecorator` because the null-selection case only ever occurs on the leading edge (clicking after an inline decorator resolves natively in Gecko).

### Tests

`test/browser/tests/prompts/typing_before_mention.test.js`, driven with a real `page.mouse.click()`:

- clicking before a leading mention places the caret before it — **fails on Firefox without this change**, passes with it
- clicking after a trailing mention places the caret after it — guards against the new path hijacking clicks Gecko already handles

Both assert the mention still exists (`toHaveCount(1)`) so the ordering check can't pass vacuously. Verified on Chromium, Firefox and WebKit. `prompts/` and `attachments/` are green on Firefox; `yarn lint` and `yarn test` are clean.
