### PR TITLE
Keep Shift+Enter line breaks in list items across save and reload

### DIFF
--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -13,6 +13,7 @@ export default class PastedContentFormatter {
     this.#unwrapWrappedListChildren()
     this.#nestStrayListChildren()
     this.#stripStrayListChildren()
+    this.#stripFillerListItemLineBreaks()
     return this.doc
   }
 
@@ -107,6 +108,16 @@ export default class PastedContentFormatter {
 
         stray = this.#firstStrayListChild(list)
       }
+    }
+  }
+
+  // Browsers pad copied list items with a filler <br> at the end of each <li>.
+  // The editor preserves trailing list item line breaks on import — in saved
+  // documents they are real Shift+Enter content — so pasted filler has to be
+  // dropped here before it reaches the importer.
+  #stripFillerListItemLineBreaks() {
+    for (const lineBreak of this.doc.querySelectorAll("li > br:last-child")) {
+      lineBreak.remove()
     }
   }
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -19,7 +19,7 @@ import { UploadRequests } from "../editor/attachments/upload_requests"
 import { CommandDispatcher } from "../editor/command_dispatcher"
 import Selection from "../editor/selection"
 import { createElement, dispatch, generateDomId, parseHtml } from "../helpers/html_helper"
-import { isAttachmentSpacerTextNode, isEditorFocused } from "../helpers/lexical_helper"
+import { importListItemTrailingLineBreak, isAttachmentSpacerTextNode, isEditorFocused } from "../helpers/lexical_helper"
 import { sanitize, setSanitizerConfig } from "../helpers/sanitization_helper"
 import { ListenerBin, registerEventListener } from "../helpers/listener_helper"
 import LexicalToolbar from "./toolbar"
