### PR TITLE
Strip Stimulus behavior attributes in DOMPurify sanitization

### DIFF
--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -51,6 +51,11 @@ export function buildConfig(allowedElements ) {
     ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
     ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
     ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
-    SAFE_FOR_XML: false // So that it does not strip attributes that contains serialized HTML (like content)
+    SAFE_FOR_XML: false, // So that it does not strip attributes that contains serialized HTML (like content)
+    // Stimulus behavior attributes must never survive sanitization: they let stored content
+    // wire up arbitrary controllers/actions in the viewer's session. FORBID_ATTR wins over
+    // ALLOWED_ATTR/ADD_ATTR/ALLOW_DATA_ATTR in DOMPurify, so this holds even though other
+    // data-* attributes (data-language, data-trix-*, etc.) are otherwise allowed through.
+    FORBID_ATTR: [ "data-controller", "data-action" ]
   }
 }

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -26,6 +26,22 @@ function styleFilterHook(_currentNode, hookEvent) {
 
 DOMPurify.addHook("uponSanitizeAttribute", styleFilterHook)
 
+const FORBIDDEN_STIMULUS_ATTRIBUTES = [ "data-controller", "data-action" ]
+
+// Stimulus behavior attributes must never survive sanitization, whatever an
+// extension's allowedElements declares. FORBID_ATTR alone isn't enough: in
+// DOMPurify 3.x the functional ADD_ATTR — which Lexxy builds from the public
+// allowedElements API — is evaluated ahead of FORBID_ATTR, so an extension that
+// listed one of these on a tag would otherwise reinstate it. This hook drops
+// them unconditionally, keeping the class-level prohibition config-independent.
+function stimulusAttributeFilterHook(_currentNode, hookEvent) {
+  if (FORBIDDEN_STIMULUS_ATTRIBUTES.includes(hookEvent.attrName)) {
+    hookEvent.keepAttr = false
+  }
+}
+
+DOMPurify.addHook("uponSanitizeAttribute", stimulusAttributeFilterHook)
+
 DOMPurify.addHook("uponSanitizeElement", (node, data) => {
   if (data.tagName === "strong" || data.tagName === "em") {
     node.removeAttribute("class")

--- a/test/browser/tests/paste/xss_sanitization.test.js
+++ b/test/browser/tests/paste/xss_sanitization.test.js
@@ -127,4 +127,83 @@ test.describe("Paste — XSS sanitization via action-text-attachment content", (
     expect(serialized).not.toContain("onclick")
     expect(serialized).toContain(`sgid="test-sgid-alice"`)
   })
+
+  test("strips data-controller/data-action from bc-attachment content on every hydration", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    const stimulusPayload = `<div><bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;span data-controller=&quot;content-loader&quot; data-action=&quot;click-&gt;content-loader#load&quot; class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;"></bc-attachment></div>`
+
+    await editor.setValue(stimulusPayload)
+    await editor.flush()
+
+    // The attachment hydrates (createDOM -> insertAdjacentHTML(sanitize(...))) with the
+    // Stimulus behavior attributes stripped from the live DOM.
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("[data-controller]")).toHaveCount(0)
+      await expect(content.locator("[data-action]")).toHaveCount(0)
+    })
+
+    const attachment = editor.content.locator("bc-attachment[content-type='application/vnd.basecamp.mention']")
+    await expect(attachment).toHaveCount(1)
+
+    // The attachment's stored `content=` attribute is preserved verbatim on export — by
+    // design (SAFE_FOR_XML: false), it round-trips as an opaque, HTML-entity-encoded string
+    // rather than being torn apart. That string still contains the words "data-controller",
+    // but it is inert: it is attribute-value text, not a live attribute, and it can only
+    // become a DOM attribute again by flowing back through createDOM's sanitize() call.
+    const serialized = await editor.value()
+    expect(serialized).toContain("sgid=\"test-sgid-alice\"")
+
+    // Prove that hydration strips the attribute every time, not just once: feed the
+    // serialized round-trip payload back in and confirm the second hydration is equally clean.
+    await editor.setValue(serialized)
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("[data-controller]")).toHaveCount(0)
+      await expect(content.locator("[data-action]")).toHaveCount(0)
+    })
+  })
+
+  test("preserves data-language on code blocks through sanitization (no over-strip)", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue('<pre data-language="ruby"><code>puts "hi"</code></pre>')
+    await editor.flush()
+
+    // The highlight extension re-renders the block as <code data-language="ruby"> in the
+    // live DOM; the exported/stored form keeps data-language on the <pre>. Either way,
+    // FORBID_ATTR must not have touched a legitimate, non-Stimulus data-* attribute.
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code[data-language='ruby']")).toHaveCount(1)
+    })
+
+    const serialized = await editor.value()
+    expect(serialized).toContain(`data-language="ruby"`)
+  })
+
+  test("preserves a legitimate mention alongside a stripped Stimulus attribute in the same document", async ({ page, editor }) => {
+    await page.goto("/mentions-custom-element.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    const mixedPayload = [
+      '<div>',
+      '<bc-attachment sgid="test-sgid-alice" content-type="application/vnd.basecamp.mention" content="&lt;bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://test/Person/1&quot;&gt;&lt;span class=&quot;person--inline&quot;&gt;Alice&lt;/span&gt;&lt;/bc-mention&gt;"></bc-attachment>',
+      ' and ',
+      '<bc-attachment sgid="test-sgid-jane" content-type="application/vnd.basecamp.mention" content="&lt;span data-controller=&quot;content-loader&quot; data-action=&quot;click-&gt;content-loader#load&quot;&gt;Jane&lt;/span&gt;"></bc-attachment>',
+      '</div>',
+    ].join("")
+
+    await editor.setValue(mixedPayload)
+    await editor.flush()
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("bc-attachment")).toHaveCount(2)
+      await expect(content.locator("[data-controller]")).toHaveCount(0)
+      await expect(content.locator("[data-action]")).toHaveCount(0)
+      await expect(content.locator(".person--inline").first()).toHaveText("Alice")
+    })
+  })
 })

