### PR TITLE
Strip the presentational trailing newline when importing code blocks

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -18,7 +18,7 @@ import { HorizontalDividerNode } from "../nodes/horizontal_divider_node"
 import { UploadRequests } from "../editor/attachments/upload_requests"
 import { CommandDispatcher } from "../editor/command_dispatcher"
 import Selection from "../editor/selection"
-import { createElement, dispatch, generateDomId, parseHtml } from "../helpers/html_helper"
+import { createElement, dispatch, generateDomId, parseHtml, stripTrailingCodeBlockNewlines } from "../helpers/html_helper"
 import { isAttachmentSpacerTextNode, isEditorFocused } from "../helpers/lexical_helper"
 import { sanitize, setSanitizerConfig } from "../helpers/sanitization_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
@@ -242,6 +242,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   $generateNodesFromDOM(doc, { editor = this.editor } = {}) {
+    stripTrailingCodeBlockNewlines(doc)
     let nodes = $generateLexicalNodesFromDOM(editor, doc)
     if ($hasUpdateTag(PASTE_TAG)) nodes = $convertInlineImageDataURIs(nodes, this)
     return filterDisallowedAttachmentNodes(nodes, this)

--- a/src/helpers/html_helper.js
+++ b/src/helpers/html_helper.js
@@ -53,6 +53,27 @@ export function addBlockSpacing(doc) {
   }
 }
 
+// A trailing newline before </pre> is presentational — markdown renderers routinely
+// emit one, and the HTML spec similarly disregards a leading newline right after <pre>.
+// Left in place, it imports as a spurious blank last line in the code block.
+export function stripTrailingCodeBlockNewlines(doc) {
+  for (const pre of doc.querySelectorAll("pre")) {
+    const lastText = lastTextNodeIn(pre)
+    if (lastText && lastText.nodeValue.endsWith("\n")) {
+      lastText.nodeValue = lastText.nodeValue.slice(0, -1)
+    }
+  }
+}
+
+function lastTextNodeIn(element) {
+  const walker = element.ownerDocument.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let lastTextNode = null
+  while (walker.nextNode()) {
+    lastTextNode = walker.currentNode
+  }
+  return lastTextNode
+}
+
 export function generateDomId(prefix) {
   const randomPart = Math.random().toString(36).slice(2, 10)
   return `${prefix}-${randomPart}`

--- a/src/helpers/html_helper.js
+++ b/src/helpers/html_helper.js
@@ -66,7 +66,7 @@ export function stripTrailingCodeBlockNewlines(doc) {
 }
 
 function lastTextNodeIn(element) {
-  const walker = element.ownerDocument.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  const walker = element.ownerDocument.createTreeWalker(element, 4 /* NodeFilter.SHOW_TEXT */)
   let lastTextNode = null
   while (walker.nextNode()) {
     lastTextNode = walker.currentNode

--- a/test/browser/tests/formatting/code_block_trailing_newline.test.js
+++ b/test/browser/tests/formatting/code_block_trailing_newline.test.js
@@ -1,0 +1,39 @@
+import { test } from "../../test_helper.js"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Code block trailing newline", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("importing a pre with a trailing newline does not add a blank last line", async ({ editor }) => {
+    await editor.setValue("<pre data-language=\"plain\">Last updated: today\n</pre>")
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      "<pre data-language=\"plain\" data-highlight-language=\"plain\">Last updated: today</pre>",
+    )
+  })
+
+  test("importing a multi-line pre with a trailing newline keeps interior line breaks", async ({ editor }) => {
+    await editor.setValue("<pre data-language=\"plain\">line one\nline two\n</pre>")
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      "<pre data-language=\"plain\" data-highlight-language=\"plain\">line one<br>line two</pre>",
+    )
+  })
+
+  test("importing a pre without a trailing newline stays unchanged", async ({ editor }) => {
+    await editor.setValue("<pre data-language=\"plain\">line one\nline two</pre>")
+    await editor.flush()
+
+    await assertEditorHtml(
+      editor,
+      "<pre data-language=\"plain\" data-highlight-language=\"plain\">line one<br>line two</pre>",
+    )
+  })
+})

