### PR TITLE
Replace pasted Gmail emojimg tags with emoji text

### DIFF
--- a/src/editor/contents/pasted_content_formatter.js
+++ b/src/editor/contents/pasted_content_formatter.js
@@ -13,6 +13,7 @@ export default class PastedContentFormatter {
     this.#unwrapWrappedListChildren()
     this.#nestStrayListChildren()
     this.#stripStrayListChildren()
+    this.#replaceGmailEmojiImgTags()
     return this.doc
   }
 
@@ -125,5 +126,15 @@ export default class PastedContentFormatter {
 
   #containsListItems(node) {
     return node.nodeType === Node.ELEMENT_NODE && node.querySelector("li") !== null
+  }
+
+  // Emoji in gmail: <img data-emoji="😂" class="an1" alt="😂" aria-label="😂" draggable="false" src="https://fonts.gstatic.com/s/e/notoemoji/17.0/1f602/32.png" loading="lazy" style="height: 1.2em; width: 1.2em; vertical-align: middle;">
+  #replaceGmailEmojiImgTags() {
+    for (const emojiImg of this.doc.querySelectorAll("img[data-emoji]")) {
+      const emoji = emojiImg.dataset.emoji
+      if (emoji === emojiImg.alt) {
+        emojiImg.replaceWith(emoji)
+      }
+    }
   }
 }

--- a/test/browser/tests/paste/gmail_emoji.test.js
+++ b/test/browser/tests/paste/gmail_emoji.test.js
@@ -1,0 +1,44 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent, assertEditorHtml, startMonitoringConsole } from "../../helpers/assertions.js"
+
+function gmailEmojiImg(emoji, { alt = emoji, src = "https://fonts.gstatic.com/s/e/notoemoji/17.0/1f602/32.png" } = {}) {
+  return `<img data-emoji="${emoji}" class="an1" alt="${alt}" aria-label="${emoji}" draggable="false" src="${src}" loading="lazy" style="height: 1.2em; width: 1.2em; vertical-align: middle;">`
+}
+
+async function pasteHtml(page, editor, html) {
+  await page.goto("/")
+  await editor.waitForConnected()
+  startMonitoringConsole(page)
+
+  await editor.setValue("<p></p>")
+  await editor.focus()
+
+  await editor.paste("ignored", { html })
+  await editor.flush()
+}
+
+test.describe("Paste Gmail emoji images", () => {
+  test("replaces a Gmail emoji image with the emoji character", async ({ page, editor }) => {
+    await pasteHtml(page, editor, `<p>Hello ${gmailEmojiImg("😂")} world</p>`)
+
+    await assertEditorHtml(editor, "<p>Hello 😂 world</p>")
+    expect(page).toHaveNoErrors()
+  })
+
+  test("replaces multiple Gmail emoji images in the same paste", async ({ page, editor }) => {
+    await pasteHtml(page, editor, `<p>${gmailEmojiImg("😂")} and ${gmailEmojiImg("👍")}</p>`)
+
+    await assertEditorHtml(editor, "<p>😂 and 👍</p>")
+    expect(page).toHaveNoErrors()
+  })
+
+  test("keeps an image whose alt doesn't match its data-emoji", async ({ page, editor }) => {
+    await pasteHtml(page, editor, `<p>Hello ${gmailEmojiImg("😂", { alt: "not an emoji" })}</p>`)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("img")).toHaveCount(1)
+    })
+    expect(page).toHaveNoErrors()
+  })
+})


### PR DESCRIPTION
Gmail substitutes it's own Noto emoji with img tags. When pasted, this creates an <img> remote image attachable rather than the desired emoji.

Added paste sanitization to replace occurences with the canonical emoji for `img` when `data-emoji` and `alt` are both the same.

Gmail emoji sample:
```html
<img data-emoji="😂" class="an1" alt="😂" aria-label="😂"
draggable="false"
src="https://fonts.gstatic.com/s/e/notoemoji/17.0/1f602/32.png"
loading="lazy" style="height: 1.2em; width: 1.2em; vertical-align:
middle;">
```