### PR TITLE
Pasted Word and Outlook lists arrive as indented paragraphs instead of lists

### DIFF
--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -1,3 +1,5 @@
+import OfficeFormatter from "./pasted_content_formatter/office_formatter"
+
 export default class PastedContentFormatter {
   constructor(doc) {
     this.doc = doc
@@ -7,7 +9,7 @@ export default class PastedContentFormatter {
     this.#stripStyleElements()
     this.#unwrapPlaceholderAnchors()
     this.#stripTableCellColorStyles()
-    this.#rebuildOfficeLists()
+    new OfficeFormatter(this.doc).format()
     this.#unwrapWrappedListChildren()
     this.#nestStrayListChildren()
     this.#stripStrayListChildren()
@@ -48,143 +50,6 @@ export default class PastedContentFormatter {
       cell.style.removeProperty("background")
       cell.style.removeProperty("color")
     }
-  }
-
-  // Word and Outlook never emit <ul>/<ol>/<li>. They simulate lists with flat
-  // paragraphs that declare their depth in an inline `mso-list:l0 level2 lfo1`
-  // and carry the bullet or number glyph in a <span style="mso-list:Ignore">.
-  // Nothing downstream understands either, so the items land as plain paragraphs
-  // with the marker baked into the text. Rebuild real lists from the level each
-  // paragraph declares.
-  //
-  // Everything this reads lives in inline attributes, so it stays correct after
-  // #stripStyleElements has dropped Office's style sheet.
-  #rebuildOfficeLists() {
-    for (const run of this.#officeListRuns()) {
-      this.#replaceWithLists(run)
-    }
-  }
-
-  // A run is a stretch of Office list paragraphs that are siblings with nothing
-  // but whitespace and Word's conditional comments between them. Anything else
-  // in between (a heading, a plain paragraph) ends one list and starts another.
-  #officeListRuns() {
-    const runs = []
-    const claimed = new Set()
-
-    for (const paragraph of this.doc.querySelectorAll("p[style*='mso-list']")) {
-      if (claimed.has(paragraph) || this.#officeListLevel(paragraph) === null) continue
-
-      const run = []
-      let node = paragraph
-      while (node) {
-        run.push(node)
-        claimed.add(node)
-        node = this.#nextOfficeListParagraph(node)
-      }
-      runs.push(run)
-    }
-
-    return runs
-  }
-
-  #nextOfficeListParagraph(paragraph) {
-    let sibling = paragraph.nextSibling
-    while (sibling && this.#isIgnorableBetweenOfficeListParagraphs(sibling)) {
-      sibling = sibling.nextSibling
-    }
-
-    if (sibling && sibling.nodeType === Node.ELEMENT_NODE && this.#officeListLevel(sibling) !== null) {
-      return sibling
-    }
-
-    return null
-  }
-
-  #isIgnorableBetweenOfficeListParagraphs(node) {
-    if (node.nodeType === Node.COMMENT_NODE) {
-      return true
-    }
-    return node.nodeType === Node.TEXT_NODE && node.textContent.trim() === ""
-  }
-
-  // Word numbers levels from 1, but a copied selection often starts partway down
-  // a list, so every paragraph declares level3 with no level1 above it. Anchoring
-  // the run at its own shallowest level is what keeps the result from arriving
-  // needlessly deep.
-  #replaceWithLists(paragraphs) {
-    const levels = paragraphs.map((paragraph) => this.#officeListLevel(paragraph))
-    const baseLevel = Math.min(...levels)
-    const roots = []
-    const stack = []
-
-    paragraphs.forEach((paragraph, index) => {
-      const depth = levels[index] - baseLevel + 1
-      const tagName = this.#officeListTagName(paragraph)
-
-      while (stack.length > depth) {
-        stack.pop()
-      }
-      if (stack.length === depth && stack[depth - 1].tagName !== tagName.toUpperCase()) {
-        stack.pop()
-      }
-
-      while (stack.length < depth) {
-        const list = this.doc.createElement(tagName)
-        if (stack.length === 0) {
-          roots.push(list)
-        } else {
-          this.#lastItemOf(stack[stack.length - 1]).appendChild(list)
-        }
-        stack.push(list)
-      }
-
-      stack[stack.length - 1].appendChild(this.#createOfficeListItem(paragraph))
-    })
-
-    paragraphs[0].replaceWith(...roots)
-    for (const paragraph of paragraphs.slice(1)) {
-      paragraph.remove()
-    }
-  }
-
-  #lastItemOf(list) {
-    if (!list.lastElementChild) {
-      list.appendChild(this.doc.createElement("li"))
-    }
-    return list.lastElementChild
-  }
-
-  // Word writes bullets as the raw glyph of the marker font (Symbol's "·",
-  // Wingdings' "§", Courier New's "o") and numbers as the rendered counter
-  // ("1.", "a)", "iv)"). A bare letter with no delimiter after it is Courier
-  // New's bullet, not a counter, so the delimiter is what tells them apart.
-  #officeListTagName(paragraph) {
-    const marker = paragraph.querySelector("[style*='mso-list:Ignore']")
-    const text = marker?.textContent || ""
-
-    if (/\d/.test(text) || /^\(?[A-Za-z]+[.)]/.test(text)) {
-      return "ol"
-    }
-    return "ul"
-  }
-
-  #createOfficeListItem(paragraph) {
-    for (const marker of paragraph.querySelectorAll("[style*='mso-list:Ignore']")) {
-      marker.remove()
-    }
-
-    const item = this.doc.createElement("li")
-    item.append(...paragraph.childNodes)
-    return item
-  }
-
-  #officeListLevel(element) {
-    const match = /mso-list:[^;"']*\blevel(\d+)/.exec(element.getAttribute("style") || "")
-    if (match) {
-      return parseInt(match[1], 10)
-    }
-    return null
   }
 
   // Some sources wrap runs of <li>s in a stray element (e.g. a <div> directly