--- a/test/javascript/unit/helpers/html_helper.test.js
+++ b/test/javascript/unit/helpers/html_helper.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest"
-import { addBlockSpacing, parseHtml } from "src/helpers/html_helper"
+import { addBlockSpacing, parseHtml, stripTrailingCodeBlockNewlines } from "src/helpers/html_helper"
 
 function bodyHtml(doc) {
   return doc.body.innerHTML
@@ -75,4 +75,40 @@ test("does not add leading spacer", () => {
   const doc = parseHtml("<p>a</p><p>b</p>")
   addBlockSpacing(doc)
   expect(doc.body.firstElementChild.innerHTML).toBe("a")
+})
+
+test("strips a single trailing newline from a code block", () => {
+  const doc = parseHtml("<pre>line one\nline two\n</pre>")
+  stripTrailingCodeBlockNewlines(doc)
+  expect(bodyHtml(doc)).toBe("<pre>line one\nline two</pre>")
+})
+
+test("strips only one trailing newline, keeping deliberate blank lines", () => {
+  const doc = parseHtml("<pre>content\n\n</pre>")
+  stripTrailingCodeBlockNewlines(doc)
+  expect(bodyHtml(doc)).toBe("<pre>content\n</pre>")
+})
+
+test("leaves code blocks without a trailing newline unchanged", () => {
+  const doc = parseHtml("<pre>content</pre>")
+  stripTrailingCodeBlockNewlines(doc)
+  expect(bodyHtml(doc)).toBe("<pre>content</pre>")
+})
+
+test("strips the trailing newline from the last text node inside nested markup", () => {
+  const doc = parseHtml("<pre><code>first\n<span>last\n</span></code></pre>")
+  stripTrailingCodeBlockNewlines(doc)
+  expect(bodyHtml(doc)).toBe("<pre><code>first\n<span>last</span></code></pre>")
+})
+
+test("handles empty code blocks", () => {
+  const doc = parseHtml("<pre></pre>")
+  stripTrailingCodeBlockNewlines(doc)
+  expect(bodyHtml(doc)).toBe("<pre></pre>")
+})
+
+test("does not touch text outside code blocks", () => {
+  const doc = parseHtml("<p>text\n</p><pre>code\n</pre>")
+  stripTrailingCodeBlockNewlines(doc)
+  expect(bodyHtml(doc)).toBe("<p>text\n</p><pre>code</pre>")
 })


### PR DESCRIPTION
Fixes #917

Markdown renderers like Redcarpet emit `<pre>` blocks whose text content ends with a newline before the closing tag. Lexical imports that newline as an extra code line, so the editor showed a spurious blank line (`<br><br>`) at the end of every imported code block.

## The fix

`stripTrailingCodeBlockNewlines(doc)` (in `html_helper.js`, alongside the existing `addBlockSpacing` DOM-preprocessing helper) trims a single trailing newline from the last text node of each `<pre>` in the parsed document. It runs in `editor.$generateNodesFromDOM`, the single choke point all import paths share (initial value, `setValue`, paste, prompt templates).

This mirrors how the HTML spec disregards a leading newline right after `<pre>` — the trailing one is presentational, not content. Only one newline is trimmed, so interior line breaks and deliberate blank lines beyond the final one survive unchanged.

## Tests

- Playwright (`test/browser/tests/formatting/code_block_trailing_newline.test.js`): importing a `<pre>` with a trailing newline yields no blank last line; interior line breaks are kept; a `<pre>` without a trailing newline is untouched. The first two fail on `main` and pass with this change.
- Vitest (`test/javascript/unit/helpers/html_helper.test.js`): unit coverage of the helper, including nested markup inside `<pre>`, the keep-deliberate-blank-lines case, and empty code blocks.

Full Playwright suite passes on Chromium (621) and the new tests on Firefox too; WebKit couldn't launch locally (missing system libraries), so relying on CI for that project. `yarn lint` and `yarn test` are clean.