### PR TITLE
Keep focus in other form fields when reconciling a stale selection

### DIFF
--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -1,7 +1,8 @@
 import {
   $addUpdateTag, $createParagraphNode, $getNearestNodeFromDOMNode, $getRoot, $getSelection, $isDecoratorNode, $isElementNode,
-  $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $setSelection, CLICK_COMMAND, COMMAND_PRIORITY_LOW, DELETE_CHARACTER_COMMAND,
-  HISTORY_MERGE_TAG, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND, SELECTION_CHANGE_COMMAND, isDOMNode
+  $isLineBreakNode, $isNodeSelection, $isRangeSelection, $isTextNode, $setSelection, CLICK_COMMAND, COMMAND_PRIORITY_CRITICAL, COMMAND_PRIORITY_LOW,
+  DELETE_CHARACTER_COMMAND, HISTORY_MERGE_TAG, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND,
+  SELECTION_CHANGE_COMMAND, SKIP_DOM_SELECTION_TAG, isDOMNode
 } from "lexical"
 import { $getNearestNodeOfType } from "@lexical/utils"
 import { $getListDepth, ListItemNode, ListNode } from "@lexical/list"
@@ -345,8 +346,32 @@ export default class Selection {
 
       this.editor.registerCommand(SELECTION_CHANGE_COMMAND, () => {
         this.#syncSelectedClasses()
-      }, COMMAND_PRIORITY_LOW)
+      }, COMMAND_PRIORITY_LOW),
+
+      this.editor.registerCommand(SELECTION_CHANGE_COMMAND, () => {
+        this.#preserveFocusOfOtherFields()
+        return false
+      }, COMMAND_PRIORITY_CRITICAL)
     )
+  }
+
+  // Firefox (152+) keeps window.getSelection() anchored inside the editor after focus
+  // moves to another field, and fires document selectionchange for every keystroke
+  // typed there. Lexical reads that stale selection, reconciles, and pulls focus back
+  // into the editor — stealing it mid-typing. When another text-entry field owns focus,
+  // tag the update so Lexical leaves the DOM selection (and with it, focus) alone.
+  #preserveFocusOfOtherFields() {
+    if (this.#anotherFieldIsFocused) {
+      $addUpdateTag(SKIP_DOM_SELECTION_TAG)
+    }
+  }
+
+  get #anotherFieldIsFocused() {
+    const rootElement = this.editor.getRootElement()
+    const activeElement = rootElement?.ownerDocument.activeElement
+
+    return activeElement && !rootElement.contains(activeElement) &&
+      (activeElement.tagName === "INPUT" || activeElement.tagName === "TEXTAREA" || activeElement.isContentEditable)
   }
 
   #listenForNodeSelections() {

--- a/test/browser/tests/editor/focus_preservation.test.js
+++ b/test/browser/tests/editor/focus_preservation.test.js
@@ -1,0 +1,71 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Focus preservation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  // Firefox (152+) keeps window.getSelection() anchored inside the editor after focus
+  // moves to another field, and fires document selectionchange for every keystroke
+  // typed there. Lexical reads that stale selection, reconciles, and pulls focus back
+  // into the editor — stealing it mid-typing (BC-10036823881). Other engines move the
+  // document selection together with focus, so the stale state cannot be built with
+  // real DOM calls here; simulate Firefox's reporting by patching getSelection() to
+  // return the stale editor-anchored selection while the title field truly owns focus,
+  // then fire selectionchange the way Firefox does for each keystroke.
+  test("typing in another field doesn't lose focus to the editor over a stale selection", async ({ page, editor }) => {
+    await editor.setValue("<h2>Inventory</h2><table><tbody><tr><td><p>Item</p></td><td><p>Count</p></td></tr></tbody></table>")
+    await editor.click()
+
+    const title = page.locator("input[name='post[title]']")
+    await title.focus()
+
+    await page.evaluate(() => {
+      const content = document.querySelector("lexxy-editor .lexxy-editor__content")
+      const anchorNode = content.querySelector("h2").parentElement
+      const realSelection = window.getSelection()
+      const staleSelection = {
+        anchorNode, focusNode: anchorNode, anchorOffset: 0, focusOffset: 1,
+        type: "Range", rangeCount: 1, isCollapsed: false,
+        getRangeAt() {
+          const range = document.createRange()
+          range.setStart(anchorNode, 0)
+          range.setEnd(anchorNode, 1)
+          return range
+        },
+        setBaseAndExtent(...args) { return realSelection.setBaseAndExtent(...args) },
+        removeAllRanges() { return realSelection.removeAllRanges() },
+        addRange(range) { return realSelection.addRange(range) },
+        extend(...args) { return realSelection.extend(...args) },
+        collapse(...args) { return realSelection.collapse(...args) }
+      }
+      window.__restoreGetSelection = Document.prototype.getSelection
+      Document.prototype.getSelection = () => staleSelection
+      window.getSelection = () => staleSelection
+    })
+
+    for (const character of "abc") {
+      await page.evaluate(() => document.dispatchEvent(new Event("selectionchange")))
+      await page.keyboard.type(character)
+      await expect(title).toBeFocused()
+    }
+
+    await expect(title).toHaveValue("abc")
+  })
+
+  test("selection updates still focus the editor when no other field owns focus", async ({ page, editor }) => {
+    await editor.click()
+    await editor.send("Hello")
+
+    await page.evaluate(() => {
+      document.activeElement.blur()
+      document.dispatchEvent(new Event("selectionchange"))
+    })
+    await editor.focus()
+    await editor.send(" there")
+
+    await expect(editor.content).toBeFocused()
+  })
+})