--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -7,6 +7,7 @@ export default class PastedContentFormatter {
     this.#stripStyleElements()
     this.#unwrapPlaceholderAnchors()
     this.#stripTableCellColorStyles()
+    this.#rebuildOfficeLists()
     this.#unwrapWrappedListChildren()
     this.#nestStrayListChildren()
     this.#stripStrayListChildren()
@@ -47,6 +48,143 @@ export default class PastedContentFormatter {
       cell.style.removeProperty("background")
       cell.style.removeProperty("color")
     }
+  }
+
+  // Word and Outlook never emit <ul>/<ol>/<li>. They simulate lists with flat
+  // paragraphs that declare their depth in an inline `mso-list:l0 level2 lfo1`
+  // and carry the bullet or number glyph in a <span style="mso-list:Ignore">.
+  // Nothing downstream understands either, so the items land as plain paragraphs
+  // with the marker baked into the text. Rebuild real lists from the level each
+  // paragraph declares.
+  //
+  // Everything this reads lives in inline attributes, so it stays correct after
+  // #stripStyleElements has dropped Office's style sheet.
+  #rebuildOfficeLists() {
+    for (const run of this.#officeListRuns()) {
+      this.#replaceWithLists(run)
+    }
+  }
+
+  // A run is a stretch of Office list paragraphs that are siblings with nothing
+  // but whitespace and Word's conditional comments between them. Anything else
+  // in between (a heading, a plain paragraph) ends one list and starts another.
+  #officeListRuns() {
+    const runs = []
+    const claimed = new Set()
+
+    for (const paragraph of this.doc.querySelectorAll("p[style*='mso-list']")) {
+      if (claimed.has(paragraph) || this.#officeListLevel(paragraph) === null) continue
+
+      const run = []
+      let node = paragraph
+      while (node) {
+        run.push(node)
+        claimed.add(node)
+        node = this.#nextOfficeListParagraph(node)
+      }
+      runs.push(run)
+    }
+
+    return runs
+  }
+
+  #nextOfficeListParagraph(paragraph) {
+    let sibling = paragraph.nextSibling
+    while (sibling && this.#isIgnorableBetweenOfficeListParagraphs(sibling)) {
+      sibling = sibling.nextSibling
+    }
+
+    if (sibling && sibling.nodeType === Node.ELEMENT_NODE && this.#officeListLevel(sibling) !== null) {
+      return sibling
+    }
+
+    return null
+  }
+
+  #isIgnorableBetweenOfficeListParagraphs(node) {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      return true
+    }
+    return node.nodeType === Node.TEXT_NODE && node.textContent.trim() === ""
+  }
+
+  // Word numbers levels from 1, but a copied selection often starts partway down
+  // a list, so every paragraph declares level3 with no level1 above it. Anchoring
+  // the run at its own shallowest level is what keeps the result from arriving
+  // needlessly deep.
+  #replaceWithLists(paragraphs) {
+    const levels = paragraphs.map((paragraph) => this.#officeListLevel(paragraph))
+    const baseLevel = Math.min(...levels)
+    const roots = []
+    const stack = []
+
+    paragraphs.forEach((paragraph, index) => {
+      const depth = levels[index] - baseLevel + 1
+      const tagName = this.#officeListTagName(paragraph)
+
+      while (stack.length > depth) {
+        stack.pop()
+      }
+      if (stack.length === depth && stack[depth - 1].tagName !== tagName.toUpperCase()) {
+        stack.pop()
+      }
+
+      while (stack.length < depth) {
+        const list = this.doc.createElement(tagName)
+        if (stack.length === 0) {
+          roots.push(list)
+        } else {
+          this.#lastItemOf(stack[stack.length - 1]).appendChild(list)
+        }
+        stack.push(list)
+      }
+
+      stack[stack.length - 1].appendChild(this.#createOfficeListItem(paragraph))
+    })
+
+    paragraphs[0].replaceWith(...roots)
+    for (const paragraph of paragraphs.slice(1)) {
+      paragraph.remove()
+    }
+  }
+
+  #lastItemOf(list) {
+    if (!list.lastElementChild) {
+      list.appendChild(this.doc.createElement("li"))
+    }
+    return list.lastElementChild
+  }
+
+  // Word writes bullets as the raw glyph of the marker font (Symbol's "·",
+  // Wingdings' "§", Courier New's "o") and numbers as the rendered counter
+  // ("1.", "a)", "iv)"). A bare letter with no delimiter after it is Courier
+  // New's bullet, not a counter, so the delimiter is what tells them apart.
+  #officeListTagName(paragraph) {
+    const marker = paragraph.querySelector("[style*='mso-list:Ignore']")
+    const text = marker?.textContent || ""
+
+    if (/\d/.test(text) || /^\(?[A-Za-z]+[.)]/.test(text)) {
+      return "ol"
+    }
+    return "ul"
+  }
+
+  #createOfficeListItem(paragraph) {
+    for (const marker of paragraph.querySelectorAll("[style*='mso-list:Ignore']")) {
+      marker.remove()
+    }
+
+    const item = this.doc.createElement("li")
+    item.append(...paragraph.childNodes)
+    return item
+  }
+
+  #officeListLevel(element) {
+    const match = /mso-list:[^;"']*\blevel(\d+)/.exec(element.getAttribute("style") || "")
+    if (match) {
+      return parseInt(match[1], 10)
+    }
+    return null
   }
 
   // Some sources wrap runs of <li>s in a stray element (e.g. a <div> directly

