### PR TITLE
macOS text replacements lose their line breaks on submit

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -60,6 +60,19 @@ export default class Contents {
     }, { tag })
   }
 
+  // A literal "\n" stays visible in the editor, which Lexical renders with white-space: pre-wrap,
+  // but collapses to a space once serialized to HTML, so it has to become line break nodes.
+  insertTextWithLineBreaks(text) {
+    const normalizedText = text?.replace(/\r\n?/g, "\n")
+    if (!normalizedText?.includes("\n")) return false
+
+    const selection = $getSelection()
+    if (!$isRangeSelection(selection)) return false
+
+    selection.insertRawText(normalizedText)
+    return true
+  }
+
   insertAtCursor(...nodes) {
     const selection = this.#insertableSelection()
     const inserter = NodeInserter.for(selection)

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -69,9 +69,9 @@ export default class Contents {
     if (normalizedText?.includes("\n") && $isRangeSelection(selection)) {
       selection.insertRawText(normalizedText)
       return true
+    } else {
+      return false
     }
-
-    return false
   }
 
   insertAtCursor(...nodes) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -64,13 +64,14 @@ export default class Contents {
   // but collapses to a space once serialized to HTML, so it has to become line break nodes.
   insertTextWithLineBreaks(text) {
     const normalizedText = text?.replace(/\r\n?/g, "\n")
-    if (!normalizedText?.includes("\n")) return false
-
     const selection = $getSelection()
-    if (!$isRangeSelection(selection)) return false
 
-    selection.insertRawText(normalizedText)
-    return true
+    if (normalizedText?.includes("\n") && $isRangeSelection(selection)) {
+      selection.insertRawText(normalizedText)
+      return true
+    }
+
+    return false
   }
 
   insertAtCursor(...nodes) {

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -661,7 +661,7 @@ export class LexicalEditorElement extends HTMLElement {
   #handleReplacementText() {
     this.#listeners.track(this.editor.registerCommand(
       CONTROLLED_TEXT_INSERTION_COMMAND,
-      (eventOrText) => $insertReplacementTextWithLineBreaks(eventOrText),
+      (event) => event instanceof InputEvent && this.contents.insertTextWithLineBreaks(event.data),
       COMMAND_PRIORITY_NORMAL
     ))
   }
@@ -919,28 +919,6 @@ export class LexicalEditorElement extends HTMLElement {
 }
 
 export default LexicalEditorElement
-
-// macOS text replacements and autocorrect arrive as CONTROLLED_TEXT_INSERTION_COMMAND, which
-// inserts their text verbatim. A newline would stay a literal "\n" inside a single text node:
-// visible in the editor, which Lexical renders with "white-space: pre-wrap", but collapsed to a
-// space once serialized to HTML. Turning it into line break nodes keeps the break on submit.
-function $insertReplacementTextWithLineBreaks(eventOrText) {
-  const text = replacementTextFrom(eventOrText)?.replace(/\r\n?/g, "\n")
-  if (!text?.includes("\n")) return false
-
-  const selection = $getSelection()
-  if (!$isRangeSelection(selection)) return false
-
-  selection.insertRawText(text)
-  return true
-}
-
-function replacementTextFrom(eventOrText) {
-  if (typeof eventOrText === "string") return eventOrText
-  if (eventOrText.dataTransfer) return null
-
-  return eventOrText.data
-}
 
 // Like $getRoot().getTextContent() but uses readable text for custom attachment nodes
 // (e.g., mentions) instead of their single-character cursor placeholder.

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,4 +1,4 @@
-import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, CONTROLLED_TEXT_INSERTION_COMMAND, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
@@ -394,6 +394,7 @@ export class LexicalEditorElement extends HTMLElement {
   #initialize() {
     this.#registerComponents()
     this.#handleEnter()
+    this.#handleReplacementText()
     this.#registerFocusEvents()
     this.#registerHistoryEvents()
     this.#registerFileAcceptFilter()
@@ -657,6 +658,14 @@ export class LexicalEditorElement extends HTMLElement {
     ))
   }
 
