### PR TITLE
Add --lexxy-text-size variable and convert content font sizes to em

### DIFF
--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -5,6 +5,7 @@
 
 :where(.lexxy-content) {
   color: var(--lexxy-color-ink);
+  font-size: var(--lexxy-text-size);
 
   h1, h2, h3, h4, h5, h6 {
     display: block;
@@ -18,12 +19,12 @@
     }
   }
 
-  h1 { font-size: 2rem; }
-  h2 { font-size: 1.5rem; }
-  h3 { font-size: 1.25rem; }
-  h4 { font-size: 1rem; }
-  h5 { font-size: 0.875rem; }
-  h6 { font-size: 0.75rem; }
+  h1 { font-size: 2em; }
+  h2 { font-size: 1.5em; }
+  h3 { font-size: 1.25em; }
+  h4 { font-size: 1em; }
+  h5 { font-size: 0.875em; }
+  h6 { font-size: 0.75em; }
 
   p,
   ul,

--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -321,7 +321,7 @@
   .attachment__caption {
     color: var(--lexxy-color-text-subtle);
     display: block;
-    font-size: var(--lexxy-text-small);
+    font-size: 0.875em;
     padding: 1ch;
   }
 
@@ -335,7 +335,7 @@
     box-sizing: border-box;
     color: var(--lexxy-attachment-icon-color);
     display: grid;
-    font-size: var(--lexxy-text-small);
+    font-size: 0.875em;
     font-weight: bold;
     inline-size: auto;
     overflow: hidden;

--- a/app/assets/stylesheets/lexxy-editor.css
+++ b/app/assets/stylesheets/lexxy-editor.css
@@ -637,7 +637,7 @@
       }
 
       span {
-        font-size: var(--lexxy-text-small);
+        font-size: 0.875em;
       }
 
       svg {
@@ -688,7 +688,7 @@
 
   &.lexxy-editor__toolbar-dropdown--link {
     [data-dropdown-panel] {
-      font-size: var(--lexxy-text-small);
+      font-size: 0.875em;
       gap: var(--lexxy-toolbar-spacing);
       inset-inline-start: var(--lexxy-toolbar-spacing);
       inset-inline-end: var(--lexxy-toolbar-spacing);
@@ -710,7 +710,7 @@
         color: var(--lexxy-color-text);
         block-size: var(--lexxy-toolbar-button-size);
         box-sizing: border-box;
-        font-size: var(--lexxy-text-small);
+        font-size: 0.875em;
         flex: 2;
         inline-size: 100%;
         line-height: inherit;
@@ -754,7 +754,7 @@
       border-start-start-radius: 0;
       gap: var(--lexxy-toolbar-spacing);
       flex-direction: column;
-      font-size: var(--lexxy-text-small);
+      font-size: 0.875em;
       inset-inline-start: 0;
       max-inline-size: var(--max-inline-size);
 
@@ -817,7 +817,7 @@
   --floating-tools-radius: calc(var(--lexxy-radius) * 1.5);
 
   color: var(--lexxy-color-ink-inverted);
-  font-size: var(--lexxy-text-small);
+  font-size: 0.875em;
   line-height: 1;
   position: absolute;
   z-index: 2;
@@ -1024,7 +1024,7 @@
       border-radius: var(--lexxy-radius);
       color: var(--lexxy-color-ink);
       font-family: var(--lexxy-font-base);
-      font-size: var(--lexxy-text-small);
+      font-size: 0.875em;
       font-weight: normal;
       margin: 0.5ch 0.5ch 0 -0.5ch;
       padding: 0 2ch 0 1ch;
@@ -1053,7 +1053,7 @@
   box-shadow: var(--lexxy-shadow);
   color: var(--lexxy-color-ink);
   font-family: var(--lexxy-font-base);
-  font-size: var(--lexxy-text-small);
+  font-size: 0.875em;
   list-style: none;
   inset-block-start: var(--lexxy-prompt-offset-y);
   inset-inline-start: var(--lexxy-prompt-offset-x);

--- a/app/assets/stylesheets/lexxy-variables.css
+++ b/app/assets/stylesheets/lexxy-variables.css
@@ -72,7 +72,6 @@
   --lexxy-font-base: system-ui, sans-serif;
   --lexxy-font-mono: ui-monospace, "Menlo", "Monaco", Consolas, monospace;
   --lexxy-text-size: 1rem;
-  --lexxy-text-small: 0.875em;
   --lexxy-content-margin: 1rem;
 
   /* Focus ring */

--- a/app/assets/stylesheets/lexxy-variables.css
+++ b/app/assets/stylesheets/lexxy-variables.css
@@ -71,7 +71,8 @@
   /* Typography */
   --lexxy-font-base: system-ui, sans-serif;
   --lexxy-font-mono: ui-monospace, "Menlo", "Monaco", Consolas, monospace;
-  --lexxy-text-small: 0.875rem;
+  --lexxy-text-size: 1rem;
+  --lexxy-text-small: 0.875em;
   --lexxy-content-margin: 1rem;
 
   /* Focus ring */


### PR DESCRIPTION
## Summary

- Add a `--lexxy-text-size` variable (default `1rem`) as the base content font size, set on `.lexxy-content`.
- Convert heading font sizes to `em` so they scale proportionally with the base: `h1 2em`, `h2 1.5em`, `h3 1.25em`, `h4 1em`, `h5 0.875em`, `h6 0.75em`.
- Remove the `--lexxy-text-small` variable, replacing its usages with the literal `0.875em`.

Computed sizes are identical to before at the default `1rem`. Overriding `--lexxy-text-size` now scales all content text proportionally.