--- a/src/editor/contents/pasted_content_formatter/office_formatter.js
+++ b/src/editor/contents/pasted_content_formatter/office_formatter.js
@@ -1,0 +1,142 @@
+// Word and Outlook never emit <ul>/<ol>/<li>. They simulate lists with flat
+// paragraphs that declare their depth in an inline `mso-list:l0 level2 lfo1`
+// and carry the bullet or number glyph in a <span style="mso-list:Ignore">.
+// Nothing downstream understands either, so the items land as plain paragraphs
+// with the marker baked into the text. Rebuild real lists from the level each
+// paragraph declares.
+//
+// Everything this reads lives in inline attributes, so it stays correct after
+// the pasted content formatter has dropped Office's style sheet.
+export default class OfficeFormatter {
+  constructor(doc) {
+    this.doc = doc
+  }
+
+  format() {
+    for (const run of this.#listRuns()) {
+      this.#replaceWithLists(run)
+    }
+  }
+
+  // A run is a stretch of Office list paragraphs that are siblings with nothing
+  // but whitespace and Word's conditional comments between them. Anything else
+  // in between (a heading, a plain paragraph) ends one list and starts another.
+  #listRuns() {
+    const runs = []
+    const claimed = new Set()
+
+    for (const paragraph of this.doc.querySelectorAll("p[style*='mso-list']")) {
+      if (claimed.has(paragraph) || this.#listLevel(paragraph) === null) continue
+
+      const run = []
+      let node = paragraph
+      while (node) {
+        run.push(node)
+        claimed.add(node)
+        node = this.#nextListParagraph(node)
+      }
+      runs.push(run)
+    }
+
+    return runs
+  }
+
+  #nextListParagraph(paragraph) {
+    let sibling = paragraph.nextSibling
+    while (sibling && this.#isIgnorableBetweenListParagraphs(sibling)) {
+      sibling = sibling.nextSibling
+    }
+
+    if (sibling && sibling.nodeType === Node.ELEMENT_NODE && this.#listLevel(sibling) !== null) {
+      return sibling
+    }
+
+    return null
+  }
+
+  #isIgnorableBetweenListParagraphs(node) {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      return true
+    }
+    return node.nodeType === Node.TEXT_NODE && node.textContent.trim() === ""
+  }
+
+  // Word numbers levels from 1, but a copied selection often starts partway down
+  // a list, so every paragraph declares level3 with no level1 above it. Anchoring
+  // the run at its own shallowest level is what keeps the result from arriving
+  // needlessly deep.
+  #replaceWithLists(paragraphs) {
+    const levels = paragraphs.map((paragraph) => this.#listLevel(paragraph))
+    const baseLevel = Math.min(...levels)
+    const roots = []
+    const stack = []
+
+    paragraphs.forEach((paragraph, index) => {
+      const depth = levels[index] - baseLevel + 1
+      const tagName = this.#listTagName(paragraph)
+
+      while (stack.length > depth) {
+        stack.pop()
+      }
+      if (stack.length === depth && stack[depth - 1].tagName !== tagName.toUpperCase()) {
+        stack.pop()
+      }
+
+      while (stack.length < depth) {
+        const list = this.doc.createElement(tagName)
+        if (stack.length === 0) {
+          roots.push(list)
+        } else {
+          this.#lastItemOf(stack[stack.length - 1]).appendChild(list)
+        }
+        stack.push(list)
+      }
+
+      stack[stack.length - 1].appendChild(this.#createListItem(paragraph))
+    })
+
+    paragraphs[0].replaceWith(...roots)
+    for (const paragraph of paragraphs.slice(1)) {
+      paragraph.remove()
+    }
+  }
+
+  #lastItemOf(list) {
+    if (!list.lastElementChild) {
+      list.appendChild(this.doc.createElement("li"))
+    }
+    return list.lastElementChild
+  }
+
+  // Word writes bullets as the raw glyph of the marker font (Symbol's "·",
+  // Wingdings' "§", Courier New's "o") and numbers as the rendered counter
+  // ("1.", "a)", "iv)"). A bare letter with no delimiter after it is Courier
+  // New's bullet, not a counter, so the delimiter is what tells them apart.
+  #listTagName(paragraph) {
+    const marker = paragraph.querySelector("[style*='mso-list:Ignore']")
+    const text = marker?.textContent || ""
+
+    if (/\d/.test(text) || /^\(?[A-Za-z]+[.)]/.test(text)) {
+      return "ol"
+    }
+    return "ul"
+  }
+
+  #createListItem(paragraph) {
+    for (const marker of paragraph.querySelectorAll("[style*='mso-list:Ignore']")) {
+      marker.remove()
+    }
+
+    const item = this.doc.createElement("li")
+    item.append(...paragraph.childNodes)
+    return item
+  }
+
+  #listLevel(element) {
+    const match = /mso-list:[^;"']*\blevel(\d+)/.exec(element.getAttribute("style") || "")
+    if (match) {
+      return parseInt(match[1], 10)
+    }
+    return null
+  }
+}

