### PR TITLE
macOS text replacements: catch the deliveries the first fix missed

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -60,20 +60,6 @@ export default class Contents {
     }, { tag })
   }
 
-  // A literal "\n" stays visible in the editor, which Lexical renders with white-space: pre-wrap,
-  // but collapses to a space once serialized to HTML, so it has to become line break nodes.
-  insertTextWithLineBreaks(text) {
-    const normalizedText = text?.replace(/\r\n?/g, "\n")
-    const selection = $getSelection()
-
-    if (normalizedText?.includes("\n") && $isRangeSelection(selection)) {
-      selection.insertRawText(normalizedText)
-      return true
-    } else {
-      return false
-    }
-  }
-
   insertAtCursor(...nodes) {
     const selection = this.#insertableSelection()
     const inserter = NodeInserter.for(selection)

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -1,4 +1,4 @@
-import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, CONTROLLED_TEXT_INSERTION_COMMAND, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
+import { $addUpdateTag, $createParagraphNode, $getRoot, $getSelection, $hasUpdateTag, $isElementNode, $isLineBreakNode, $isRangeSelection, $isTextNode, $onUpdate, CAN_REDO_COMMAND, CAN_UNDO_COMMAND, CLEAR_HISTORY_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ENTER_COMMAND, PASTE_TAG, SKIP_DOM_SELECTION_TAG, TextNode } from "lexical"
 import { buildEditorFromExtensions } from "@lexical/extension"
 import { ListItemNode, ListNode, registerList } from "@lexical/list"
 import { AutoLinkNode, LinkNode } from "@lexical/link"
@@ -45,6 +45,7 @@ import { FormatEscapeExtension } from "../extensions/format_escape_extension.js"
 import { LinkOpenerExtension } from "../extensions/link_opener_extension.js"
 import { PreventLexicalTripleClickExtension } from "../extensions/prevent_lexical_triple_click_extension.js"
 import { CustomAttachmentDragAndDropExtension } from "../extensions/custom_attachment_drag_and_drop_extension.js"
+import { LineSeparatorsExtension } from "../extensions/line_separators_extension.js"
 import { nextFrame } from "../helpers/timing_helper.js"
 
 
@@ -206,7 +207,8 @@ export class LexicalEditorElement extends HTMLElement {
       FormatEscapeExtension,
       LinkOpenerExtension,
       PreventLexicalTripleClickExtension,
-      CustomAttachmentDragAndDropExtension
+      CustomAttachmentDragAndDropExtension,
+      LineSeparatorsExtension
     ]
   }
 
@@ -394,7 +396,6 @@ export class LexicalEditorElement extends HTMLElement {
   #initialize() {
     this.#registerComponents()
     this.#handleEnter()
-    this.#handleReplacementText()
     this.#registerFocusEvents()
     this.#registerHistoryEvents()
     this.#registerFileAcceptFilter()
@@ -654,14 +655,6 @@ export class LexicalEditorElement extends HTMLElement {
 
         return false
       },
-      COMMAND_PRIORITY_NORMAL
-    ))
-  }
-
-  #handleReplacementText() {
-    this.#listeners.track(this.editor.registerCommand(
-      CONTROLLED_TEXT_INSERTION_COMMAND,
-      (event) => event instanceof InputEvent && this.contents.insertTextWithLineBreaks(event.data),
       COMMAND_PRIORITY_NORMAL
     ))
   }

--- a/src/extensions/line_separators_extension.js
+++ b/src/extensions/line_separators_extension.js
@@ -1,0 +1,35 @@
+import { $createLineBreakNode, TextNode } from "lexical"
+import LexxyExtension from "./lexxy_extension"
+
+const LINE_SEPARATORS = /\r\n|[\n\r\u2028\u2029]/
+
+// A literal line separator inside a text node renders as a break in the editor, or not at all,
+// but never survives serialization to HTML. macOS text replacements deliver U+2028 LINE SEPARATOR,
+// and other insertions can carry "\n", so however the text arrives, a transform converts whatever
+// lands in a text node into line break nodes.
+export class LineSeparatorsExtension extends LexxyExtension {
+  get lexicalExtension() {
+    return this.defineExtension({
+      name: "lexxy/line-separators",
+      register(editor) {
+        return editor.registerNodeTransform(TextNode, $replaceLineSeparatorWithLineBreak)
+      }
+    })
+  }
+}
+
+// Replaces the first separator only: the split leaves dirty text nodes behind, so Lexical re-runs
+// the transform until none remain.
+function $replaceLineSeparatorWithLineBreak(textNode) {
+  const match = textNode.getTextContent().match(LINE_SEPARATORS)
+
+  if (match) {
+    let separatorNode
+    if (match.index === 0) {
+      [ separatorNode ] = textNode.splitText(match[0].length)
+    } else {
+      [ , separatorNode ] = textNode.splitText(match.index, match.index + match[0].length)
+    }
+    separatorNode.replace($createLineBreakNode())
+  }
+}

--- a/test/javascript/unit/editor/insert_replacement_text.test.js
+++ b/test/javascript/unit/editor/insert_replacement_text.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { $getRoot, $setSelection, CONTROLLED_TEXT_INSERTION_COMMAND } from "lexical"
+import { $getRoot, CONTROLLED_TEXT_INSERTION_COMMAND } from "lexical"
 import { createTestEditor, destroyTestEditor, selectFirstText, setContent, tick } from "../helpers/editor_helper"
 
 // macOS "Keyboard > Text Replacements" (and autocorrect) reach the editor as a beforeinput event
@@ -16,15 +16,6 @@ function nodeTypes(editorElement) {
   return editorElement.editor.read(() => $getRoot().getFirstChild().getChildren().map((node) => node.getType()))
 }
 