+  #handleReplacementText() {
+    this.#listeners.track(this.editor.registerCommand(
+      CONTROLLED_TEXT_INSERTION_COMMAND,
+      (eventOrText) => $insertReplacementTextWithLineBreaks(eventOrText),
+      COMMAND_PRIORITY_NORMAL
+    ))
+  }
+
   #registerFocusEvents() {
     this.#listeners.track(
       registerEventListener(this, "focusin", this.#handleFocusIn),
@@ -910,6 +919,28 @@ export class LexicalEditorElement extends HTMLElement {
 }
 
 export default LexicalEditorElement
+
+// macOS text replacements and autocorrect arrive as CONTROLLED_TEXT_INSERTION_COMMAND, which
+// inserts their text verbatim. A newline would stay a literal "\n" inside a single text node:
+// visible in the editor, which Lexical renders with "white-space: pre-wrap", but collapsed to a
+// space once serialized to HTML. Turning it into line break nodes keeps the break on submit.
+function $insertReplacementTextWithLineBreaks(eventOrText) {
+  const text = replacementTextFrom(eventOrText)?.replace(/\r\n?/g, "\n")
+  if (!text?.includes("\n")) return false
+
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection)) return false
+
+  selection.insertRawText(text)
+  return true
+}
+
+function replacementTextFrom(eventOrText) {
+  if (typeof eventOrText === "string") return eventOrText
+  if (eventOrText.dataTransfer) return null
+
+  return eventOrText.data
+}
 
 // Like $getRoot().getTextContent() but uses readable text for custom attachment nodes
 // (e.g., mentions) instead of their single-character cursor placeholder.