--- a/test/browser/tests/paste/paste_office_lists.test.js
+++ b/test/browser/tests/paste/paste_office_lists.test.js
@@ -1,0 +1,257 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorHtml, startMonitoringConsole } from "../../helpers/assertions.js"
+
+// Word and Outlook never put <ul>/<ol>/<li> on the clipboard. They simulate lists
+// with flat paragraphs: the depth lives in `mso-list:lN levelM lfoK` in the style
+// attribute, and the bullet or number glyph sits in a <span style="mso-list:Ignore">
+// fenced by <![if !supportLists]> conditional comments. The helpers below build
+// that markup the way Word writes it.
+//
+// Word renders a bullet as the raw glyph of its marker font: Symbol's "·" at level
+// one, Courier New's "o" at level two, Wingdings' "§" at level three.
+const SYMBOL_BULLET = "·"
+const COURIER_BULLET = "o"
+const WINGDINGS_BULLET = "§"
+
+const MARKER_GAP = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; "
+
+function wordListParagraph(level, marker, text, { listId = 0, font = "Symbol" } = {}) {
+  const markerSpan =
+    `<span style='font-family:${font};mso-fareast-font-family:${font}'>` +
+    `<span style='mso-list:Ignore'>${marker}` +
+    `<span style='font:7.0pt "Times New Roman"'>${MARKER_GAP}</span>` +
+    `</span></span>`
+
+  return (
+    `<p class=MsoListParagraph style='margin-left:${0.25 * level}in;text-indent:-.25in;` +
+    `mso-list:l${listId} level${level} lfo${listId + 1}'>` +
+    `<![if !supportLists]>${markerSpan}<![endif]>${text}<o:p></o:p></p>`
+  )
+}
+
+function wordParagraph(text) {
+  return `<p class=MsoNormal>${text}<o:p></o:p></p>`
+}
+
+// Word always ships a style sheet alongside the body, including the @list rules that
+// describe each level. Keeping it here proves the rebuild works with the sheet present
+// and does not depend on it surviving — Office style sheets are stripped on paste.
+function wordDocument(...body) {
+  return `<html xmlns:o="urn:schemas-microsoft-com:office:office"
+xmlns:w="urn:schemas-microsoft-com:office:word"
+xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=ProgId content=Word.Document>
+<meta name=Generator content="Microsoft Word 15">
+<style>
+<!--
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+\t{margin:0in;
+\tfont-size:12.0pt;
+\tfont-family:"Calibri",sans-serif;
+\tcolor:black;}
+p.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph
+\t{margin-left:.5in;
+\tfont-size:12.0pt;
+\tfont-family:"Calibri",sans-serif;}
+@list l0:level1
+\t{mso-level-number-format:bullet;
+\tmso-level-text:\\F0B7;
+\ttext-indent:-.25in;
+\tfont-family:Symbol;}
+-->
+</style>
+</head>
+<body lang=EN-US style='tab-interval:.5in;word-wrap:break-word'>
+<div class=WordSection1>
+${body.join("\n")}
+</div>
+</body>
+</html>`
+}
+
+async function assertWordPasteBecomes(page, editor, body, expectedHtml) {
+  await page.goto("/")
+  await editor.waitForConnected()
+  startMonitoringConsole(page)
+
+  await editor.setValue("<p></p>")
+  await editor.focus()
+
+  await editor.paste("ignored", { html: wordDocument(...body) })
+  await editor.flush()
+
+  await assertEditorHtml(editor, expectedHtml)
+  expect(page).toHaveNoErrors()
+}
+
+test.describe("Paste a Word/Outlook bulleted list", () => {
+  test("rebuilds a flat bulleted list into a real <ul>", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, SYMBOL_BULLET, "First item"),
+        wordListParagraph(1, SYMBOL_BULLET, "Second item"),
+      ],
+      '<ul><li value="1">First item</li><li value="2">Second item</li></ul>',
+    )
+  })
+
+  test("nests each bulleted level under the item above it", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, SYMBOL_BULLET, "First item"),
+        wordListParagraph(2, COURIER_BULLET, "Nested item", { font: "Courier New" }),
+        wordListParagraph(3, WINGDINGS_BULLET, "Deeply nested item", { font: "Wingdings" }),
+        wordListParagraph(1, SYMBOL_BULLET, "Second item"),
+      ],
+      '<ul><li value="1">First item<ul><li value="1">Nested item' +
+        '<ul><li value="1">Deeply nested item</li></ul></li></ul></li>' +
+        '<li value="2">Second item</li></ul>',
+    )
+  })
+
+  test("treats Courier New's bare \"o\" marker as a bullet, not a counter", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [ wordListParagraph(1, COURIER_BULLET, "An item", { font: "Courier New" }) ],
+      '<ul><li value="1">An item</li></ul>',
+    )
+  })
+})
+
+test.describe("Paste a Word/Outlook numbered list", () => {
+  test("rebuilds a flat numbered list into a real <ol>", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, "1.", "First item"),
+        wordListParagraph(1, "2.", "Second item"),
+      ],
+      '<ol><li value="1">First item</li><li value="2">Second item</li></ol>',
+    )
+  })
+
+  test("nests numbered levels through Word's letter and roman counters", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, "1)", "First item"),
+        wordListParagraph(2, "a)", "Nested item"),
+        wordListParagraph(3, "iv)", "Deeply nested item"),
+        wordListParagraph(1, "2)", "Second item"),
+      ],
+      '<ol><li value="1">First item<ol><li value="1">Nested item' +
+        '<ol><li value="1">Deeply nested item</li></ol></li></ol></li>' +
+        '<li value="2">Second item</li></ol>',
+    )
+  })
+
+  test("keeps a bulleted sublist under a numbered parent", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, "1.", "First item"),
+        wordListParagraph(2, WINGDINGS_BULLET, "Nested bullet", { font: "Wingdings" }),
+        wordListParagraph(1, "2.", "Second item"),
+      ],
+      '<ol><li value="1">First item<ul><li value="1">Nested bullet</li></ul></li>' +
+        '<li value="2">Second item</li></ol>',
+    )
+  })
+
+  test("starts a new list when the marker switches type at the same level", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, "1.", "Numbered item"),
+        wordListParagraph(1, SYMBOL_BULLET, "Bulleted item"),
+      ],
+      '<ol><li value="1">Numbered item</li></ol><ul><li value="1">Bulleted item</li></ul>',
+    )
+  })
+})
+
+test.describe("Paste a Word/Outlook list copied out of context", () => {
+  // This is the shape that made the pasted result look absurdly deep: copying a
+  // fragment out of the middle of a document yields paragraphs that all declare
+  // level3 with no level1 or level2 above them.
+  test("anchors a selection copied from deep inside a list at the top level", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(3, WINGDINGS_BULLET, "First item", { font: "Wingdings" }),
+        wordListParagraph(3, WINGDINGS_BULLET, "Second item", { font: "Wingdings" }),
+        wordListParagraph(4, SYMBOL_BULLET, "Nested item"),
+      ],
+      '<ul><li value="1">First item</li><li value="2">Second item' +
+        '<ul><li value="1">Nested item</li></ul></li></ul>',
+    )
+  })
+
+  test("starts a separate list for each run split by a plain paragraph", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        wordListParagraph(1, SYMBOL_BULLET, "First item"),
+        wordParagraph("An explanation"),
+        wordListParagraph(1, SYMBOL_BULLET, "Second item"),
+      ],
+      '<ul><li value="1">First item</li></ul><p>An explanation</p>' +
+        '<ul><li value="1">Second item</li></ul>',
+    )
+  })
+
+  test("leaves paragraphs that declare no list level alone", async ({ page, editor }) => {
+    await assertWordPasteBecomes(
+      page,
+      editor,
+      [
+        `<p class=MsoNormal style='margin-left:.5in;mso-list:none'>Not a list item<o:p></o:p></p>`,
+        wordParagraph("Another paragraph"),
+      ],
+      "<p>Not a list item</p><p>Another paragraph</p>",
+    )
+  })
+})
+
+test.describe("Paste a Word/Outlook list — leftovers", () => {
+  test("drops the marker glyphs and Word's indentation", async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+    startMonitoringConsole(page)
+
+    await editor.setValue("<p></p>")
+    await editor.focus()
+
+    await editor.paste("ignored", {
+      html: wordDocument(
+        wordListParagraph(1, "1.", "First item"),
+        wordListParagraph(2, COURIER_BULLET, "Nested item", { font: "Courier New" }),
+        wordListParagraph(3, WINGDINGS_BULLET, "Deeply nested item", { font: "Wingdings" }),
+      ),
+    })
+    await editor.flush()
+
+    const value = await editor.value()
+    expect(value).not.toContain(SYMBOL_BULLET)
+    expect(value).not.toContain(WINGDINGS_BULLET)
+    expect(value).not.toContain("margin-left")
+    expect(value).not.toContain("text-indent")
+    expect(value).not.toContain("mso-list")
+    expect(value).not.toContain("&nbsp;")
+    expect(page).toHaveNoErrors()
+  })
+})