-function insertTextWithLineBreaks(editorElement, text) {
-  let result
-  editorElement.editor.update(() => {
-    result = editorElement.contents.insertTextWithLineBreaks(text)
-  }, { discrete: true })
-
-  return result
-}
-
 describe("insertReplacementText", () => {
   test("turns a newline into a line break instead of a literal newline", async () => {
     const editorElement = await createTestEditor()
@@ -36,6 +27,21 @@ describe("insertReplacementText", () => {
     expect(nodeTypes(editorElement)).toEqual([ "text", "linebreak", "text" ])
     expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
     expect(editorElement.value).not.toContain("\n")
+
+    await destroyTestEditor(editorElement)
+  })
+
+  // macOS separates the lines of a multi-line replacement with U+2028 (Option+Return in the
+  // Text Replacements pane), not "\n".
+  test("turns a line separator into a line break", async () => {
+    const editorElement = await createTestEditor()
+    await setContent(editorElement, "<p>Hello</p>")
+    selectFirstText(editorElement, "Hello".length)
+
+    await insertReplacementText(editorElement, " Thanks,\u2028Kyle")
+
+    expect(nodeTypes(editorElement)).toEqual([ "text", "linebreak", "text" ])
+    expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
 
     await destroyTestEditor(editorElement)
   })
@@ -61,36 +67,6 @@ describe("insertReplacementText", () => {
 
     expect(editorElement.value).toBe("<p>Hello Thanks,<br>Kyle</p>")
     expect(editorElement.value).not.toContain("\r")
-
-    await destroyTestEditor(editorElement)
-  })
-
-  // The return value is the command handler's: true stops Lexical, anything falsy lets it insert
-  // the text normally, so every path that does not convert line breaks has to stay falsy.
-  test("reports whether it converted line breaks", async () => {
-    const editorElement = await createTestEditor()
-    await setContent(editorElement, "<p>Hello</p>")
-    selectFirstText(editorElement, "Hello".length)
-
-    expect(insertTextWithLineBreaks(editorElement, " Thanks,\nKyle")).toBe(true)
-    expect(insertTextWithLineBreaks(editorElement, " there")).toBe(false)
-    expect(insertTextWithLineBreaks(editorElement, null)).toBe(false)
-
-    await destroyTestEditor(editorElement)
-  })
-
-  test("reports false without a range selection", async () => {
-    const editorElement = await createTestEditor()
-    await setContent(editorElement, "<p>Hello</p>")
-
-    let result
-    editorElement.editor.update(() => {
-      $setSelection(null)
-      result = editorElement.contents.insertTextWithLineBreaks(" Thanks,\nKyle")
-    }, { discrete: true })
-
-    expect(result).toBe(false)
-    expect(editorElement.value).toBe("<p>Hello</p>")
 
     await destroyTestEditor(editorElement)
   })


### PR DESCRIPTION
Follow-up to #1213

That PR (shipped in 0.9.28) intercepts `CONTROLLED_TEXT_INSERTION_COMMAND` and converts a `"\n"` found in the` InputEvent`'s `data` into line break nodes. We retested that version and confirmed it fixed the problem in Safari, but it continued failing in Chrome. Now, testing this via BrowserStack:

| Delivery | Payload | #1213 | This PR |
|---|---|---|---|
| Chrome `insertReplacementText` | `data` string | fires only on `\n` | converted |
| Chrome macOS replacement via `insertText` | bare **string** command payload | deliberately ignored | converted |
| Any payload carrying **U+2028/U+2029** instead of `\n` | all of the above | passes the `"\n"` check | normalized |
| Uncontrolled insertion reconciled from the DOM | no command at all | unreachable | transform backstop |


**Real Safari 17.3 on macOS Sonoma, genuine OS substitution (Live session):** typing a misspelling and letting real macOS autocorrect fire — WebKit routes autocorrect and Text Replacement through the same `SpellingCorrectionCommand` — produced:

```
beforeinput inputType=insertReplacementText data=[null] dataTransfer(text/plain)=[74 68 65] targetRanges=1
```

`data` is **null**; the replacement text rides in `dataTransfer`. So the shipped fix cannot fire in Safari, matching WebKit source (`SpellingCorrectionCommand::inputEventData()` returns the correction only for textarea/input; for contenteditable it goes into `inputEventDataTransfer()`).

**Real Safari 17.3 + real Chrome 150 on macOS Sonoma (Automate, against the built bundle):**
- Baseline (main): an `insertReplacementText` carrying `U+2028` — in `data` (Chrome shape) or `dataTransfer` (Safari shape) — left a literal U+2028 in the serialized value on **both** browsers: `<p> Thanks,U+2028Kyle...</p>`. With this branch, all shapes serialize to `<p> Thanks,<br>Kyle...</p>`.
- Rendering probes on both engines: a literal `\n` shows as a line break under `white-space: pre-wrap` (the editor) and collapses in normal rendering (the submitted message) — exactly the customer's "right while composing, one line after submit". A literal U+2028 renders as one line in both, and `\n` via Safari's dataTransfer became two `<p>`s even before #1213 — so the reported symptom can only come from the string/`data` shapes, which this PR now covers.

## The fix

- `LexicalEditorElement##insertionTextFrom` extracts the text from all three payload shapes; `dataTransfer` is only consulted for `insertReplacementText`, so drops and yanks keep Lexical's own handling.
- `Contents#insertTextWithLineBreaks` normalizes `U+2028`/`U+2029` alongside CRLF.
- New `LineSeparatorsExtension` registers a `TextNode` transform that converts any literal separator that lands in a text node — through uncontrolled insertions, pastes, or stored content — into a line break node. It also heals previously saved content on re-edit.