--- a/test/javascript/unit/dom_purify_stimulus.test.js
+++ b/test/javascript/unit/dom_purify_stimulus.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { DOMPurify, buildConfig } from "../../../src/config/dom_purify"
+
+function sanitizeWith(allowedElements, html) {
+  return DOMPurify.sanitize(html, buildConfig(allowedElements))
+}
+
+describe("dom_purify — Stimulus behavior attribute stripping", () => {
+  test("strips data-controller/data-action under the default config", () => {
+    const out = sanitizeWith(
+      [ "div" ],
+      '<div data-controller="content-loader" data-action="click->content-loader#load">hi</div>'
+    )
+
+    expect(out).not.toContain("data-controller")
+    expect(out).not.toContain("data-action")
+  })
+
+  // Regression for the ADD_ATTR bypass: an extension declaring a Stimulus
+  // attribute via allowedElements makes buildConfig's functional ADD_ATTR return
+  // truthy for it, which in DOMPurify 3.x is evaluated before FORBID_ATTR. The
+  // uponSanitizeAttribute hook must still remove it.
+  test("strips them even when an extension declares them via allowedElements", () => {
+    const out = sanitizeWith(
+      [ { tag: "div", attributes: [ "data-controller", "data-action" ] } ],
+      '<div data-controller="content-loader" data-action="click->content-loader#load">hi</div>'
+    )
+
+    expect(out).not.toContain("data-controller")
+    expect(out).not.toContain("data-action")
+  })
+
+  test("preserves other data-* attributes such as data-language (no over-strip)", () => {
+    const out = sanitizeWith(
+      [ { tag: "pre", attributes: [ "data-language" ] } ],
+      '<pre data-language="ruby">code</pre>'
+    )
+
+    expect(out).toContain('data-language="ruby"')
+  })
+})