### PR DESCRIPTION
Fixes the residual focus-theft in [BC-10036823881](https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10036823881): in Firefox, after pasting a table copied from another Fizzy card into a new card's description, clicking into the title field and typing bounces focus back to the description editor on every keystroke — the title can only be written one letter per click.

## Repro confirmed

Tony reproduced on Firefox 152.0.6 with the customer's exact steps (open old card → Edit → highlight the table → copy → board → New Card → paste into body → click title → type). I reproduced the same against a local Fizzy dev server with stock Firefox 152.0.6 driven by Selenium/geckodriver: after the table paste, the title captured exactly one letter per click into it (typed 5 characters across 2 clicks, title value `"ad"`), with focus jumping to the description editor after each keystroke. Playwright's patched Gecko builds (Firefox 150/151) cannot reproduce naturally — see below.

## Mechanism

Three browser/editor behaviors stack:

1. **Arm** — pasting a table leaves Lexical's internal selection and the DOM selection in persistent disagreement (DOM caret sits on an element point beside the table wrapper; plain-text pastes converge and do not arm — verified as a negative control).
2. **Trigger (Firefox 152+ only)** — Firefox keeps `window.getSelection()` anchored *inside the editor* after focus moves to the title field (Firefox ≤151 moved it with focus — this is why nobody could reproduce for weeks, including on BrowserStack automation), and it fires document-level `selectionchange` for every keystroke typed in a textarea (Chrome doesn't).
3. **Steal** — Lexical's `selectionchange` handler reads the stale editor-anchored selection, marks it dirty, and the reconciler's `updateDOMSelection` re-asserts it: it rewrites the DOM selection (which moves focus into a contenteditable on Gecko) and, on Firefox, explicitly calls `rootElement.focus()` when `document.activeElement` is outside the root. Caught in the act with a wrapped `HTMLElement.prototype.focus`:

    ```
    focus(DIV.lexxy-editor__content)
      updateDOMSelection → reconciler commit (lexical, bundled)
    ```

This also explains the customer's "still one letter at a time after deleting the pasted content, until refresh" — the stale-selection state survives content deletion.

## Fix

When a text-entry field outside the editor root owns focus (`INPUT`, `TEXTAREA`, or a foreign contenteditable), a `SELECTION_CHANGE_COMMAND`-bearing update tags itself with Lexical's own `SKIP_DOM_SELECTION_TAG`, so the reconciler leaves the DOM selection — and with it, focus — alone. The internal selection still updates, and Lexical re-syncs the DOM selection normally when the editor regains focus.

This is the layer where the bug lives: Fizzy pins lexxy (0.9.23) and BC5 pins 0.9.25 — both inherit the fix through the next release. No behavior changes when focus is in the editor, on its toolbar, or lost to `body` (Lexical's focus-restoration still runs for those).

## Tests

`test/browser/tests/editor/focus_preservation.test.js`:

- **Steal case**: simulates Firefox 152's stale-selection reporting by patching `getSelection()` to return the editor-anchored selection while the title input truly owns focus, then fires `selectionchange` per keystroke. The simulation is necessary because all three Playwright engines move the document selection *with* focus (`addRange` into a contenteditable synchronously focuses it), so the Firefox 152 state cannot be armed with real DOM calls. Forwarded `setBaseAndExtent` reaches the real reconciler, so the unpatched steal reproduces in **all three engines** — verified RED on unfixed src (chromium, firefox, webkit), GREEN with the fix.
- **Negative control**: selection updates still focus the editor when no other field owns focus.

End-to-end: local Fizzy + this branch via `path:` gem, stock Firefox 152.0.6, Tony's exact steps — title receives all 12 typed characters, focus never leaves the title, zero focus-steal events.

Full suite: `yarn lint`, `bin/rubocop`, `yarn test` (119), `yarn test:browser` (3 engines), `bin/rails test:all` — green.

## Follow-ups

- Lexical upstream: the reconciler's focus restoration treats "activeElement outside the root" as "focus was lost" — when another text-entry control owns focus, that's theft. Worth an upstream issue/PR; this fix uses Lexical's sanctioned update tag and stands regardless.
- Fizzy closes the card via a lexxy release + version bump (`0.9.23 → next`).
