### PR TITLE
Keep the selection when a drag crosses a custom attachment

### DIFF
--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -478,6 +478,17 @@
     position: relative;
     white-space: normal;
 
+    /* Gecko drops the whole selection when a drag crosses a contenteditable="false"
+       island unless it is selectable as a single unit. Editor-only: the rendered
+       view has no contenteditable and must keep normal text selection. */
+    lexxy-editor & {
+      -webkit-user-select: all;
+
+      @supports (user-select: all) {
+        user-select: all;
+      }
+    }
+
     img {
       block-size: var(--lexxy-attachment-image-size);
       border-radius: 50%;

--- a/test/browser/tests/prompts/selection_across_mention.test.js
+++ b/test/browser/tests/prompts/selection_across_mention.test.js
@@ -1,0 +1,47 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+const MENTION = '<action-text-attachment sgid="test-sgid-zacharias" content-type="application/vnd.actiontext.mention" content="&lt;span class=&quot;person person--inline&quot;&gt;Zacharias&lt;/span&gt;"></action-text-attachment>'
+
+async function dragAcrossParagraph(page, editor) {
+  const paragraph = await editor.content.locator("p").first().boundingBox()
+  const y = paragraph.y + paragraph.height / 2
+
+  await page.mouse.move(paragraph.x + 4, y)
+  await page.mouse.down()
+  await page.mouse.move(paragraph.x + paragraph.width - 4, y, { steps: 15 })
+  await page.mouse.up()
+  await editor.flush()
+}
+
+function selectedText(page) {
+  return page.evaluate(() => window.getSelection().toString())
+}
+
+test.describe("Selecting content that contains a mention", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/mentions.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("dragging across a mention selects the surrounding text", async ({ page, editor }) => {
+    await editor.setValue(`<p>Hello ${MENTION} world</p>`)
+    await editor.flush()
+
+    await dragAcrossParagraph(page, editor)
+
+    const selection = await selectedText(page)
+    expect(selection).toContain("Hello")
+    expect(selection).toContain("world")
+    expect(selection).toContain("Zacharias")
+  })
+
+  test("dragging across plain text still selects it", async ({ page, editor }) => {
+    await editor.setValue("<p>Hello there world</p>")
+    await editor.flush()
+
+    await dragAcrossParagraph(page, editor)
+
+    expect(await selectedText(page)).toContain("Hello there world")
+  })
+})


### PR DESCRIPTION
Fixes #1148.

### The bug

Dragging a selection across a mention wiped the entire selection in Firefox. The drag ended with **no range at all** — nothing highlighted, nothing to copy or replace.

| | drag across `Hello @Zacharias world` |
|---|---|
| Blink | `"Hello \n world"`, 1 range |
| Gecko | `""`, **0 ranges**, collapsed |

A drag across plain text in the same editor selects normally in Gecko, so the mention is what breaks it.

### Why

Gecko will not extend a selection across a `contenteditable="false"` island unless the island is selectable as a single unit; it abandons the selection instead. Marking custom attachments `user-select: all` makes them span-able, and the mention's text is included in the selection.

Two other suspects were ruled out first — neither changed the outcome:

- `draggable="true"` on the attachment (setting it to `false` made no difference)
- `display: inline-flex` (`inline-block` and `inline` both still failed)

### The fix

`user-select: all` on custom attachments, following the existing `@supports` pattern in this file.

The rule is scoped to the editor with the `lexxy-editor &` nesting this file already uses (see the `:not(lexxy-editor &)` block above). Rendered, read-only Action Text has no `contenteditable` island and so never hits the Gecko bug — it must keep normal text selection, so the workaround must not reach it.

Inside the editor there is no visual change: before/after screenshots of a selected mention are pixel-identical, and clicking a mention still selects the node as it did before.

### Tests

`test/browser/tests/prompts/selection_across_mention.test.js`, driven with a real mouse drag:

- dragging across a mention selects the surrounding text — **fails on Firefox without this change**, passes with it
- dragging across plain text still selects it — the control, so a regression in ordinary selection cannot hide behind the first test

Verified on Chromium, Firefox and WebKit. `prompts/` and `attachments/` are green on Firefox; `yarn lint` and `yarn test` are clean.
