### PR TITLE
Layout shift persists on lexxy.dev as the editor mounts

### DIFF
--- a/home/assets/landing.css
+++ b/home/assets/landing.css
@@ -384,6 +384,16 @@ a:not(.btn) {
       font-size: 0.9em;
       line-height: 1.3em;
     }
+
+    /* Reserve the exact mounted height before the editor upgrades. Lexxy's own
+       pre-upgrade reservation resolves lh/ch against the host, which overshoots
+       here: the toolbar renders at 0.9em/1.3 (above), and the border-box reset
+       makes the content's 8lh minimum absorb its padding. Mounted height:
+       toolbar (2 lines × 0.9em × 1.3 + 4px padding + 1px border)
+       + content (8 rows × 1.6 line-height) + host borders (2px). */
+    &:not(:defined) {
+      min-block-size: calc(2.34em + 12.8em + 7px);
+    }
   }
 }
 
@@ -653,7 +663,7 @@ a:not(.btn) {
 
   lexxy-editor {
     --lexxy-color-canvas: var(--bg);
-    --lexxy-editor-rows: 30lh;
+    --lexxy-editor-rows: 35lh;
     font-size: 1em;
     inline-size: 100%;
     margin: 0 auto;
@@ -670,6 +680,15 @@ a:not(.btn) {
       inset-block-start: 0;
       position: sticky;
       z-index: 10;
+    }
+
+    /* Same pre-upgrade reservation as the hero editor, with this section's
+       metrics: toolbar (2 lines × 0.8em × 1.25 + 5px chrome) + content
+       (35 rows × 1.6 line-height) + host borders (2px). 35 rows covers the
+       sandbox's preloaded value at desktop widths, so the minimum — and with
+       it the reservation — matches the mounted height. */
+    &:not(:defined) {
+      min-block-size: calc(2em + 56em + 7px);
     }
   }
 
@@ -703,6 +722,10 @@ a:not(.btn) {
 
       lexxy-editor {
         --lexxy-editor-rows: 20lh;
+
+        &:not(:defined) {
+          min-block-size: calc(2em + 32em + 7px);
+        }
       }
     }
 


### PR DESCRIPTION
lexxy.dev still shifts noticeably as the editor mounts, even with #1201's pre-upgrade reservation shipped in the published CSS (0.9.26). The reservation is live on the page — it just reserves the wrong height there, so the layout jumps *up* ~29px when the editor snaps in.

## Why #1201 didn't hold on lexxy.dev

The generic reservation resolves `lh`/`ch` against the `lexxy-editor` host. That matches the mounted height under default styling (how #1201 was validated), but the landing pages break both of its assumptions:

- **`* { box-sizing: border-box }`** (landing.css) makes `.lexxy-editor__content`'s `min-block-size: 8lh` absorb its padding, so the formula's `+ 2 * padding` term over-counts by ~18px.
- **Toolbar font overrides** (`font-size: 0.9em; line-height: 1.3em` on the home, `0.8em/1.25em` in the sandbox) make the mounted toolbar's `2lh` smaller than the host-resolved `2lh` in the calc — another ~13px.

Measured on the home page: 265px reserved vs 236px mounted → one 29px upward shift on mount.

## Fix

Override the pre-upgrade reservation per page in `landing.css` with the exact mounted height, derived from each page's own metrics (the gem rule is `:where()`-wrapped precisely so consumers can do this). The values are plain `em` + `px`, so they track the page's responsive font sizing and stay independent of the gem CSS internals.

Also bump the sandbox editor from 30 to 35 rows so its minimum covers the preloaded value at desktop widths — that makes the mounted height equal the minimum, and with it the reservation, instead of shifting again when the value renders.

## Validation (local Jekyll + published lexxy@0.9.26 CSS from esm.sh, same as production)

| Page | Before | After |
|---|---|---|
| Home | 265px reserved → 236px mounted, CLS 0.02, 29px jump | 236.09px → 235.97px, **zero layout-shift entries, CLS 0.00** (DevTools trace) |
| Home (390px mobile viewport) | — | 234.09px → 234.09px, zero shifts |
| Sandbox | 798px → 763px → 875px double shift | 884.65px → 884.09px, single 0.0003-score sub-pixel shift |

Verified with a `layout-shift` PerformanceObserver plus per-frame height sampling of the editor through the pre-upgrade → mounted transition, and a DevTools performance trace on the home page.

Note: if the gem's default reservation formula or the editor's mounted sizing changes in a future release, these page overrides should be re-checked — they intentionally pin the current mounted metrics.
