### PR TITLE
Apply mXSS-safe SAFE_FOR_XML on attachment content re-inflation

### DIFF
--- a/src/editor/sanitizer.js
+++ b/src/editor/sanitizer.js
@@ -85,9 +85,15 @@ export default class EditorSanitizer {
   }
 
   // safeForXml opts into DOMPurify's mXSS-safe mode, for a caller re-inflating
-  // stored content. It is off by default because that is what the config this
-  // sanitizer was built with says, and because the value an editor reads back is
-  // its own markup on its way out, not untrusted input on its way in.
+  // stored content. It is off by default, and the reason is not that the default
+  // hop is trustworthy — the value an editor reads back carries the attacker's
+  // stored `content` verbatim. The reason is that strictness there is destructive:
+  // SAFE_FOR_XML drops any attribute whose value could close a comment, a
+  // serialized `content` full of Rails view annotations is exactly that, and
+  // CustomActionTextAttachmentNode.importDOM returns null for an attachment with no
+  // `content` — so the attachment vanishes on the next edit. Verified: strict on the
+  // value hop leaves `<action-text-attachment sgid content-type>` and re-editing that
+  // renders nothing.
   //
   // The strict config is this instance's own, spread rather than rebuilt, so the
   // per-editor allowlist and everything else buildConfig put there — the Trusted

--- a/src/editor/sanitizer.js
+++ b/src/editor/sanitizer.js
@@ -84,7 +84,19 @@ export default class EditorSanitizer {
     this.#config = buildConfig(allowedElements)
   }
 