@@ -426,7 +426,8 @@ export class LexicalEditorElement extends HTMLElement {
       theme: theme,
       nodes: this.#lexicalNodes,
       html: {
-        export: new Map([ [ TextNode, exportTextNodeDOM ], [ CodeHighlightNode, exportTextNodeDOM ] ])
+        export: new Map([ [ TextNode, exportTextNodeDOM ], [ CodeHighlightNode, exportTextNodeDOM ] ]),
+        import: { br: importListItemTrailingLineBreak }
       },
       $initialEditorState: (editor) => {
         this.#configureSanitizer(editor)

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -1,4 +1,4 @@
-import { $caretFromPoint, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getRoot, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $normalizeSelection__EXPERIMENTAL as $normalizeSelection, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
+import { $caretFromPoint, $createLineBreakNode, $createNodeSelection, $createParagraphNode, $findMatchingParent, $getCaretInDirection, $getCaretRange, $getChildCaret, $getCommonAncestor, $getRoot, $getSelection, $getSiblingCaret, $isChildCaret, $isDecoratorNode, $isElementNode, $isExtendableTextPointCaret, $isLineBreakNode, $isParagraphNode, $isRangeSelection, $isRootNode, $isRootOrShadowRoot, $isSiblingCaret, $isTextNode, $isTextPointCaret, $normalizeCaret, $normalizeSelection__EXPERIMENTAL as $normalizeSelection, $rewindSiblingCaret, $setSelectionFromCaretRange, $splitAtPointCaretNext, TextNode } from "lexical"
 import { ListNode } from "@lexical/list"
 import { $getNearestNodeOfType, $lastToFirstIterator } from "@lexical/utils"
 import { $wrapNodeInElement } from "@lexical/utils"
@@ -92,6 +92,24 @@ export function extendConversion(nodeKlass, conversionName, callback = (output =
 
     return callback(conversionOutput, element) ?? conversionOutput
   }
+}
+
+// Lexical drops a <br> that ends a block element on import, treating it as
+// contenteditable filler. A line break at the end of a list item is real content
+// the user added with Shift+Enter, so keep it. A <br> that is a list item's only
+// child stays subject to the default filler rules.
+export function importListItemTrailingLineBreak(domNode) {
+  if (isTrailingLineBreakAfterListItemContent(domNode)) {
+    return { conversion: () => ({ node: $createLineBreakNode() }), priority: 1 }
+  }
+
+  return null
+}
+
+function isTrailingLineBreakAfterListItemContent(domNode) {
+  const parent = domNode.parentElement
+  return parent !== null && parent.tagName === "LI" &&
+    domNode.nextSibling === null && domNode.previousSibling !== null
 }
 
 export function $isCursorOnLastLine(selection) {

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -108,8 +108,29 @@ export function importListItemTrailingLineBreak(domNode) {
 
 function isTrailingLineBreakAfterListItemContent(domNode) {
   const parent = domNode.parentElement
-  return parent !== null && parent.tagName === "LI" &&
-    domNode.nextSibling === null && domNode.previousSibling !== null
+  if (parent === null || parent.tagName !== "LI" || domNode.nextSibling !== null) {
+    return false
+  }
+
+  return hasListItemContentBefore(domNode)
+}
+
+function hasListItemContentBefore(domNode) {
+  let sibling = domNode.previousSibling
+  while (sibling !== null) {
+    if (isListItemContent(sibling)) {
+      return true
+    }
+    sibling = sibling.previousSibling
+  }
+  return false
+}
+
+function isListItemContent(node) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent.trim() !== ""
+  }
+  return node.nodeType === Node.ELEMENT_NODE && node.tagName !== "BR"
 }
 
 export function $isCursorOnLastLine(selection) {

--- a/test/browser/tests/formatting/list_item_line_breaks.test.js
+++ b/test/browser/tests/formatting/list_item_line_breaks.test.js
@@ -1,0 +1,47 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorHtml } from "../../helpers/assertions.js"
+
+test.describe("Line breaks inside list items", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("a Shift+Enter line break at the end of a list item survives a value round-trip", async ({ editor }) => {
+    await editor.setValue("<ul><li value=\"1\">First</li><li value=\"2\">Second</li><li value=\"3\">Third</li></ul>")
+    await editor.flush()
+
+    await editor.placeCaretInside("First", "First".length)
+    await editor.send("Shift+Enter")
+
+    const saved = await editor.value()
+    expect(saved).toContain("<br>")
+
+    await editor.setValue(saved)
+    await editor.flush()
+
+    await assertEditorHtml(editor, saved)
+  })
+
+  test("importing a list item with a trailing line break keeps it", async ({ editor }) => {
+    await editor.setValue("<ul><li value=\"1\">First<br></li><li value=\"2\">Second</li></ul>")
+    await editor.flush()
+
+    await assertEditorHtml(editor, "<ul><li value=\"1\">First<br></li><li value=\"2\">Second</li></ul>")
+  })
+
+  test("importing a list item with a blank line keeps it", async ({ editor }) => {
+    await editor.setValue("<ul><li value=\"1\">First<br><br></li><li value=\"2\">Second</li></ul>")
+    await editor.flush()
+
+    await assertEditorHtml(editor, "<ul><li value=\"1\">First<br><br></li><li value=\"2\">Second</li></ul>")
+  })
+
+  test("a filler line break in an empty list item is still dropped", async ({ editor }) => {
+    await editor.setValue("<ul><li value=\"1\"><br></li><li value=\"2\">Second</li></ul>")
+    await editor.flush()
+
+    await assertEditorHtml(editor, "<ul><li value=\"1\"></li><li value=\"2\">Second</li></ul>")
+  })
+})

--- a/test/browser/tests/formatting/list_item_line_breaks.test.js
+++ b/test/browser/tests/formatting/list_item_line_breaks.test.js
@@ -38,6 +38,13 @@ test.describe("Line breaks inside list items", () => {
     await assertEditorHtml(editor, "<ul><li value=\"1\">First<br><br></li><li value=\"2\">Second</li></ul>")
   })
 
+  test("a filler line break preceded only by whitespace is still dropped", async ({ editor }) => {
+    await editor.setValue("<ul><li value=\"1\">\n    <br></li><li value=\"2\">Second</li></ul>")
+    await editor.flush()
+
+    await assertEditorHtml(editor, "<ul><li value=\"1\"></li><li value=\"2\">Second</li></ul>")
+  })
+
   test("a filler line break in an empty list item is still dropped", async ({ editor }) => {
     await editor.setValue("<ul><li value=\"1\"><br></li><li value=\"2\">Second</li></ul>")
     await editor.flush()


### PR DESCRIPTION
Fixes #1004

Line breaks added with Shift+Enter at the end of a list item were silently dropped when a saved document was re-opened in the editor. The editor exports the break as `<li>First<br></li>`, but Lexical's `LineBreakNode.importDOM` refuses to convert a `<br>` that is the last child of a block element — it assumes contenteditable filler — so every save/reload cycle collapsed the spacing between list items.

## The fix

- **`html.import` override for `br`** (`importListItemTrailingLineBreak` in `lexical_helper.js`, registered in the editor config next to the existing `html.export` overrides): a trailing `<br>` inside a `<li>` that *follows actual content* converts to a real `LineBreakNode`. A `<br>` that is the item's only child stays subject to Lexical's default filler rules, so empty items keep their canonical `<li></li>` form.
- **Paste keeps its existing canonicalization**: pasted browser HTML really does pad copied list items with a filler `<br>`, and `test/browser/tests/paste/clean_invalid_pasted_list_html.test.js` codifies stripping it. `PastedContentFormatter` now removes `li > br:last-child` before import, so paste behavior is unchanged — only the load/re-edit path preserves the break.

## Tests

`test/browser/tests/formatting/list_item_line_breaks.test.js`:

- a Shift+Enter break typed at the end of a list item survives a full value round-trip (save → `setValue` → compare), reproducing the exact steps from the issue
- importing `<li>First<br></li>` and `<li>First<br><br></li>` keeps the breaks
- a filler `<br>` in an empty list item is still dropped

The first three fail on `main` and pass with this change. Full Playwright suite passes on Chromium (622, including all existing paste-cleanup tests) and the new tests on Firefox; WebKit couldn't launch locally (missing system libraries), so relying on CI for that project. `yarn lint` and `yarn test` (126) are clean.