### PR TITLE
Render emphasis upright inside italic blockquotes

### DIFF
--- a/app/assets/stylesheets/lexxy-content.css
+++ b/app/assets/stylesheets/lexxy-content.css
@@ -77,6 +77,11 @@
     margin: var(--lexxy-content-margin) 0;
     padding: 0.5lh 2ch;
 
+    em,
+    .lexxy-content__italic {
+      font-style: normal;
+    }
+
     p:last-child {
       margin-block-end: 0;
     }

--- a/test/browser/tests/formatting/blockquote_nested_emphasis.test.js
+++ b/test/browser/tests/formatting/blockquote_nested_emphasis.test.js
@@ -22,8 +22,10 @@ test.describe("Emphasis inside blockquotes", () => {
     await editor.setValue("<blockquote><p>Quoted <strong><em>emphasized</em></strong> text</p></blockquote>")
     await editor.flush()
 
+    const paragraph = editor.content.locator("blockquote p")
     const emphasis = editor.content.locator("blockquote .lexxy-content__italic")
 
+    await expect(paragraph).toHaveCSS("font-style", "italic")
     await expect(emphasis).toHaveCSS("font-style", "normal")
   })
 })

--- a/test/browser/tests/formatting/blockquote_nested_emphasis.test.js
+++ b/test/browser/tests/formatting/blockquote_nested_emphasis.test.js
@@ -1,0 +1,29 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+test.describe("Emphasis inside blockquotes", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("renders emphasized text upright inside an italic blockquote", async ({ editor }) => {
+    await editor.setValue("<blockquote><p>Quoted <em>emphasized</em> text</p></blockquote>")
+    await editor.flush()
+
+    const paragraph = editor.content.locator("blockquote p")
+    const emphasis = editor.content.locator("blockquote em")
+
+    await expect(paragraph).toHaveCSS("font-style", "italic")
+    await expect(emphasis).toHaveCSS("font-style", "normal")
+  })
+
+  test("renders bold emphasized text upright inside an italic blockquote", async ({ editor }) => {
+    await editor.setValue("<blockquote><p>Quoted <strong><em>emphasized</em></strong> text</p></blockquote>")
+    await editor.flush()
+
+    const emphasis = editor.content.locator("blockquote .lexxy-content__italic")
+
+    await expect(emphasis).toHaveCSS("font-style", "normal")
+  })
+})


### PR DESCRIPTION
Fixes #939

Blockquotes are styled `font-style: italic`, and `.lexxy-content__italic` applies the same style — so `<em>` inside a quote is visually indistinguishable from the surrounding text. This follows the standard typographic convention of flipping nested emphasis back to upright so it stands out by contrast.

The new rule targets both:

- plain `<em>` tags — exported Action Text content carries semantic tags, and hand-authored/imported HTML may have no classes at all
- `.lexxy-content__italic` — the editor theme class, which also covers bold+italic runs that render as `<strong class="…__italic">` with no `<em>` element

Nesting stays inside the existing `:where(.lexxy-content)` wrapper, so consumer overrides keep working the same way they do for the other blockquote rules.

## Tests

Added a Playwright test asserting the computed `font-style` of emphasis inside a blockquote is `normal` while the quote itself stays `italic`, for both the plain-emphasis and bold+italic cases. The test fails on `main` and passes with this change.

Ran the full Playwright suite on Chromium (609 passed) and Firefox for this test; WebKit couldn't launch locally (missing system libraries), so relying on CI for that project. `yarn lint` is clean.