### PR TITLE
Keep Tab out of image captions

### DIFF
--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -1,8 +1,8 @@
-import { $getSelection, $isDecoratorNode, $isParagraphNode, $splitNode, COMMAND_PRIORITY_NORMAL, DELETE_CHARACTER_COMMAND, defineExtension } from "lexical"
+import { $getSelection, $isDecoratorNode, $isNodeSelection, $isParagraphNode, $splitNode, COMMAND_PRIORITY_HIGH, COMMAND_PRIORITY_NORMAL, DELETE_CHARACTER_COMMAND, KEY_TAB_COMMAND, defineExtension } from "lexical"
 import { mergeRegister } from "@lexical/utils"
 
 import { $findOrCreateGalleryForImage, $isImageGalleryNode, ImageGalleryNode } from "../nodes/image_gallery_node"
-import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
+import { $isActionTextAttachmentNode, ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 import { ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node.js"
 import { AttachmentDragAndDrop } from "../editor/attachments/drag_and_drop"
 
@@ -39,6 +39,7 @@ export class AttachmentsExtension extends LexxyExtension {
         return mergeRegister(
           editor.registerNodeTransform(ActionTextAttachmentNode, $extractAttachmentFromParagraph),
           editor.registerCommand(DELETE_CHARACTER_COMMAND, $collapseIntoGallery, COMMAND_PRIORITY_NORMAL),
+          editor.registerCommand(KEY_TAB_COMMAND, $focusCaptionFromSelectedAttachment, COMMAND_PRIORITY_HIGH),
           editor.registerMutationListener(ActionTextAttachmentUploadNode, this.#handleUploadMutations.bind(this)),
           () => dragAndDrop.destroy()
         )
@@ -132,6 +133,27 @@ function $collapseAtGalleryEdge(anchor, backwards) {
   if (isAtGalleryEdge && anchorNode.collapseWith(sibling, backwards)) {
     const selectionOffset = backwards ? 1 : anchorNode.getChildrenSize() - 1
     anchorNode.select(selectionOffset, selectionOffset)
+    return true
+  } else {
+    return false
+  }
+}
+
+// Tab from a selected attachment moves focus into its caption textarea. The
+// textarea carries tabIndex -1 so it is no longer reachable by walking the
+// document with Tab; this is the deliberate way back in. Shift+Tab is left
+// alone so it still steps backwards out of the editor.
+function $focusCaptionFromSelectedAttachment(event) {
+  if (event.shiftKey) return false
+
+  const selection = $getSelection()
+  if (!$isNodeSelection(selection)) return false
+
+  const nodes = selection.getNodes()
+  const node = nodes.length === 1 ? nodes[0] : null
+
+  if ($isActionTextAttachmentNode(node) && node.focusCaption()) {
+    event.preventDefault()
     return true
   } else {
     return false

--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -1,6 +1,7 @@
 import Lexxy from "../config/lexxy"
-import { $getEditor, $getNearestRootOrShadowRoot, DecoratorNode, HISTORY_MERGE_TAG } from "lexical"
+import { $getEditor, $getNearestRootOrShadowRoot, $setSelection, DecoratorNode, HISTORY_MERGE_TAG } from "lexical"
 import { createAttachmentFigure, createElement, isPreviewableImage } from "../helpers/html_helper"
+import { $createNodeSelectionWith } from "../helpers/lexical_helper"
 import { bytesToHumanSize, extractFileName } from "../helpers/storage_helper"
 import { parseBoolean } from "../helpers/string_helper"
 import { REWRITE_HISTORY_COMMAND } from "../extensions/rewritable_history_extension"
@@ -217,6 +218,15 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     return this.contentType.startsWith("video/")
   }
 
+  // The caption textarea is deliberately out of the tab order, so this is the
+  // only way in from the keyboard. Returns false when there is no caption to
+  // focus, which lets the Tab handler fall through to default behaviour.
+  focusCaption() {
+    const textarea = this.editor.getElementByKey(this.getKey())?.querySelector("figcaption textarea")
+    textarea?.focus()
+    return textarea != null
+  }
+
   #createDOMForPendingPreview() {
     const figure = this.createAttachmentFigure(false)
     figure.appendChild(this.#createDOMForFile())
@@ -411,6 +421,8 @@ export class ActionTextAttachmentNode extends DecoratorNode {
     const input = createElement("textarea", {
       value: this.caption,
       placeholder: this.fileName,
+      ariaLabel: this.isVideo ? "Video caption" : "Image caption",
+      tabIndex: -1,
       rows: "1"
     })
 
@@ -445,6 +457,20 @@ export class ActionTextAttachmentNode extends DecoratorNode {
       this.editor.update(() => {
         // Place the cursor after the current image
         this.selectNext(0, 0)
+      }, {
+        tag: HISTORY_MERGE_TAG
+      })
+    } else if (event.key === "Escape") {
+      // Leave the caption without moving the caret past the attachment: hand
+      // focus back to the editor and reselect the attachment the caption
+      // belongs to, so Tab can step back in.
+      event.preventDefault()
+      event.target.blur()
+
+      this.editor.getRootElement()?.focus({ preventScroll: true })
+
+      this.editor.update(() => {
+        $setSelection($createNodeSelectionWith(this))
       }, {
         tag: HISTORY_MERGE_TAG
       })

--- a/test/browser/tests/attachments/attachment_caption_focus.test.js
+++ b/test/browser/tests/attachments/attachment_caption_focus.test.js
@@ -1,0 +1,64 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
+
+test.describe("Attachment caption focus", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+    await mockActiveStorageUploads(page)
+  })
+
+  test("Tab past an attachment does not fall into its caption", async ({ page, editor }) => {
+    await editor.uploadFile("test/fixtures/files/example.png")
+    await expect(captionOf(page)).toBeVisible({ timeout: 10_000 })
+
+    // The reported bug: caret in ordinary text, nothing selected, and Tab lands
+    // in an image caption instead of moving on.
+    await editor.focus()
+    await page.keyboard.press("Home")
+    await page.keyboard.type("Hello")
+    await expect(page.locator("figure.attachment.node--selected")).toHaveCount(0)
+
+    await page.keyboard.press("Tab")
+
+    await expect(captionOf(page)).not.toBeFocused()
+  })
+
+  test("Tab from a selected attachment focuses the caption textarea", async ({ page, editor }) => {
+    await editor.uploadFile("test/fixtures/files/example.png")
+
+    const figure = page.locator("figure.attachment")
+    await expect(figure).toBeVisible({ timeout: 10_000 })
+    await selectAttachment(figure)
+
+    await page.keyboard.press("Tab")
+
+    await expect(figure.locator("figcaption textarea")).toBeFocused()
+  })
+
+  test("Escape from caption restores attachment selection and editor focus", async ({ page, editor }) => {
+    await editor.uploadFile("test/fixtures/files/example.png")
+
+    const caption = captionOf(page)
+    await expect(caption).toBeVisible({ timeout: 10_000 })
+
+    await caption.click()
+    await caption.pressSequentially("Hello")
+    await caption.press("Escape")
+
+    await expect(page.locator("figure.attachment.node--selected")).toHaveCount(1)
+    await expect(editor.content).toBeFocused()
+  })
+})
+
+function captionOf(page) {
+  return page.locator("figure.attachment figcaption textarea")
+}
+
+async function selectAttachment(figure) {
+  await figure.locator("img[src*='/blobs/']").waitFor()
+  await figure.locator("img").click()
+  await expect(figure).toHaveClass(/node--selected/)
+}


### PR DESCRIPTION
Tabbing through a message drops the cursor into image captions. Reported by a customer in early July; the fix has been sitting inside #1053 since then, behind a review conversation about a different part of that PR.

## The bug

The caption is a real `<textarea>` in the document, so native sequential focus navigation walks straight into it. Verified on `main` with a probe before touching anything — caret in ordinary text, nothing selected, `captionTabIndex: 0`, one `Tab`, and `document.activeElement` is the caption textarea.

## The fix

`tabIndex: -1` takes the textarea out of the tab order. That one line is the whole fix for the reported behaviour.

On its own it would trade one accessibility bug for another — a caption no keyboard user could reach at all. So `KEY_TAB_COMMAND` at `COMMAND_PRIORITY_HIGH` restores a deliberate path: with an attachment selected, `Tab` moves into that attachment's caption. `Escape` hands focus back to the editor and reselects the attachment, so `Tab` can step in again. `Shift+Tab` is untouched and still steps backwards out of the editor.

The caption also gains an accessible name (`ariaLabel`). It is now reachable only on purpose, so the label is what tells a screen-reader user where they have landed.

## Why this is separable from #1053

Every external symbol it needs is already on `main`: `$isActionTextAttachmentNode`, `$createNodeSelectionWith`, `this.editor`, and the existing `NodeSelection`. Nothing here touches `attachment_toolbar.js` or `fake_selection.js` — the two files the open review threads on #1053 are actually about.

Two deliberate trims against the #1053 version:

- **No `ariaHidden` toggling.** That belongs to the aria-hidden caption mirror (`.attachment__caption-text`), which is not in this PR; without the mirror the toggle is dead code.
- **`$singleSelectedNode` inlined** rather than exported from `lexical_helper.js`, so this PR adds no shared surface that #1053 would then conflict with.

#1053 stays open for the toolbar work.

## One check worth flagging

The behaviour I could not settle by reading was whether a figure click leaves the contenteditable focused on `main`, since #1053 also adds a fake-selection span that parks the DOM range inside the figure. Without that span, does `KEY_TAB_COMMAND` fire at all?

It does. After a figure click on `main`: `activeElement` is the contenteditable, `window.getSelection().rangeCount` is `0` (no DOM range at all — the NodeSelection state), and a `Tab` keydown still arrives on the contenteditable. The fake-selection span is not load-bearing for this.

## Tests

Three, in `attachment_caption_focus.test.js`. Two are ported from #1053; **the first is new** — #1053's pair does not actually cover the reported complaint, because neither asserts that `Tab` from a text caret stays out of the caption.

Each was checked for non-vacuity by reverting one piece at a time, and each revert fails exactly one test:

| revert | fails |
|---|---|
| drop `tabIndex: -1` | *Tab past an attachment does not fall into its caption* |
| keep `tabIndex`, drop `KEY_TAB_COMMAND` | *Tab from a selected attachment focuses the caption textarea* |
| drop the `Escape` branch | *Escape from caption restores attachment selection and editor focus* |

Worth noting the middle row: with `tabIndex` at `0` the Tab-into-caption test passes *without* the command, because native focus order reaches the textarea anyway. It only tests the command once the textarea is out of the tab order.

9/9 green across Chromium, Firefox and WebKit. Full attachment suite: 103 passed. Four tests reported flaky, all upload-timing; `main` flakes in the same files with a different subset each run, so they are pre-existing and not from this change.