--- a/test/javascript/unit/editor/insert_replacement_text.test.js
+++ b/test/javascript/unit/editor/insert_replacement_text.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest"
+import { $getRoot, CONTROLLED_TEXT_INSERTION_COMMAND } from "lexical"
+import { createTestEditor, destroyTestEditor, selectFirstText, setContent, tick } from "../helpers/editor_helper"
+
+// macOS "Keyboard > Text Replacements" (and autocorrect) reach the editor as a beforeinput event
+// with inputType "insertReplacementText", which Lexical forwards to CONTROLLED_TEXT_INSERTION_COMMAND
+// carrying the event itself. jsdom's InputEvent has no getTargetRanges, so Lexical's beforeinput
+// handling is inert here and we dispatch the command directly instead.
+async function insertReplacementText(editorElement, text) {
+  editorElement.editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, { data: text, dataTransfer: null })
+  await tick()
+}
+
+function nodeTypes(editorElement) {
+  return editorElement.editor.read(() => $getRoot().getFirstChild().getChildren().map((node) => node.getType()))
+}
+
+describe("insertReplacementText", () => {
+  test("turns a newline into a line break instead of a literal newline", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+    selectFirstText(editorElement, "Hello".length)
+
+    await insertReplacementText(editorElement, " Thanks,\nKyle")
+
+    expect(nodeTypes(editorElement)).toEqual([ "text", "linebreak", "text" ])
+    expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
+    expect(editorElement.value).not.toContain("\n")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("keeps every line break of a multi-line replacement", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hi</p>")
+    selectFirstText(editorElement, "Hi".length)
+
+    await insertReplacementText(editorElement, "\nline two\nline three")
+
+    expect(nodeTypes(editorElement)).toEqual([ "text", "linebreak", "text", "linebreak", "text" ])
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("normalizes CRLF line endings", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+    selectFirstText(editorElement, "Hello".length)
+
+    await insertReplacementText(editorElement, " Thanks,\r\nKyle")
+
+    expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
+    expect(editorElement.value).not.toContain("\r")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("inserts single-line replacements unchanged", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+    selectFirstText(editorElement, "Hello".length)
+
+    await insertReplacementText(editorElement, " there")
+
+    expect(nodeTypes(editorElement)).toEqual([ "text" ])
+    expect(editorElement.value).toBe("<p>Hello there</p>")
+
+    await destroyTestEditor(editorElement)
+  })
+})

--- a/test/javascript/unit/editor/insert_replacement_text.test.js
+++ b/test/javascript/unit/editor/insert_replacement_text.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { $getRoot, CONTROLLED_TEXT_INSERTION_COMMAND } from "lexical"
+import { $getRoot, $setSelection, CONTROLLED_TEXT_INSERTION_COMMAND } from "lexical"
 import { createTestEditor, destroyTestEditor, selectFirstText, setContent, tick } from "../helpers/editor_helper"
 
 // macOS "Keyboard > Text Replacements" (and autocorrect) reach the editor as a beforeinput event
@@ -14,6 +14,15 @@ async function insertReplacementText(editorElement, text) {
 
 function nodeTypes(editorElement) {
   return editorElement.editor.read(() => $getRoot().getFirstChild().getChildren().map((node) => node.getType()))
+}
+
+function insertTextWithLineBreaks(editorElement, text) {
+  let result
+  editorElement.editor.update(() => {
+    result = editorElement.contents.insertTextWithLineBreaks(text)
+  }, { discrete: true })
+
+  return result
 }
 
 describe("insertReplacementText", () => {
@@ -52,6 +61,36 @@ describe("insertReplacementText", () => {
 
     expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
     expect(editorElement.value).not.toContain("\r")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  // The return value is the command handler's: true stops Lexical, anything falsy lets it insert
+  // the text normally, so every path that does not convert line breaks has to stay falsy.
+  test("reports whether it converted line breaks", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+    selectFirstText(editorElement, "Hello".length)
+
+    expect(insertTextWithLineBreaks(editorElement, " Thanks,\nKyle")).toBe(true)
+    expect(insertTextWithLineBreaks(editorElement, " there")).toBe(false)
+    expect(insertTextWithLineBreaks(editorElement, null)).toBe(false)
+
+    await destroyTestEditor(editorElement)
+  })
+
+  test("reports false without a range selection", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+
+    let result
+    editorElement.editor.update(() => {
+      $setSelection(null)
+      result = editorElement.contents.insertTextWithLineBreaks(" Thanks,\nKyle")
+    }, { discrete: true })
+
+    expect(result).toBe(false)
+    expect(editorElement.value).toBe("<p>Hello</p>")
 
     await destroyTestEditor(editorElement)
   })

--- a/test/javascript/unit/editor/insert_replacement_text.test.js
+++ b/test/javascript/unit/editor/insert_replacement_text.test.js
@@ -7,7 +7,8 @@ import { createTestEditor, destroyTestEditor, selectFirstText, setContent, tick 
 // carrying the event itself. jsdom's InputEvent has no getTargetRanges, so Lexical's beforeinput
 // handling is inert here and we dispatch the command directly instead.
 async function insertReplacementText(editorElement, text) {
-  editorElement.editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, { data: text, dataTransfer: null })
+  const event = new InputEvent("beforeinput", { inputType: "insertReplacementText", data: text })
+  editorElement.editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, event)
   await tick()
 }
 
@@ -51,6 +52,21 @@ describe("insertReplacementText", () => {
 
     expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
     expect(editorElement.value).not.toContain("\r")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  // Plain typing and composition start dispatch the same command with a bare string, which is
+  // never a replacement, so it must fall through to Lexical's own handler.
+  test("leaves string payloads to Lexical", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+    selectFirstText(editorElement, "Hello".length)
+
+    editorElement.editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, " there")
+    await tick()
+
+    expect(editorElement.value).toBe("<p>Hello there</p>")
 
     await destroyTestEditor(editorElement)
   })

--- a/test/system/trix/from_lexxy_to_trix_test.rb
+++ b/test/system/trix/from_lexxy_to_trix_test.rb
@@ -58,7 +58,9 @@ class Trix::FromLexxyToTrixTest < ApplicationSystemTestCase
     attach_file [ file_fixture("example.png"), file_fixture("example2.png") ] do
       click_on "Upload file"
     end
-    assert_selector ".attachment-gallery"
+    within first(".attachment-gallery") do
+      assert_selector "figure.attachment", count: 2
+    end
     find_editor.send "With gallery"
 
     click_on "Create Post"


### PR DESCRIPTION
A macOS "Keyboard > Text Replacements" snippet containing a newline — a multi-line signature like `Thanks,\nKyle` — looks right while composing but comes back on a single line once the message is submitted.

macOS delivers text replacements as a `beforeinput` event with `inputType: "insertReplacementText"`, which Lexical forwards to `CONTROLLED_TEXT_INSERTION_COMMAND`. Both `registerRichText` and `registerPlainText` handle that by calling `selection.insertText(data)`, which inserts the string verbatim — so the newline stays a literal `\n` inside a single text node instead of becoming a line break node.

That reads as correct in the editor, because Lexical sets `white-space: pre-wrap` on the contenteditable root. But the newline is plain whitespace once the content is serialized to HTML, and collapses to a space when the content is rendered. We lose it where vanilla Lexical wouldn't, because `exportTextNodeDOM` unwraps the `<span>` that would otherwise have carried Lexical's own `white-space: pre-wrap` into the exported markup.

So we now intercept `CONTROLLED_TEXT_INSERTION_COMMAND` when the incoming text contains a newline and insert it with `insertRawText`, which splits it into real line break nodes — the same nodes Shift+Enter produces, serializing to `<br>`. Single-line replacements keep taking the existing path, and events carrying a `dataTransfer` (drop, yank) are left to the default handler.

The regression test dispatches the command directly rather than firing `beforeinput`: jsdom's `InputEvent` has no `getTargetRanges`, so Lexical's own `beforeinput` handling is inert there. Verified end-to-end in Chromium too, with a real `beforeinput` event — before the fix the editor showed the break while the serialized value was `<p>Hello Thanks,\nKyle</p>`; after it, `<p>Hello Thanks,<br>Kyle</p>`.

---

Card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10140982528