### PR DESCRIPTION
Pasting a bulleted or numbered list from Word or Outlook produced no list at all. Every item arrived as a plain paragraph with the bullet glyph baked into the text — `<p>·&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; First item</p>` — and all nesting was flattened.

Word and Outlook never put `<ul>`/`<ol>`/`<li>` on the clipboard. They simulate lists with flat paragraphs that declare their depth in an inline `mso-list:l0 level2 lfo1`, and carry the marker glyph in a `<span style="mso-list:Ignore">`:

```html
<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;mso-list:l0 level2 lfo1'>
<![if !supportLists]><span style='font-family:Symbol'><span style='mso-list:Ignore'>·<span
style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp; </span></span></span><![endif]>First item</p>
```

`PastedContentFormatter`'s existing list repairs (`#unwrapWrappedListChildren`, `#nestStrayListChildren`, `#stripStrayListChildren`) all start from `doc.querySelectorAll("ol, ul")`, so for Word content none of them ever run. There was no handling of `mso-list` anywhere in the repo.

## What this does

Adds `#rebuildOfficeLists()`, which runs before the existing repairs so the reconstructed lists still get the same hygiene pass. It groups contiguous `mso-list` paragraphs into runs, reads the `level` each one declares, and rebuilds real nested `<ul>`/`<ol>`/`<li>`, dropping the marker span as it goes.