-  sanitize(html) {
+  // safeForXml opts into DOMPurify's mXSS-safe mode, for a caller re-inflating
+  // stored content. It is off by default because that is what the config this
+  // sanitizer was built with says, and because the value an editor reads back is
+  // its own markup on its way out, not untrusted input on its way in.
+  //
+  // The strict config is this instance's own, spread rather than rebuilt, so the
+  // per-editor allowlist and everything else buildConfig put there — the Trusted
+  // Types policy, ADD_URI_SAFE_ATTR — survive the flip.
+  sanitize(html, { safeForXml = false } = {}) {
+    if (safeForXml) {
+      return DOMPurify.sanitize(html, { ...this.#config, SAFE_FOR_XML: true })
+    }
+
     return DOMPurify.sanitize(html, this.#config)
   }
 }

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -78,7 +78,13 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
 
     // Resolved from the editor so this content is sanitized with its own
     // allowlist rather than whichever editor connected most recently.
-    figure.insertAdjacentHTML("beforeend", EditorSanitizer.for(editor).sanitize(this.innerHtml))
+    //
+    // this.innerHtml is untrusted stored content being re-inflated into the editor,
+    // so it goes through DOMPurify's mXSS-safe mode. What is sanitized here is the
+    // decoded inner markup, which carries no serialized `content` attribute of its
+    // own — that attribute is only ever produced by exportDOM, where SAFE_FOR_XML
+    // is off — so mXSS-safe mode is free to be strict on this hop.
+    figure.insertAdjacentHTML("beforeend", EditorSanitizer.for(editor).sanitize(this.innerHtml, { safeForXml: true }))
 
     const deleteButton = createElement("lexxy-node-delete-button")
     figure.appendChild(deleteButton)

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -80,10 +80,17 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
     // allowlist rather than whichever editor connected most recently.
     //
     // this.innerHtml is untrusted stored content being re-inflated into the editor,
-    // so it goes through DOMPurify's mXSS-safe mode. What is sanitized here is the
-    // decoded inner markup, which carries no serialized `content` attribute of its
-    // own — that attribute is only ever produced by exportDOM, where SAFE_FOR_XML
-    // is off — so mXSS-safe mode is free to be strict on this hop.
+    // so it goes through DOMPurify's mXSS-safe mode. Strictness is free here because
+    // of where the `content` attribute that has to survive is sanitized, which is not
+    // this hop: it is produced by exportDOM and by the server-side pass in
+    // lib/lexxy/rich_text_area_tag.rb, and it is only ever sanitized on the lax hop
+    // where an editor reads its own value back.
+    //
+    // The decoded inner markup can carry a `content` attribute of its own — nested
+    // attachment markup does, and the attribute is allowlisted on the attachment tag
+    // in extensions/attachments_extension.js — and mXSS-safe mode drops it. That loss
+    // is cosmetic: it is a nested attachment's rendering inside this one, not the
+    // attribute anything re-imports from.
     figure.insertAdjacentHTML("beforeend", EditorSanitizer.for(editor).sanitize(this.innerHtml, { safeForXml: true }))
 
     const deleteButton = createElement("lexxy-node-delete-button")

--- a/test/dummy/app/views/people/_person.html.erb
+++ b/test/dummy/app/views/people/_person.html.erb
@@ -2,4 +2,12 @@
 <%# custom attachment get sanitized on re-edit, and alt/width/height on it are %>
 <%# what attachment_content_images_test asserts survive the round trip. A data: %>
 <%# URI keeps the fixture self-contained and off the network. %>
+<%# %>
+<%# The HTML comment is load-bearing too, and is emitted rather than written as %>
+<%# an ERB comment so it reaches the serialized content attribute. It stands in %>
+<%# for the view annotations Rails emits with annotate_rendered_view_with_filenames, %>
+<%# which is how comments turn up inside real attachment content. A comment is %>
+<%# the value DOMPurify's SAFE_FOR_XML guard rejects, so this is what %>
+<%# attachment_content_round_trip_test needs in order to mean anything. %>
+<!-- BEGIN app/views/people/_person.html.erb -->
 <bc-mention gid="<%= person.to_gid %>"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="<%= person.name %>" width="20" height="20" class="avatar"><em><%= person.name %></em> (<strong><%= person.initials %></strong>)</bc-mention>

--- a/test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js
+++ b/test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js
@@ -9,8 +9,12 @@ afterEach(async () => {
 
 // Re-inflating stored attachment content is an untrusted storage round-trip. The
 // custom attachment node re-parses the serialized `content` HTML into the live
-// editor DOM, so it must be sanitized in DOMPurify's mXSS-safe mode while keeping
-// legitimate content (including comments) intact.
+// editor DOM, so it must be sanitized in DOMPurify's mXSS-safe mode.
+//
+// Only the first test here guards that opt-in. The second one passes with the
+// opt-in reverted, and is meant to: it pins the lax value hop, where a
+// comment-bearing `content` attribute has to survive being read back. Both
+// properties are needed, but they are not the same property.
 describe("attachment content re-inflation sanitization", () => {
   const attachment = (content) =>
     `<action-text-attachment content-type="text/html" sgid="abc123" content="${content}"></action-text-attachment>`
@@ -31,13 +35,23 @@ describe("attachment content re-inflation sanitization", () => {
     const figure = editorElement.querySelector("action-text-attachment, [content-type]")
     expect(figure, "attachment was dropped on re-inflation").not.toBeNull()
 
-    // Verified by reverting the safeForXml opt-in in createDOM: without it the
-    // title survives verbatim and this assertion fails.
-    expect(figure.innerHTML).not.toContain("--&gt;")
+    // Asserted on the DOM rather than on serialized markup, because the serialized
+    // form does not show the difference. HTML attribute serialization escapes `&`
+    // and `"` and never `>`, so with the opt-in reverted figure.innerHTML reads
+    // `title="--><img src=x onerror=alert(1)>"` literally — a `--&gt;` never appears
+    // in it either way, and asserting on one could not fail.
+    //
+    // Reverting the safeForXml opt-in in createDOM fails these two, and only these.
+    expect(figure.querySelector("p").hasAttribute("title")).toBe(false)
     expect(figure.innerHTML).not.toMatch(/onerror/i)
     expect(figure.textContent).toContain("hi")
   })
 
+  // Passes with the opt-in reverted, by design. What it guards is the hop the opt-in
+  // is deliberately *not* applied to: an editor reading its own value back keeps
+  // SAFE_FOR_XML off, so a comment-bearing `content` attribute survives. Turn that
+  // hop strict and the attribute is dropped, importDOM returns null, and the
+  // attachment disappears on the next edit.
   test("preserves legitimate comment-bearing attachment content after round-trip", async () => {
     const content = "&lt;!-- BEGIN app/views/users/_user.html.erb --&gt;&lt;span&gt;Chris&lt;/span&gt;&lt;!-- END app/views/users/_user.html.erb --&gt;"
     editorElement = await createTestEditor({ value: attachment(content) })

--- a/test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js
+++ b/test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { createTestEditor, destroyTestEditor, tick } from "../../helpers/editor_helper"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+// Re-inflating stored attachment content is an untrusted storage round-trip. The
+// custom attachment node re-parses the serialized `content` HTML into the live
+// editor DOM, so it must be sanitized in DOMPurify's mXSS-safe mode while keeping
+// legitimate content (including comments) intact.
+describe("attachment content re-inflation sanitization", () => {
+  const attachment = (content) =>
+    `<action-text-attachment content-type="text/html" sgid="abc123" content="${content}"></action-text-attachment>`
+
+  // The payload has to be one SAFE_FOR_XML actually decides, or the test passes
+  // with the change reverted and proves nothing. An ordinary `onerror` doesn't
+  // qualify: DOMPurify's tag and attribute allowlists remove it either way.
+  //
+  // A comment terminator inside an attribute value does. SAFE_FOR_XML drops any
+  // attribute whose value could close a comment or a raw-text element when the
+  // sanitized markup is re-serialized and parsed again — which is exactly what
+  // re-inflating stored content does.
+  test("drops an attribute whose value can break out of a comment", async () => {
+    const payload = "&lt;p title=&quot;--&gt;&lt;img src=x onerror=alert(1)&gt;&quot;&gt;hi&lt;/p&gt;"
+    editorElement = await createTestEditor({ value: attachment(payload) })
+    await tick()
+
+    const figure = editorElement.querySelector("action-text-attachment, [content-type]")
+    expect(figure, "attachment was dropped on re-inflation").not.toBeNull()
+
+    // Verified by reverting the safeForXml opt-in in createDOM: without it the
+    // title survives verbatim and this assertion fails.
+    expect(figure.innerHTML).not.toContain("--&gt;")
+    expect(figure.innerHTML).not.toMatch(/onerror/i)
+    expect(figure.textContent).toContain("hi")
+  })
+
+  test("preserves legitimate comment-bearing attachment content after round-trip", async () => {
+    const content = "&lt;!-- BEGIN app/views/users/_user.html.erb --&gt;&lt;span&gt;Chris&lt;/span&gt;&lt;!-- END app/views/users/_user.html.erb --&gt;"
+    editorElement = await createTestEditor({ value: attachment(content) })
+    await tick()
+
+    // The attachment survives, and its exported value still carries the content.
+    expect(editorElement.value).toContain("action-text-attachment")
+    expect(editorElement.value).toContain("BEGIN app/views/users/_user.html.erb")
+    // The rendered inner content is present in the editor DOM.
+    expect(editorElement.textContent).toContain("Chris")
+  })
+})

--- a/test/javascript/unit/editor/sanitizer.test.js
+++ b/test/javascript/unit/editor/sanitizer.test.js
@@ -116,3 +116,33 @@ test("an editor denying attachment content strips it when another editor allows 
   // Only the attribute is refused — the element itself is still allowed here.
   expect(result).toContain("action-text-attachment")
 })
+
+// The mXSS-safe re-inflation opt-in, which the attachment node passes on
+// createDOM. The strict config is this instance's own, spread rather than
+// rebuilt, so everything buildConfig put in it survives the SAFE_FOR_XML flip —
+// rebuilding from a bare buildConfig([]) here would drop the allowlist along
+// with the rest.
+test("safe-XML mode keeps the editor's own allowlist and the rest of its config", () => {
+  const allows = editorAllowing()
+  EditorSanitizer.register(allows, ALLOWS_CONTENT)
+
+  expect(EditorSanitizer.for(allows).sanitize("<span>a</span>", { safeForXml: true })).toBe("a")
+  expect(EditorSanitizer.for(allows).sanitize(ATTACHMENT, { safeForXml: true })).toContain("action-text-attachment")
+})
+
+// Every other call site — an editor reading its own value back — passes no
+// options at all, and has to keep sanitizing exactly as it did before the option
+// existed. SAFE_FOR_XML off is what buildConfig sets, and it is what keeps a
+// serialized `content` attribute intact on the way out.
+test("sanitizing without options leaves mXSS-safe mode off", () => {
+  expect(sanitizer.sanitize(ATTACHMENT)).toBe(EditorSanitizer.for(editor).sanitize(ATTACHMENT, { safeForXml: false }))
+
+  const withContent = EditorSanitizer.register(editorAllowing(), ALLOWS_CONTENT)
+
+  // A comment terminator in the value is what SAFE_FOR_XML rejects, so this is
+  // the assertion that distinguishes the default from the opt-in.
+  const commented = '<action-text-attachment sgid="x" content-type="text/html" content="&lt;!-- BEGIN --&gt;"></action-text-attachment>'
+
+  expect(withContent.sanitize(commented)).toContain("content=")
+  expect(withContent.sanitize(commented, { safeForXml: true })).not.toContain("content=")
+})

--- a/test/system/attachments/attachment_content_round_trip_test.rb
+++ b/test/system/attachments/attachment_content_round_trip_test.rb
@@ -1,0 +1,73 @@
+require "application_system_test_case"
+
+# Attachment content is re-sanitized in mXSS-safe mode every time the attachment
+# renders in the editor, so comment-bearing content — Rails view annotations land
+# inside the partial an attachment renders — has to survive the whole loop: the
+# editor, the saved value, the rendered page and the re-edited document all have to
+# agree, with Loofah on the server getting a say between them. Unit tests only ever
+# see the first hop; this is the test that would catch a server stage dropping it.
+#
+# The content survives without any special force-keep. The serialized `content`
+# attribute is only produced by exportDOM, where SAFE_FOR_XML is off, so it is never
+# subject to the mXSS guard; the safe-XML call in CustomActionTextAttachmentNode#createDOM
+# is handed the *decoded inner* markup, which has no `content` attribute of its own.
+# The client-side re-inflation guard is covered directly in
+# test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js.
+class AttachmentContentRoundTripTest < ApplicationSystemTestCase
+  COMMENT = "BEGIN app/views/people/_person.html.erb"
+
+  test "comment-bearing attachment content survives save, render and re-edit" do
+    person = people(:james)
+
+    visit edit_post_path(posts(:hello_james))
+    wait_for_editor
+
+    assert_comment_in_saved_value
+    assert_mention_in_editor person
+
+    click_on "Update Post"
+
+    # The rendered page: the attachment has been through Loofah on the way in.
+    within "article.post" do
+      assert_selector %(bc-mention[gid="#{person.to_gid}"]), text: person.name
+    end
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    # The re-edit: content is re-inflated under SAFE_FOR_XML, and the attachment
+    # renders from it. Lose the content on any hop and the attachment comes back
+    # empty here.
+    assert_mention_in_editor person
+    assert_comment_in_saved_value
+  end
+
+  private
+    # Asserted on the attachment element rather than on bc-mention, which never
+    # reaches the editor DOM: an editor's allowlist is its importable tags plus
+    # whatever its extensions declare, and the dummy app declares no
+    # allowedElements for bc-mention. DOMPurify drops an unlisted tag and keeps
+    # its children, so what re-inflation leaves behind is the rendered mention —
+    # the avatar and the name — inside the attachment. That is the property this
+    # test is after: lose the content and the attachment renders empty.
+    #
+    # The gid is not dropped, only relocated: mention_round_trip_test asserts it
+    # on the rendered page and in the serialized content, which is where it lives.
+    def assert_mention_in_editor(person)
+      within find_editor.selector do
+        assert_selector %(action-text-attachment[content-type="application/vnd.actiontext.mention"]),
+          text: person.name, visible: :all
+      end
+    end
+
+    # The value the form submits: attachment content re-serialized after sanitizing.
+    def assert_comment_in_saved_value
+      attachment = Capybara.string(find_editor.value)
+        .find(%(action-text-attachment[content-type="application/vnd.actiontext.mention"]))
+
+      content = CGI.unescapeHTML(attachment["content"])
+
+      assert_includes content, COMMENT,
+        "the comment inside attachment content was dropped, which is what SAFE_FOR_XML does without the preservation hook"
+    end
+end

--- a/test/system/attachments/attachment_content_round_trip_test.rb
+++ b/test/system/attachments/attachment_content_round_trip_test.rb
@@ -7,10 +7,12 @@ require "application_system_test_case"
 # agree, with Loofah on the server getting a say between them. Unit tests only ever
 # see the first hop; this is the test that would catch a server stage dropping it.
 #
-# The content survives without any special force-keep. The serialized `content`
-# attribute is only produced by exportDOM, where SAFE_FOR_XML is off, so it is never
-# subject to the mXSS guard; the safe-XML call in CustomActionTextAttachmentNode#createDOM
-# is handed the *decoded inner* markup, which has no `content` attribute of its own.
+# The content survives with no special handling. The `content` attribute this test
+# follows is produced by exportDOM and by the server-side pass in
+# lib/lexxy/rich_text_area_tag.rb, and it is only ever sanitized on the value hop,
+# where SAFE_FOR_XML is off — so the mXSS guard never sees it. The safe-XML call in
+# CustomActionTextAttachmentNode#createDOM is handed the *decoded inner* markup, one
+# level down, where a `content` attribute would only belong to a nested attachment.
 # The client-side re-inflation guard is covered directly in
 # test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js.
 class AttachmentContentRoundTripTest < ApplicationSystemTestCase
@@ -68,6 +70,6 @@ class AttachmentContentRoundTripTest < ApplicationSystemTestCase
       content = CGI.unescapeHTML(attachment["content"])
 
       assert_includes content, COMMENT,
-        "the comment inside attachment content was dropped, which is what SAFE_FOR_XML does without the preservation hook"
+        "the comment inside attachment content was dropped, which is what SAFE_FOR_XML would do to it on this hop"
     end
 end


### PR DESCRIPTION
## Summary

When Lexxy loads a saved attachment back into the editor, it now sanitizes that content in DOMPurify's mXSS-safe mode.

**Who is affected:** every Lexxy user. **Action needed:** none.

## The problem

An attachment stores HTML in its `content` attribute. When you reopen a saved document, Lexxy reads that HTML and puts it back into the editor.

That HTML is untrusted. It has been to storage and back, and whoever wrote the document chose it.

Lexxy sanitized it, but with DOMPurify's `SAFE_FOR_XML` option turned off. That option guards against mutation XSS, usually written mXSS. A mutation XSS attack uses markup that means one thing when the browser parses it, and something else after the browser has written it out and parsed it again. Sanitizing the first form can produce a second form that is unsafe.

Re-inflating stored content is the one place in the editor where an untrusted raw string goes straight into live DOM, via `insertAdjacentHTML`. That is where the option belongs.

## Scope: defence in depth, not a hole being closed

No live XSS at this hop was constructible. The payload the test uses re-parses inert, and the classic mXSS families die on the tag and attribute allowlists with the flag either way. So this is not a fix for a demonstrated bug — it is the right guard in the right place on the one sink that has the shape mXSS needs, and it stops the next allowlist widening from being the thing that matters.

## Why the option is off everywhere else

Because turning it on globally deletes attachments.

`SAFE_FOR_XML` removes any attribute whose value could close a comment or a raw text element such as `<style>`. An attachment's serialized `content` value regularly contains one: Rails writes view annotations like `<!-- BEGIN app/views/people/_person.html.erb -->` into rendered partials, and an attachment's content is a rendered partial.

The hop that has to stay lax is the one where an editor reads its own `value` back — not because that value is trustworthy (it carries the attacker's stored `content` verbatim) but because strictness there is destructive. The guard removes `content`, `CustomActionTextAttachmentNode.importDOM` returns `null` for an attachment without it, and the attachment disappears on the next edit. Verified: strict on the value hop leaves `<action-text-attachment sgid content-type>`, and re-editing that renders nothing.

## The fix

`EditorSanitizer#sanitize` takes an opt-in, and the attachment node passes it on `createDOM`. Nothing else does.

The strict configuration is the instance's own, spread rather than rebuilt, so the per-editor allowlist and everything else that went into it — the Trusted Types policy, `ADD_URI_SAFE_ATTR` — survive the flip.

Strictness is free on this hop because of where the `content` attribute that has to survive is sanitized, which is not here. It is produced by `exportDOM` and by the server-side pass in `lib/lexxy/rich_text_area_tag.rb`, and it is only ever sanitized on the lax value hop. What `createDOM` is handed is the decoded markup one level down. That markup *can* carry a `content` attribute of its own — nested attachment markup does, and the attribute is allowlisted on the attachment tag — and the guard drops it. That loss is display-only: it is a nested attachment's rendering inside this one, never the attribute anything re-imports from.

## Why there is no force-keep hook

An earlier version of this change kept the `content` attribute through a `uponSanitizeAttribute` hook setting `forceKeepAttr`. That approach cannot work, and this is recorded here so nobody rebuilds it.

In the vendored dompurify 3.4.13, the `SAFE_FOR_XML` attribute removal (`purify.cjs.js:1993`) runs *before* the `forceKeepAttr` check (`:2003`), and it `continue`s. The hook never gets a say. Only mutating `hookEvent.attrValue` could have worked — and once the guard is scoped to the hop that does not carry a `content` attribute, nothing needs keeping in the first place.

## Tests

`test/javascript/unit/editor/attachments/content_reinflation_sanitization.test.js` covers the opt-in through a real editor. The payload is `<p title="--><img src=x onerror=alert(1)>">`: the comment terminator inside the attribute value is the part `SAFE_FOR_XML` decides on, not the `onerror`, which the allowlists remove either way.

Its assertions are on the DOM, not on serialized markup, because the serialized form does not show the difference — HTML attribute serialization escapes `&` and `"` and never `>`. Reverting the opt-in fails it with `expected true to be false`.

The second test in that file passes with the opt-in reverted, and is meant to. It pins the lax hop: a comment-bearing `content` attribute has to survive being read back. The file says so, so a future revert does not look half-covered.

`test/javascript/unit/editor/sanitizer.test.js` pins the two directions at the sanitizer: the strict call keeps the editor's own allowlist and the rest of its config, and a call with no options leaves the guard off.

`test/system/attachments/attachment_content_round_trip_test.rb` covers the full path — edit, save, view, edit again — with Loofah on the server getting a say in the middle. The dummy application's partial emits an HTML comment so the test exercises the value `SAFE_FOR_XML` objects to. A server-side stage that removed the attribute would fail it.

## Review follow-ups

Three corrections from a review pass, all in the commit on top.

**One assertion could not fail.** `expect(figure.innerHTML).not.toContain("--&gt;")` was written as *the* guard on the opt-in, but `>` is never escaped in a serialized attribute value, so with the opt-in reverted `figure.innerHTML` reads `title="--><img src=x onerror=alert(1)>"` literally and `--&gt;` never appears either way. Reverting the opt-in in an isolated copy failed only the `onerror` line beside it, and the comment above both credited the wrong one. It asserts the attribute's absence from the DOM now.

**A call-site invariant was false as worded.** It said the decoded markup "carries no serialized `content` attribute of its own — that attribute is only ever produced by `exportDOM`." Two counterexamples: the server-side producer in `lib/lexxy/rich_text_area_tag.rb`, and nested attachment markup, where `content` is explicitly allowlisted and does survive with the flag off. Probed against the real DOMPurify. Narrowed to the invariant that holds, as described above.

**And one comment was a rationalization.** It said the value an editor reads back "is its own markup on its way out, not untrusted input on its way in." It isn't. The honest reason that hop stays lax is that strictness there destroys attachments, which is the reason that will stop someone "hardening" it.

---

**Part of a series** re-filing #1227 at reviewable scope, after #1227 was reverted from `main` in 8c64aa45. Merge order: #1228 → #1229 → #1230 → #1231 → #1232 → **this**. Nothing here is released.

*Draft: needs human review and a soak period before merging.*