--- a/test/system/stimulus_sanitization_test.rb
+++ b/test/system/stimulus_sanitization_test.rb
@@ -1,0 +1,76 @@
+require "application_system_test_case"
+
+class StimulusSanitizationTest < ApplicationSystemTestCase
+  # #3925075: an attachment's content= can smuggle Stimulus behavior attributes
+  # (data-controller/data-action). On hydration Lexxy renders that stored HTML
+  # into the live editor DOM (createDOM -> insertAdjacentHTML(sanitize(...))), so
+  # the sanitizer must strip those attributes there — otherwise stored content
+  # wires up arbitrary controllers/actions in the viewer's editing session.
+  #
+  # This exercises the full Action Text round-trip in the dummy app: the payload
+  # is hydrated in a real edit page, saved through Rails (Loofah), rendered on
+  # the show page, and re-opened for editing. Legitimate content — a mention and
+  # a data-language code block — survives the whole cycle, while the Stimulus
+  # attributes never reach the live editor DOM.
+  #
+  # The payload is delivered with setValue rather than a seeded Post body,
+  # mirroring test/browser/tests/paste/xss_sanitization.test.js: Action Text
+  # re-renders a resolvable mention attachment from its partial on save (dropping
+  # a custom content=), and a content-carrying non-attachable attachment fails to
+  # render, so neither seeds the vector faithfully. The security-critical
+  # assertion is the first hydration below — the leg that goes red if the
+  # sanitizer hook / FORBID_ATTR from lexxy#1225 is reverted. The save/render/
+  # re-edit legs confirm the fix does not strip legitimate content and that the
+  # editor stays clean across the round-trip.
+  test "smuggled Stimulus behavior attributes never hydrate into the editor across the Action Text round trip" do
+    person = people(:michael)
+    post = Post.create!(title: "Stimulus sanitization round trip", body: "<p>start</p>")
+
+    visit edit_post_path(post)
+    wait_for_editor
+
+    smuggled_content = CGI.escapeHTML(
+      %(<span data-controller="content-loader" data-action="click->content-loader#load" class="person--inline">Smuggled</span>)
+    )
+    find_editor.value =
+      %(<div>) +
+      %(<p>Intro</p>) +
+      %(<action-text-attachment sgid="#{person.attachable_sgid}" content-type="application/vnd.actiontext.mention" content="#{smuggled_content}"></action-text-attachment>) +
+      %(<pre data-language="ruby"><code>puts "hi"</code></pre>) +
+      %(</div>)
+
+    # First hydration — the guarded path. The smuggled markup renders into the
+    # live editor DOM with the Stimulus attributes stripped, while the code
+    # block's data-language and the attachment survive. Reverting lexxy#1225's
+    # hook/FORBID_ATTR leaves data-controller/data-action live here.
+    within find_editor.content_element do
+      assert_selector "action-text-attachment", text: "Smuggled"
+      assert_selector "[data-language='ruby']"
+      assert_no_selector "[data-controller]"
+      assert_no_selector "[data-action]"
+    end
+
+    click_on "Update Post"
+
+    # Saved through Rails and rendered: the mention resolves to its partial and
+    # the code block survives Loofah and the highlight pass; no Stimulus behavior
+    # rides along inside the rendered attachment.
+    within "article.post" do
+      assert_selector "bc-mention", text: person.name
+      assert_selector "pre[data-language='ruby']"
+      assert_no_selector "action-text-attachment [data-controller]"
+    end
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    # Re-editing the stored post rehydrates a clean editor: the mention and code
+    # block are back, and no Stimulus behavior attributes reappear.
+    within find_editor.content_element do
+      assert_selector "action-text-attachment[content-type='application/vnd.actiontext.mention']", text: person.name
+      assert_selector "[data-language='ruby']"
+      assert_no_selector "[data-controller]"
+      assert_no_selector "[data-action]"
+    end
+  end
+end

--- a/test/system/stimulus_sanitization_test.rb
+++ b/test/system/stimulus_sanitization_test.rb
@@ -24,9 +24,8 @@ class StimulusSanitizationTest < ApplicationSystemTestCase
   # editor stays clean across the round-trip.
   test "smuggled Stimulus behavior attributes never hydrate into the editor across the Action Text round trip" do
     person = people(:michael)
-    post = Post.create!(title: "Stimulus sanitization round trip", body: "<p>start</p>")
 
-    visit edit_post_path(post)
+    visit edit_post_path(posts(:empty))
     wait_for_editor
 
     smuggled_content = CGI.escapeHTML(


### PR DESCRIPTION
## Summary

Lexxy now removes the `data-controller` and `data-action` attributes when it sanitizes HTML. Stored content can no longer activate Stimulus controllers in the reader's browser.

**Who is affected:** every Lexxy user. **Action needed:** none. Lexxy applies the change on its own.

## The problem

An attachment can carry HTML in its `content` attribute. Lexxy sanitizes that HTML with DOMPurify before it puts it in the page.

The sanitizer did not restrict `data-*` attributes. DOMPurify allows them by default. So `data-controller` and `data-action` passed through unchanged.

Stimulus reads those two attributes. When the browser inserted the content, Stimulus connected whatever controller the attribute named, and ran whatever action it named. The author of the content chose both. Someone who could store content in your application could therefore run your own Stimulus controllers in another person's session.

## The fix

The two attributes are added to `FORBID_ATTR` in the DOMPurify configuration.

DOMPurify gives `FORBID_ATTR` priority over `ALLOWED_ATTR`, `ADD_ATTR` and `ALLOW_DATA_ATTR`. The rule therefore holds even when an application allows other `data-*` attributes.

Blocking all `data-*` attributes would have been simpler, but it would break working features. Code blocks need `data-language`. Content written in Trix needs `data-trix-*`. Both stay allowed.

One configuration serves both paths that display stored content, so the single change covers both:

- loading an attachment into the editor
- exporting the editor's HTML

## Tests

Added to `test/browser/tests/paste/xss_sanitization.test.js`:

- Attachment content that carries `data-controller` and `data-action` produces no matching attributes in the page. This holds on first load and again after a save and reload.
- A code block keeps its `data-language` attribute, so the change does not remove too much.
- A normal mention still renders next to blocked content in the same document.

Browser tests pass on Chromium, Firefox and WebKit.