Two details worth calling out:

- **Bullet vs. number** is decided from the marker glyph. Word writes bullets as the raw glyph of the marker font (Symbol's `·`, Wingdings' `§`, Courier New's `o`) and numbers as the rendered counter (`1.`, `a)`, `iv)`). Note that Courier New's level-two bullet is a bare letter `o`, so a trailing delimiter — not "is it alphanumeric" — is what separates a counter from a bullet.
- **Each run is anchored at its own shallowest level.** A selection copied out of the middle of a document has every paragraph declaring `level3` with nothing above it. Taking those levels literally is what produced the absurdly deep indentation in the report; normalising per run is what fixes it.

## Keeping Office paste compatibility intact

`#stripStyleElements` exists because of the Excel colour-bleed bug (Excel ships a `<style>` block whose `td { color: black }` rules cascade onto pasted cells and don't adapt to dark mode). The obvious way to learn whether a Word level is bulleted or numbered is the `@list l0:level1 { mso-level-number-format:bullet }` rule in that same `<style>` block — which would have meant keeping the stylesheet around and regressing that fix.

So this reads nothing from `<style>`. Everything it needs — the `mso-list` declaration and the marker glyph — lives in inline attributes on the paragraphs, which `#stripStyleElements` never touches. The two fixes are independent, and the ordering in `format()` is unchanged.

Verified rather than assumed: the full `table_cell_styles.test.js` suite still passes, including the case that pastes a real Excel clipboard payload complete with its `<style>` block and asserts no cascaded colour survives. The Word fixtures in the new tests also carry a Word `<style>` block with `@list` rules, which proves the rebuild works with the stylesheet present *and* does not depend on it surviving.

## Tests

`test/browser/tests/paste/paste_office_lists.test.js` covers single-level and multi-level bulleted and numbered lists, a bulleted sublist under a numbered parent, a marker type switch at the same level, a selection copied from deep inside a list, runs split by a plain paragraph, paragraphs declaring `mso-list:none`, and the absence of leftover glyphs and `margin-left`/`text-indent`. Ten of the eleven fail on `main` and pass here; the eleventh (`mso-list:none` paragraphs stay paragraphs) passes both ways on purpose, as a guard that the new pass is scoped.

## On the fixture's fidelity

Worth being explicit, since it bounds how much this proves: the Help Scout case contained only a screenshot and the source `.docx`, not a clipboard capture, and there is no Word or Outlook on this machine. So the Word clipboard HTML used to reproduce the bug was **constructed**, not captured — generated from the customer document's own `word/document.xml` and `word/numbering.xml` (level formats, marker glyphs and fonts, indent geometry) into the clipboard shape Word is documented to emit.

That reproduces the reported symptom exactly (65 list paragraphs → 0 lists, marker glyphs inlined as text) and the fix turns it into 65 correctly nested `<li>`s across 6 `<ul>`s and 19 `<ol>`s. But a hand-built fixture is weaker evidence than a captured one: it confirms the shape I modelled is handled, not that it is byte-identical to every Word and Outlook version. A verification paste from a real Windows Word/Outlook would be worth doing before this is considered closed.

The committed fixtures use neutral placeholder content — the customer document is a university's meeting minutes, so only its *structure* informed the tests.

---

Card: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/10126744106
