### PR TITLE
Stop configuring the shared DOMPurify, and give each editor its own allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@lexical/selection": "^0.44.0",
     "@lexical/table": "^0.44.0",
     "@lexical/utils": "^0.44.0",
-    "dompurify": "^3.3.0",
+    "dompurify": "^3.4.13",
     "lexical": "^0.44.0",
     "marked": "^16.4.1",
     "prismjs": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:browser:webkit": "npx playwright test --config test/browser/playwright.config.js --project=webkit",
     "test:browser:headed": "npx playwright test --config test/browser/playwright.config.js --headed",
     "test:browser:debug": "npx playwright test --config test/browser/playwright.config.js --debug",
+    "prepare": "rollup -c rollup.config.npm.mjs",
     "prerelease": "yarn build:npm",
     "release": "yarn build:npm && yarn publish",
     "release:alpha": "yarn build:npm && yarn publish --tag alpha"

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -17,17 +17,23 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 // instance. This one carries the hooks and config below; nothing we do here can
 // reach the app's instance, and nothing it does can reach ours.
 //
-// Known limitation, under Trusted Types only: every DOMPurify instance lazily
-// creates a policy named `dompurify` on its first sanitize, and TT rejects a
-// duplicate name. Whichever instance sanitizes second gets no policy — DOMPurify
-// catches this, warns, and carries on unsigned. That is harmless today because
-// no app here sends a `trusted-types` CSP directive, and DOMPurify's normal path
-// is DOMParser, which isn't a TT sink. If you are adding
-// `require-trusted-types-for 'script'`, this is the line to revisit: allow
-// duplicate policies, or hand us an explicit one via TRUSTED_TYPES_POLICY.
-// Note the second sink below (insertAdjacentHTML in
-// nodes/custom_action_text_attachment_node.js) already receives a plain string,
-// so it needs the same attention at that point.
+// Known limitation, and read this before enabling Trusted Types. Every DOMPurify
+// instance lazily creates a policy named `dompurify` on its first sanitize, and
+// TT rejects a duplicate name, so whichever instance sanitizes second gets none —
+// DOMPurify catches that, warns, and carries on unsigned.
+//
+// Under `require-trusted-types-for 'script'` that is not cosmetic. DOMPurify
+// hands its input to DOMParser.parseFromString, which *is* a TT sink — that's
+// why it wraps the payload in `trustedTypesPolicy.createHTML` when it has a
+// policy. Without one, sanitizing throws. Whichever instance loses the race
+// breaks, so this can take out the host app's sanitizing rather than ours.
+//
+// It's latent today only because no app here sends a `trusted-types` directive,
+// and it can't be fixed from inside this file: the distinct-policy route needs a
+// name the host's CSP allowlists, and TRUSTED_TYPES_POLICY needs the host to
+// supply one. If you're turning TT on, that's the decision to make here — and
+// the `insertAdjacentHTML` sink in nodes/custom_action_text_attachment_node.js
+// receives a plain string and needs the same attention, independently of this.
 const DOMPurify = createDOMPurify(window)
 
 // alt/height/width are inert and carry no URL or script surface, and dropping

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -50,6 +50,37 @@ const DEFAULT_TAG_ATTRIBUTES = { img: [ "width", "height" ] }
 
 const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
 
+// An attachment's `url` ends up as an <img src> (action_text_attachment_node
+// reads it into `this.src`, which is assigned to img.src). DOMPurify already
+// permits a data: URI on img[src] — img is in its DATA_URI_TAGS — but it has no
+// way to know that a custom element's `url` feeds the same sink, so it applies
+// the plain URI check and drops it.
+//
+// Until 3.3.2 that never came up: attributes admitted by a *functional* ADD_ATTR
+// skipped URI validation entirely (GHSA-cjmm-f4jc-qw8r), which is how data:
+// URLs worked here — and, less happily, how `url="javascript:…"` survived too.
+// The fix restored validation for both.
+//
+// So `url` is marked URI-safe, which hands the decision to this hook, and the
+// hook allows exactly what DOMPurify allows on an img src: its default scheme
+// list plus data:. javascript: and friends are dropped, which is stricter than
+// what shipped before the upgrade. The hook only ever removes an attribute — it
+// never force-keeps one — so scoping stays with the ADD_ATTR predicate, and a
+// `url` on a tag that never declared it is dropped as it always was.
+const URI_BEARING_ATTACHMENT_ATTRIBUTES = [ "url" ]
+const SAFE_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
+// eslint-disable-next-line no-control-regex -- mirrors DOMPurify's own ATTR_WHITESPACE
+const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
+
+function attachmentUriFilterHook(_currentNode, hookEvent) {
+  if (!URI_BEARING_ATTACHMENT_ATTRIBUTES.includes(hookEvent.attrName)) return
+
+  if (!SAFE_ATTACHMENT_URI.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
+    hookEvent.keepAttr = false
+  }
+}
+
+
 function styleFilterHook(_currentNode, hookEvent) {
   if (hookEvent.attrName === "style" && hookEvent.attrValue) {
     const styles = { ...getStyleObjectFromCSS(hookEvent.attrValue) }
@@ -70,6 +101,7 @@ function styleFilterHook(_currentNode, hookEvent) {
 }
 
 DOMPurify.addHook("uponSanitizeAttribute", styleFilterHook)
+DOMPurify.addHook("uponSanitizeAttribute", attachmentUriFilterHook)
 
 const FORBIDDEN_STIMULUS_ATTRIBUTES = [ "data-controller", "data-action" ]
 
@@ -117,7 +149,7 @@ export function buildConfig(allowedElements ) {
     ALLOWED_TAGS: Object.keys(tagAttributes),
     ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
     ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
-    ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
+    ADD_URI_SAFE_ATTR: [ "caption", "filename", ...URI_BEARING_ATTACHMENT_ATTRIBUTES ],
     SAFE_FOR_XML: false, // So that it does not strip attributes that contains serialized HTML (like content)
     // Stimulus behavior attributes must never survive sanitization: they let stored content
     // wire up arbitrary controllers/actions in the viewer's session. FORBID_ATTR wins over

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -17,23 +17,35 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 // instance. This one carries the hooks and config below; nothing we do here can
 // reach the app's instance, and nothing it does can reach ours.
 //
-// Known limitation, and read this before enabling Trusted Types. Every DOMPurify
-// instance lazily creates a policy named `dompurify` on its first sanitize, and
-// TT rejects a duplicate name, so whichever instance sanitizes second gets none —
-// DOMPurify catches that, warns, and carries on unsigned.
+// Under Trusted Types, every DOMPurify instance tries to create a policy named
+// `dompurify` on its first sanitize, and TT rejects a duplicate name — so the
+// second instance on the page gets none. That matters: DOMPurify hands its input
+// to DOMParser.parseFromString, which is itself a TT sink, so an unsigned
+// instance throws rather than degrading, and which sanitizer breaks depends on
+// which one ran first.
 //
-// Under `require-trusted-types-for 'script'` that is not cosmetic. DOMPurify
-// hands its input to DOMParser.parseFromString, which *is* a TT sink — that's
-// why it wraps the payload in `trustedTypesPolicy.createHTML` when it has a
-// policy. Without one, sanitizing throws. Whichever instance loses the race
-// breaks, so this can take out the host app's sanitizing rather than ours.
-//
-// It's latent today only because no app here sends a `trusted-types` directive,
-// and it can't be fixed from inside this file: the distinct-policy route needs a
-// name the host's CSP allowlists, and TRUSTED_TYPES_POLICY needs the host to
-// supply one. If you're turning TT on, that's the decision to make here — and
-// the `insertAdjacentHTML` sink in nodes/custom_action_text_attachment_node.js
-// receives a plain string and needs the same attention, independently of this.
+// So we create our own, under our own name, and hand it to DOMPurify rather than
+// letting it try. Guarded, because creating a policy the CSP hasn't allowlisted
+// throws: if that happens we're back to no policy, which is exactly where this
+// stood before. An app enforcing `require-trusted-types-for 'script'` should add
+// `lexxy` to its `trusted-types` directive.
+const TRUSTED_TYPES_POLICY = createTrustedTypesPolicy()
+
+function createTrustedTypesPolicy() {
+  // Feature-detected below, so browsers without Trusted Types simply get no
+  // policy — the same path as a CSP that doesn't allowlist ours.
+  // eslint-disable-next-line compat/compat
+  const trustedTypes = window.trustedTypes
+
+  if (typeof trustedTypes?.createPolicy !== "function") return null
+
+  try {
+    return trustedTypes.createPolicy("lexxy", { createHTML: (html) => html, createScriptURL: (url) => url })
+  } catch {
+    return null
+  }
+}
+
 const DOMPurify = createDOMPurify(window)
 
 // alt is inert on every element it can appear on, so it sits in the blanket
@@ -150,6 +162,7 @@ export function buildConfig(allowedElements ) {
     ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
     ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
     ADD_URI_SAFE_ATTR: [ "caption", "filename", ...URI_BEARING_ATTACHMENT_ATTRIBUTES ],
+    ...(TRUSTED_TYPES_POLICY ? { TRUSTED_TYPES_POLICY } : {}),
     SAFE_FOR_XML: false, // So that it does not strip attributes that contains serialized HTML (like content)
     // Stimulus behavior attributes must never survive sanitization: they let stored content
     // wire up arbitrary controllers/actions in the viewer's session. FORBID_ATTR wins over

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -36,12 +36,17 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 // receives a plain string and needs the same attention, independently of this.
 const DOMPurify = createDOMPurify(window)
 
-// alt/height/width are inert and carry no URL or script surface, and dropping
-// them costs real things: an image inside attachment content loses its alternative
-// text entirely, and loses the intrinsic size that keeps it from reflowing the
-// line as it loads. srcset is deliberately not here — it carries URLs, so it
-// belongs to a consumer that declares it, not to the blanket allowlist.
-const ALLOWED_HTML_ATTRIBUTES = [ "alt", "class", "contenteditable", "height", "href", "src", "style", "title", "width" ]
+// alt is inert on every element it can appear on, so it sits in the blanket
+// list. srcset is deliberately absent — it carries URLs, so it belongs to a
+// consumer that declares it.
+const ALLOWED_HTML_ATTRIBUTES = [ "alt", "class", "contenteditable", "href", "src", "style", "title" ]
+
+// width/height are scoped to img rather than allowlisted globally, because
+// ALLOWED_ATTR is not per-tag: putting them there would also permit
+// `<table width="100000">` and `<td height="500">` in attachment content, which
+// is layout the editor previously stripped. An image needs them to hold its
+// place while it loads; nothing else here does.
+const DEFAULT_TAG_ATTRIBUTES = { img: [ "width", "height" ] }
 
 const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
 
@@ -100,6 +105,12 @@ export function buildConfig(allowedElements ) {
       tagAttributes[element.tag] ||= []
       tagAttributes[element.tag].push(...element.attributes)
     }
+  }
+
+  // Only for tags the caller already permits — this widens what an allowed
+  // element may carry, never which elements are allowed.
+  for (const [ tag, attributes ] of Object.entries(DEFAULT_TAG_ATTRIBUTES)) {
+    if (tagAttributes[tag]) tagAttributes[tag].push(...attributes)
   }
 
   return {

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -1,5 +1,22 @@
-import DOMPurify from "dompurify"
+import createDOMPurify from "dompurify"
 import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
+
+// Lexxy's own DOMPurify instance, deliberately not the shared default export.
+//
+// dompurify's default export is a singleton, and both its config and its hooks
+// are global to every consumer in the bundle. That makes configuring it from an
+// editor's connectedCallback actively dangerous for the host app: DOMPurify
+// treats a persistent config as final, so once setConfig() has run, every
+// later `sanitize(html, config)` anywhere in the app silently ignores its own
+// config argument. An app sanitizing untrusted HTML with, say,
+// `{ ALLOW_DATA_ATTR: false }` would keep passing that option and stop getting
+// it the moment a Lexxy editor connected — with no error and no visible change
+// at the call site.
+//
+// Calling the default export with a window returns a fresh, independent
+// instance. This one carries the hooks and config below; nothing we do here can
+// reach the app's instance, and nothing it does can reach ours.
+const DOMPurify = createDOMPurify(window)
 
 const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
 

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -16,6 +16,18 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 // Calling the default export with a window returns a fresh, independent
 // instance. This one carries the hooks and config below; nothing we do here can
 // reach the app's instance, and nothing it does can reach ours.
+//
+// Known limitation, under Trusted Types only: every DOMPurify instance lazily
+// creates a policy named `dompurify` on its first sanitize, and TT rejects a
+// duplicate name. Whichever instance sanitizes second gets no policy — DOMPurify
+// catches this, warns, and carries on unsigned. That is harmless today because
+// no app here sends a `trusted-types` CSP directive, and DOMPurify's normal path
+// is DOMParser, which isn't a TT sink. If you are adding
+// `require-trusted-types-for 'script'`, this is the line to revisit: allow
+// duplicate policies, or hand us an explicit one via TRUSTED_TYPES_POLICY.
+// Note the second sink below (insertAdjacentHTML in
+// nodes/custom_action_text_attachment_node.js) already receives a plain string,
+// so it needs the same attention at that point.
 const DOMPurify = createDOMPurify(window)
 
 // alt/height/width are inert and carry no URL or script surface, and dropping

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -18,7 +18,12 @@ import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection
 // reach the app's instance, and nothing it does can reach ours.
 const DOMPurify = createDOMPurify(window)
 
-const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
+// alt/height/width are inert and carry no URL or script surface, and dropping
+// them costs real things: an image inside attachment content loses its alternative
+// text entirely, and loses the intrinsic size that keeps it from reflowing the
+// line as it loads. srcset is deliberately not here — it carries URLs, so it
+// belongs to a consumer that declares it, not to the blanket allowlist.
+const ALLOWED_HTML_ATTRIBUTES = [ "alt", "class", "contenteditable", "height", "href", "src", "style", "title", "width" ]
 
 const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
 

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -361,7 +361,7 @@ export class LexicalEditorElement extends HTMLElement {
 
   #readSanitizedEditorValue() {
     return this.editor?.read(() => {
-      return sanitize($generateHtmlFromNodes(this.editor, null))
+      return sanitize($generateHtmlFromNodes(this.editor, null), this.editor)
     }) ?? null
   }
 
@@ -755,7 +755,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #configureSanitizer(editor) {
-    setSanitizerConfig(this.#getAllowedElements(editor))
+    setSanitizerConfig(editor, this.#getAllowedElements(editor))
   }
 
   #getAllowedElements(editor) {

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -1,18 +1,37 @@
 import { DOMPurify, buildConfig } from "../config/dom_purify"
 
-// The config is passed to each sanitize() call rather than installed with
-// DOMPurify.setConfig().
+// Sanitizer config is per editor, and passed to each sanitize() call.
 //
-// A persistent config is final — DOMPurify ignores the per-call config once one
-// has been set — so setConfig() is only ever safe on an instance nobody else
-// shares. We now have our own (see config/dom_purify), and keeping the config
-// per-call means there is no global sanitizer state left even on that instance.
-let config = {}
+// Neither of those is incidental. This used to call DOMPurify.setConfig() on the
+// shared singleton, which had two distinct consequences:
+//
+// 1. A persistent config is final — DOMPurify ignores the per-call config once
+//    one is set — so it silently disarmed the sanitizing of any host app that
+//    also imports dompurify. See config/dom_purify for why we now own our
+//    instance; keeping the config per-call means there is no global sanitizer
+//    state left even on that instance.
+//
+// 2. One config for the whole module meant the last editor to connect decided
+//    how every other editor on the page sanitized. That is not cosmetic: an
+//    editor's `value` is sanitized on read, so a rich editor sharing a page with
+//    a plain one would silently drop its own headings, lists and links from the
+//    value it submits. Keying on the editor is what fixes that.
+//
+// Registered against the Lexical editor, which is the identity both call sites
+// have to hand: the element has it as `this.editor`, and nodes receive it as the
+// second argument to createDOM().
+const configs = new WeakMap()
 
-export function setSanitizerConfig(allowedTags) {
-  config = buildConfig(allowedTags)
+// Only reached if sanitize() is called for an editor that never registered one.
+// Falling back to the most recent config keeps the old behaviour rather than
+// silently widening the allowlist to DOMPurify's permissive defaults.
+let fallbackConfig = {}
+
+export function setSanitizerConfig(editor, allowedTags) {
+  fallbackConfig = buildConfig(allowedTags)
+  configs.set(editor, fallbackConfig)
 }
 
-export function sanitize(html) {
-  return DOMPurify.sanitize(html, config)
+export function sanitize(html, editor) {
+  return DOMPurify.sanitize(html, configs.get(editor) ?? fallbackConfig)
 }

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -1,10 +1,18 @@
 import { DOMPurify, buildConfig } from "../config/dom_purify"
 
+// The config is passed to each sanitize() call rather than installed with
+// DOMPurify.setConfig().
+//
+// A persistent config is final — DOMPurify ignores the per-call config once one
+// has been set — so setConfig() is only ever safe on an instance nobody else
+// shares. We now have our own (see config/dom_purify), and keeping the config
+// per-call means there is no global sanitizer state left even on that instance.
+let config = {}
+
 export function setSanitizerConfig(allowedTags) {
-  DOMPurify.clearConfig()
-  DOMPurify.setConfig(buildConfig(allowedTags))
+  config = buildConfig(allowedTags)
 }
 
 export function sanitize(html) {
-  return DOMPurify.sanitize(html)
+  return DOMPurify.sanitize(html, config)
 }

--- a/src/nodes/custom_action_text_attachment_node.js
+++ b/src/nodes/custom_action_text_attachment_node.js
@@ -72,11 +72,13 @@ export class CustomActionTextAttachmentNode extends DecoratorNode {
     this.plainText = plainText ?? extractPlainTextFromHtml(innerHtml)
   }
 
-  createDOM() {
+  createDOM(_config, editor) {
     const figure = createElement(this.tagName, { "content-type": this.contentType, "data-lexxy-decorator": true, draggable: true })
     figure.dataset.lexicalNodeKey = this.__key
 
-    figure.insertAdjacentHTML("beforeend", sanitize(this.innerHtml))
+    // The editor is passed through so this content is sanitized with its own
+    // allowlist rather than whichever editor connected most recently.
+    figure.insertAdjacentHTML("beforeend", sanitize(this.innerHtml, editor))
 
     const deleteButton = createElement("lexxy-node-delete-button")
     figure.appendChild(deleteButton)

--- a/test/actiontext/image_attributes_test.rb
+++ b/test/actiontext/image_attributes_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+# Lexxy's sanitizer decides what an image may carry inside the editor. Action
+# Text's decides what survives being saved. When the two disagree the editor
+# shows something the server quietly drops, and the difference only appears
+# after a reload — so this asserts they agree about images, reading Lexxy's list
+# from source rather than copying it, so widening one side without the other
+# fails here.
+#
+# Not every client-side attribute belongs in this check. `contenteditable` and
+# `style` are editor machinery and Action Text drops both by design; persisting
+# them is not wanted. What has to round-trip is the markup an image needs to
+# render the same way twice.
+class ImageAttributesTest < ActiveSupport::TestCase
+  DOM_PURIFY_SOURCE = Pathname.new(File.expand_path("../../src/config/dom_purify.js", __dir__)).read
+
+  # `alt` is in the blanket allowlist; width/height are scoped to img through the
+  # tag-specific mechanism, so they're read from different places.
+  IMAGE_ATTRIBUTES = begin
+    tag_scoped = DOM_PURIFY_SOURCE[/DEFAULT_TAG_ATTRIBUTES\s*=\s*\{\s*img:\s*\[([^\]]*)\]/m, 1].to_s.scan(/"([^"]+)"/).flatten
+    blanket = DOM_PURIFY_SOURCE[/ALLOWED_HTML_ATTRIBUTES\s*=\s*\[([^\]]*)\]/m, 1].to_s.scan(/"([^"]+)"/).flatten
+    # Parenthesised deliberately: `+` binds tighter than `&`, so without them
+    # this reads (tag_scoped + blanket) & %w[ alt ] and collapses to just "alt".
+    (tag_scoped + (blanket & %w[ alt ])).uniq
+  end
+
+  test "the source still declares the image attributes this test reads" do
+    # Guards the regexes above: if the declarations are renamed or restructured,
+    # IMAGE_ATTRIBUTES silently empties and every assertion below passes vacuously.
+    assert_includes IMAGE_ATTRIBUTES, "alt"
+    assert_includes IMAGE_ATTRIBUTES, "width"
+    assert_includes IMAGE_ATTRIBUTES, "height"
+  end
+
+  test "every image attribute Lexxy preserves also survives Action Text" do
+    markup = %(<img src="/avatar.png" #{IMAGE_ATTRIBUTES.map { |name| %(#{name}="1") }.join(" ")}>)
+
+    sanitized = ActionText::Content.new(markup).to_s
+
+    IMAGE_ATTRIBUTES.each do |name|
+      assert_includes sanitized, "#{name}=", "Lexxy keeps #{name} on an image but Action Text strips it on save"
+    end
+  end
+
+  test "srcset is excluded on both sides" do
+    # It carries URLs, so Lexxy leaves it to a consumer that declares it —
+    # and Action Text wouldn't persist it anyway. Allowing it client-side would
+    # have produced exactly the disagreement this test exists to catch.
+    refute_includes IMAGE_ATTRIBUTES, "srcset"
+    refute_includes ActionText::Content.new(%(<img src="/a.png" srcset="/a2.png 2x">)).to_s, "srcset"
+  end
+end

--- a/test/browser/fixtures/sanitizer-isolation.html
+++ b/test/browser/fixtures/sanitizer-isolation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — sanitizer isolation</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor id="rich" class="lexxy-content" placeholder="Rich"></lexxy-editor>
+    </div>
+
+    <!-- Connects second, so under the old module-level config it was this
+         editor's allowlist that governed the rich one above. -->
+    <div class="body">
+      <lexxy-editor id="plain" preset="plain" class="lexxy-content" placeholder="Plain"></lexxy-editor>
+    </div>
+
+    <div class="events"></div>
+  </form>
+
+  <script type="module" src="/sanitizer-isolation.js"></script>
+</body>
+</html>

--- a/test/browser/fixtures/sanitizer-isolation.js
+++ b/test/browser/fixtures/sanitizer-isolation.js
@@ -1,0 +1,6 @@
+import { configure } from "lexxy"
+import "./events_logger.js"
+
+// A plain-text preset alongside the default rich one. The two resolve different
+// importable tags, which is what makes their sanitizer allowlists differ.
+configure({ plain: { richText: false } })

--- a/test/browser/tests/editor/sanitizer_isolation.test.js
+++ b/test/browser/tests/editor/sanitizer_isolation.test.js
@@ -1,0 +1,56 @@
+import { test } from "../../test_helper.js"
+import { EditorHandle } from "../../helpers/editor_handle.js"
+import { expect } from "@playwright/test"
+
+// Each editor sanitizes with its own allowlist.
+//
+// The config used to be one module-level value installed with
+// DOMPurify.setConfig(), so the last editor to connect decided how every editor
+// on the page sanitized. An editor's `value` is sanitized on read, so a rich
+// editor sharing a page with a plain one silently dropped its own headings and
+// lists from the value it submitted — with nothing different on screen, because
+// the editor DOM was never the thing being rewritten.
+//
+// The unit test for this runs in JSDOM. This one exists because the failure
+// involves the custom-element lifecycle, cached value reads and the bundled
+// build, none of which JSDOM proves anything about.
+test.describe("sanitizer isolation between editors", () => {
+  const RICH = "<h1>Title</h1><ul><li>one</li></ul><p>body</p>"
+
+  test("a rich editor keeps its formatting after a plain editor connects", async ({ page }) => {
+    const rich = new EditorHandle(page, "#rich")
+    const plain = new EditorHandle(page, "#plain")
+
+    await page.goto("/sanitizer-isolation.html")
+    await rich.waitForConnected()
+    await plain.waitForConnected()
+
+    await rich.setValue(RICH)
+
+    // Editing clears the cached value, so the next read re-sanitizes. That read
+    // is what used to pick up the plain editor's allowlist.
+    await rich.click()
+    await rich.send("!")
+
+    const value = await rich.value()
+    expect(value).toContain("<h1>")
+    expect(value).toContain("<ul>")
+  })
+
+  test("the plain editor still sanitizes with its own narrower allowlist", async ({ page }) => {
+    const rich = new EditorHandle(page, "#rich")
+    const plain = new EditorHandle(page, "#plain")
+
+    await page.goto("/sanitizer-isolation.html")
+    await rich.waitForConnected()
+    await plain.waitForConnected()
+
+    await plain.setValue(RICH)
+    await plain.click()
+    await plain.send("!")
+
+    // Control: proves the two editors really do resolve different allowlists, so
+    // the assertion above isn't passing because both are simply permissive.
+    expect(await plain.value()).not.toContain("<h1>")
+  })
+})

--- a/test/dummy/app/views/people/_person.html.erb
+++ b/test/dummy/app/views/people/_person.html.erb
@@ -1,1 +1,5 @@
-<bc-mention gid="<%= person.to_gid %>"><em><%= person.name %></em> (<strong><%= person.initials %></strong>)</bc-mention>
+<%# The avatar is here because attachment content is where images inside a %>
+<%# custom attachment get sanitized on re-edit, and alt/width/height on it are %>
+<%# what attachment_content_images_test asserts survive the round trip. A data: %>
+<%# URI keeps the fixture self-contained and off the network. %>
+<bc-mention gid="<%= person.to_gid %>"><img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="<%= person.name %>" width="20" height="20" class="avatar"><em><%= person.name %></em> (<strong><%= person.initials %></strong>)</bc-mention>

--- a/test/helpers/lexxy/tag_helper_test.rb
+++ b/test/helpers/lexxy/tag_helper_test.rb
@@ -8,6 +8,8 @@ class Lexxy::TagHelperTest < ActionView::TestCase
   end
 
   test "#lexxy_rich_textarea_tag renders <action-text-attachment> elements" do
+    person = people(:james)
+
     render inline: <<~ERB, locals: { post: posts(:hello_james) }
       <%= lexxy_rich_textarea_tag :body, post.body %>
     ERB
@@ -17,8 +19,15 @@ class Lexxy::TagHelperTest < ActionView::TestCase
         attachment = value.at("action-text-attachment")
 
         assert_equal "Hello ", value.text
-        assert_equal %(<bc-mention gid="#{people(:james).to_gid}"><em>James Anderson</em> (<strong>JA</strong>)</bc-mention>), JSON.parse(attachment["content"])
         assert_equal "application/vnd.actiontext.mention", attachment["content-type"]
+
+        # Assert the parts of the mention this test is about, not the partial's
+        # exact markup: test/dummy/app/views/people/_person.html.erb is shared
+        # with the attachment-content image tests and changes when they do.
+        mention = fragment(JSON.parse(attachment["content"]))
+        assert_dom mention, %(bc-mention[gid="#{person.to_gid}"]), count: 1
+        assert_dom mention, "bc-mention em", text: person.name
+        assert_dom mention, "bc-mention strong", text: person.initials
       end
     end
   end

--- a/test/javascript/unit/editor/sanitizer_isolation.test.js
+++ b/test/javascript/unit/editor/sanitizer_isolation.test.js
@@ -1,0 +1,79 @@
+import { afterEach, expect, test } from "vitest"
+import { $getRoot } from "lexical"
+import Lexxy from "src/config/lexxy"
+import { createTestEditor, destroyTestEditor, setContent, tick } from "../helpers/editor_helper"
+
+// Each editor sanitizes with its own allowlist.
+//
+// The sanitizer config used to be one module-level value installed with
+// DOMPurify.setConfig(), so the last editor to connect decided how every other
+// editor on the page sanitized. Because an editor's `value` is sanitized on
+// read, a rich editor sharing a page with a plain one would silently drop its
+// own headings and lists from the value it submitted — data loss on save, with
+// nothing visible in the editor to suggest it.
+
+const RICH = "<h1>Title</h1><ul><li>one</li></ul><p>body</p>"
+
+let rich, plain
+
+afterEach(async () => {
+  await destroyTestEditor(rich)
+  await destroyTestEditor(plain)
+  rich = plain = undefined
+})
+
+async function typeInto(editorElement) {
+  editorElement.editor.update(() => {
+    $getRoot().getLastDescendant()?.select().insertText("!")
+  }, { discrete: true })
+  await tick()
+}
+
+test("a rich editor keeps its formatting after a plain editor connects", async () => {
+  Lexxy.configure({ plain: { richText: false } })
+
+  rich = await createTestEditor({ value: RICH })
+  plain = await createTestEditor({ attributes: { preset: "plain" } })
+  await tick()
+
+  // Editing clears the cached value, so the next read re-sanitizes. That read is
+  // what used to pick up the plain editor's allowlist.
+  await typeInto(rich)
+
+  expect(rich.value).toContain("<h1>")
+  expect(rich.value).toContain("<ul>")
+})
+
+test("the plain editor still sanitizes with its own narrower allowlist", async () => {
+  Lexxy.configure({ plain: { richText: false } })
+
+  rich = await createTestEditor({ value: RICH })
+  plain = await createTestEditor({ attributes: { preset: "plain" }, value: RICH })
+  await tick()
+
+  await typeInto(plain)
+
+  // Control: proves the two editors really do resolve different allowlists, so
+  // the assertion above isn't passing because both are simply permissive.
+  expect(plain.value).not.toContain("<h1>")
+})
+
+test("attachment content is sanitized with its own editor's allowlist", async () => {
+  Lexxy.configure({ plain: { richText: false } })
+
+  const attachment = '<action-text-attachment content-type="application/vnd.test.thing" ' +
+    'content="&lt;blockquote&gt;quoted&lt;/blockquote&gt;"></action-text-attachment>'
+
+  rich = await createTestEditor()
+  plain = await createTestEditor({ attributes: { preset: "plain" } })
+  await tick()
+
+  // The content has to be set *after* the plain editor connects. A decorator
+  // node builds its DOM once, so loading the attachment up front would render
+  // it before there was any competing config — passing whether or not the bug
+  // is present.
+  await setContent(rich, `<p>${attachment}</p>`)
+
+  // blockquote is in the rich editor's allowlist but not the plain one's.
+  expect(rich.querySelector("action-text-attachment").innerHTML).toContain("<blockquote>")
+})

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -19,7 +19,7 @@ const editor = { name: "stand-in for a Lexical editor" }
 
 beforeEach(() => {
   DOMPurify.clearConfig()
-  setSanitizerConfig(editor, [ "span", "p", "strong" ])
+  setSanitizerConfig(editor, [ "span", "p", "strong", "img" ])
 })
 
 test("configuring Lexxy's sanitizer leaves the app's per-call config working", () => {
@@ -55,4 +55,28 @@ test("each editor keeps its own allowlist", () => {
 
   expect(sanitize("<span>a</span><strong>b</strong>", editor)).toBe("<span>a</span><strong>b</strong>")
   expect(sanitize("<span>a</span><strong>b</strong>", other)).toBe("a<strong>b</strong>")
+})
+
+test("declared attributes survive only in the object form of allowedElements", () => {
+  // A bare tag name declares the element with no attributes of its own, so an
+  // identifying attribute is stripped. Consumers that need one — a mention's
+  // person id, say — have to declare it.
+  const bare = { name: "bare" }
+  const declared = { name: "declared" }
+  setSanitizerConfig(bare, [ "span" ])
+  setSanitizerConfig(declared, [ { tag: "span", attributes: [ "gid" ] } ])
+
+  expect(sanitize('<span gid="1">@joe</span>', bare)).toBe("<span>@joe</span>")
+  expect(sanitize('<span gid="1">@joe</span>', declared)).toBe('<span gid="1">@joe</span>')
+})
+
+test("keeps an image's alternative text and intrinsic size", () => {
+  const image = '<img src="/av.png" alt="Joe" width="20" height="20" class="avatar">'
+
+  expect(sanitize(image, editor)).toBe(image)
+})
+
+test("still drops URL-bearing image attributes nobody declared", () => {
+  expect(sanitize('<img src="/av.png" srcset="/av2.png 2x">', editor))
+    .toBe('<img src="/av.png">')
 })

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -10,13 +10,16 @@ import { sanitize, setSanitizerConfig } from "src/helpers/sanitization_helper"
 // it would silently disarm the app's own sanitizing — options the app is still
 // passing, and still relying on, would stop applying with no error anywhere.
 //
-// These assert isolation in both directions against the real singleton.
+// These assert isolation in both directions against the real singleton. The
+// config is keyed by editor, but nothing here depends on it being a real
+// Lexical editor — any identity will do.
 
 const DIRTY = '<span data-controller="evil" class="keep">hi</span>'
+const editor = { name: "stand-in for a Lexical editor" }
 
 beforeEach(() => {
   DOMPurify.clearConfig()
-  setSanitizerConfig([ "span", "p", "strong" ])
+  setSanitizerConfig(editor, [ "span", "p", "strong" ])
 })
 
 test("configuring Lexxy's sanitizer leaves the app's per-call config working", () => {
@@ -32,7 +35,7 @@ test("configuring Lexxy's sanitizer leaves the app's per-call config working", (
 test("the app's persistent config does not reach into Lexxy's sanitizing", () => {
   DOMPurify.setConfig({ ALLOWED_TAGS: [ "b" ], ALLOWED_ATTR: [] })
 
-  expect(sanitize('<span class="keep">hi</span>')).toBe('<span class="keep">hi</span>')
+  expect(sanitize('<span class="keep">hi</span>', editor)).toBe('<span class="keep">hi</span>')
 })
 
 test("Lexxy's hooks are not installed on the shared instance", () => {
@@ -43,11 +46,13 @@ test("Lexxy's hooks are not installed on the shared instance", () => {
 })
 
 test("sanitize applies the configured allowlist", () => {
-  expect(sanitize("<span>keep</span><script>evil()</script>")).toBe("<span>keep</span>")
+  expect(sanitize("<span>keep</span><script>evil()</script>", editor)).toBe("<span>keep</span>")
 })
 
-test("a later setSanitizerConfig replaces the previous allowlist", () => {
-  setSanitizerConfig([ "strong" ])
+test("each editor keeps its own allowlist", () => {
+  const other = { name: "a second editor" }
+  setSanitizerConfig(other, [ "strong" ])
 
-  expect(sanitize("<span>a</span><strong>b</strong>")).toBe("a<strong>b</strong>")
+  expect(sanitize("<span>a</span><strong>b</strong>", editor)).toBe("<span>a</span><strong>b</strong>")
+  expect(sanitize("<span>a</span><strong>b</strong>", other)).toBe("a<strong>b</strong>")
 })

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -144,3 +144,33 @@ test("url is still refused on a tag that never declared it", () => {
   // The hook only ever removes, so scoping stays with the ADD_ATTR predicate.
   expect(sanitize('<p url="data:image/png;base64,x">hi</p>', noAttachments)).toBe("<p>hi</p>")
 })
+
+// Every DOMPurify instance claims a policy named `dompurify` under Trusted Types,
+// and TT rejects a duplicate — so on a page with a host sanitizer, ours would get
+// none, and an unsigned instance throws at DOMParser rather than degrading.
+// Ours is created under its own name and handed over, so both work.
+test("uses its own Trusted Types policy name", async () => {
+  const created = []
+  const previous = globalThis.trustedTypes
+
+  globalThis.trustedTypes = {
+    createPolicy(name, rules) {
+      if (created.includes(name)) throw new TypeError(`Policy "${name}" already exists`)
+      created.push(name)
+      return { createHTML: rules.createHTML, createScriptURL: rules.createScriptURL }
+    },
+    getAttributeType: () => null
+  }
+
+  try {
+    // Re-import so the module-scope policy is created against the stub.
+    const fresh = await import(`src/config/dom_purify?tt=${created.length}`)
+    const config = fresh.buildConfig([ "b" ])
+
+    expect(created).toContain("lexxy")
+    expect(created).not.toContain("dompurify")
+    expect(config.TRUSTED_TYPES_POLICY).toBeTruthy()
+  } finally {
+    globalThis.trustedTypes = previous
+  }
+})

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -80,3 +80,23 @@ test("still drops URL-bearing image attributes nobody declared", () => {
   expect(sanitize('<img src="/av.png" srcset="/av2.png 2x">', editor))
     .toBe('<img src="/av.png">')
 })
+
+test("scopes an image's size attributes to images", () => {
+  const sized = { name: "sized" }
+  setSanitizerConfig(sized, [ "img", "table", "td" ])
+
+  expect(sanitize('<img src="/a.png" alt="Joe" width="20" height="20">', sized))
+    .toBe('<img src="/a.png" alt="Joe" width="20" height="20">')
+
+  // ALLOWED_ATTR is not per-tag, so a blanket allowlist would have let these
+  // through and handed attachment content the editor's layout.
+  expect(sanitize('<table width="100000"><td height="500">x</td></table>', sized))
+    .not.toMatch(/width|height/)
+})
+
+test("does not permit an element the caller left out", () => {
+  const noImages = { name: "no-images" }
+  setSanitizerConfig(noImages, [ "p" ])
+
+  expect(sanitize('<p>text</p><img src="/a.png" width="20">', noImages)).toBe("<p>text</p>")
+})

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -1,0 +1,53 @@
+import { beforeEach, expect, test } from "vitest"
+import DOMPurify from "dompurify"
+import { sanitize, setSanitizerConfig } from "src/helpers/sanitization_helper"
+
+// Lexxy must not configure the DOMPurify singleton the host app also imports.
+//
+// DOMPurify treats a persistent config as final: after setConfig(), every later
+// sanitize(html, config) ignores its config argument. Lexxy configures its
+// sanitizer when an editor connects, so if that ran against the shared instance
+// it would silently disarm the app's own sanitizing — options the app is still
+// passing, and still relying on, would stop applying with no error anywhere.
+//
+// These assert isolation in both directions against the real singleton.
+
+const DIRTY = '<span data-controller="evil" class="keep">hi</span>'
+
+beforeEach(() => {
+  DOMPurify.clearConfig()
+  setSanitizerConfig([ "span", "p", "strong" ])
+})
+
+test("configuring Lexxy's sanitizer leaves the app's per-call config working", () => {
+  // The app's call still gets exactly what it asked for.
+  expect(DOMPurify.sanitize(DIRTY, { ALLOW_DATA_ATTR: false }))
+    .toBe('<span class="keep">hi</span>')
+
+  // Control: the option is what's doing the work, so this test can't pass
+  // because something else happened to strip data-*.
+  expect(DOMPurify.sanitize(DIRTY, {})).toContain("data-controller")
+})
+
+test("the app's persistent config does not reach into Lexxy's sanitizing", () => {
+  DOMPurify.setConfig({ ALLOWED_TAGS: [ "b" ], ALLOWED_ATTR: [] })
+
+  expect(sanitize('<span class="keep">hi</span>')).toBe('<span class="keep">hi</span>')
+})
+
+test("Lexxy's hooks are not installed on the shared instance", () => {
+  // The style filter hook in config/dom_purify would rewrite this to color
+  // only, dropping the disallowed property.
+  expect(DOMPurify.sanitize('<p style="color: red; position: fixed">x</p>', { ALLOWED_ATTR: [ "style" ] }))
+    .toContain("position")
+})
+
+test("sanitize applies the configured allowlist", () => {
+  expect(sanitize("<span>keep</span><script>evil()</script>")).toBe("<span>keep</span>")
+})
+
+test("a later setSanitizerConfig replaces the previous allowlist", () => {
+  setSanitizerConfig([ "strong" ])
+
+  expect(sanitize("<span>a</span><strong>b</strong>")).toBe("a<strong>b</strong>")
+})

--- a/test/javascript/unit/helpers/sanitization_helper.test.js
+++ b/test/javascript/unit/helpers/sanitization_helper.test.js
@@ -100,3 +100,47 @@ test("does not permit an element the caller left out", () => {
 
   expect(sanitize('<p>text</p><img src="/a.png" width="20">', noImages)).toBe("<p>text</p>")
 })
+
+// An attachment's `url` becomes an <img src>, so it has to allow the data: URIs
+// DOMPurify already allows there — without allowing the schemes it doesn't.
+//
+// Before dompurify 3.3.2 this attribute skipped URI validation altogether, because
+// it is admitted by a functional ADD_ATTR (GHSA-cjmm-f4jc-qw8r). That is what let
+// data: URLs through, and javascript: with them. These assert the split the hook
+// now draws, which is stricter than what shipped before the fix.
+const attachments = { name: "an editor with attachments" }
+const attachment = (url) => `<action-text-attachment content-type="image/*" url="${url}"></action-text-attachment>`
+
+test("keeps the data: URIs an attachment url legitimately carries", () => {
+  setSanitizerConfig(attachments, [ { tag: "action-text-attachment", attributes: [ "url", "content-type" ] } ])
+
+  for (const url of [
+    "data:image/png;base64,iVBORw0KGgo=",
+    "data:application/pdf;base64,aGVsbG8=",
+    "data:image/svg+xml,%3Csvg%3E%3C/svg%3E",
+    "https://example.com/a.png",
+    "/rails/active_storage/blobs/a.png"
+  ]) {
+    expect(sanitize(attachment(url), attachments)).toContain(url)
+  }
+})
+
+test("drops an executable scheme from an attachment url", () => {
+  setSanitizerConfig(attachments, [ { tag: "action-text-attachment", attributes: [ "url", "content-type" ] } ])
+
+  for (const url of [ "javascript:alert(1)", "JaVaScRiPt:alert(1)", "vbscript:msgbox(1)" ]) {
+    const sanitized = sanitize(attachment(url), attachments)
+
+    expect(sanitized).not.toContain("url=")
+    // The element itself survives — only the attribute is refused.
+    expect(sanitized).toContain("action-text-attachment")
+  }
+})
+
+test("url is still refused on a tag that never declared it", () => {
+  const noAttachments = { name: "an editor without attachments" }
+  setSanitizerConfig(noAttachments, [ "p" ])
+
+  // The hook only ever removes, so scoping stays with the ADD_ATTR predicate.
+  expect(sanitize('<p url="data:image/png;base64,x">hi</p>', noAttachments)).toBe("<p>hi</p>")
+})

--- a/test/system/attachment_content_images_test.rb
+++ b/test/system/attachment_content_images_test.rb
@@ -1,0 +1,50 @@
+require "application_system_test_case"
+
+# Images inside a custom attachment's content are sanitized every time the
+# attachment renders in the editor, so what an <img> may carry is decided by
+# Lexxy rather than by the app that wrote the markup. That makes it a round-trip
+# property: the editor, the saved value, the rendered page and the re-edited
+# document all have to agree, and a difference only shows up after a reload.
+#
+# alt is what a screen reader reads; width and height are what stop the line
+# reflowing while the image loads. Both are inert, and both were being dropped.
+class AttachmentContentImagesTest < ApplicationSystemTestCase
+  test "an avatar inside attachment content keeps its alt and size through save, render and re-edit" do
+    person = people(:james)
+
+    visit edit_post_path(posts(:hello_james))
+    wait_for_editor
+
+    assert_avatar_in_editor person
+    assert_avatar_in_saved_value person
+
+    click_on "Update Post"
+
+    within "article.post" do
+      assert_selector %(bc-mention[gid="#{person.to_gid}"] img[alt="#{person.name}"][width="20"][height="20"])
+    end
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    assert_avatar_in_editor person
+    assert_avatar_in_saved_value person
+  end
+
+  private
+    # The rendered editor DOM: attachment content passed through createDOM.
+    def assert_avatar_in_editor(person)
+      within find_editor.selector do
+        assert_selector %(img[alt="#{person.name}"][width="20"][height="20"]), visible: :all
+      end
+    end
+
+    # The value the form submits: attachment content re-serialized and sanitized.
+    def assert_avatar_in_saved_value(person)
+      attachment = Capybara.string(find_editor.value)
+        .find(%(action-text-attachment[content-type="application/vnd.actiontext.mention"]))
+
+      Capybara.string(CGI.unescapeHTML(attachment["content"]))
+        .assert_selector %(img[alt="#{person.name}"][width="20"][height="20"]), visible: :all
+    end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dompurify@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.0.tgz#aaaadbb83d87e1c2fbb066452416359e5b62ec97"
-  integrity sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==
+dompurify@^3.4.13:
+  version "3.4.13"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
+  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Summary

Lexxy no longer changes the DOMPurify instance that your application uses. It creates its own instance, and it gives each editor on the page its own list of allowed tags and attributes.

This fixes three problems: Lexxy weakened the host application's sanitizing, two editors on one page corrupted each other's saved content, and images lost their `alt` text and size.

## Action needed

**If your application sets a `require-trusted-types-for 'script'` Content Security Policy, add `lexxy` to your `trusted-types` directive.**

```
Content-Security-Policy: require-trusted-types-for 'script'; trusted-types ... lexxy;
```

Lexxy now creates a Trusted Types policy named `lexxy`. If your policy does not allow that name, Lexxy cannot create it and falls back to running without one, which is where it stood before this change.

The reason for a separate name: every DOMPurify instance tries to create a policy called `dompurify`, and the browser rejects a second policy with the same name. With two instances on a page, one of them would get no policy and would throw instead of degrading. Which one broke depended on load order.

**No action needed for anything else in this pull request.**

## Dependency change

`dompurify` moves from `^3.3.0` to `^3.4.13`.

Version 3.4.13 restores URI validation for attributes allowed by a function-based `ADD_ATTR` (GHSA-cjmm-f4jc-qw8r). Lexxy uses that form, so an attachment `url` is now checked. Lexxy allows the same schemes DOMPurify allows on an image, plus `data:`. `javascript:` and similar are removed. This is stricter than earlier versions.

## 1. Lexxy weakened the host application's sanitizing

`setSanitizerConfig()` called `DOMPurify.setConfig()` on the shared default export. That instance belongs to whoever imports `dompurify`.

DOMPurify treats a configuration set this way as final. After `setConfig()`, every later `sanitize(html, config)` call ignores its own `config` argument.

So an application sanitizing untrusted HTML with `{ ALLOW_DATA_ATTR: false }` kept passing that option and stopped receiving it, from the moment a Lexxy editor connected. There was no error. Nothing changed at the call site. The option was still visible in the source.

Lexxy now calls the default export with a window, which returns a separate instance. It passes configuration to each `sanitize()` call instead of installing it. No global sanitizer state remains on either instance.

**Who was affected:** applications that install Lexxy from npm and also import `dompurify`. Rails applications using importmap were not affected, because that build includes its own copy of DOMPurify.

## 2. Two editors on one page corrupted each other's saved content

The configuration was a single value shared by the whole module, so the last editor to connect decided how every editor sanitized.

An editor sanitizes its content when something reads its `value`. A rich text editor sharing a page with a plain text editor therefore dropped its own formatting from the content it submitted:

```
<h1>Title</h1><ul><li>one</li></ul><p>body</p>   becomes   Titleone<p>body</p>
```

The editor still looked correct. The loss appeared only in what was saved.

The sequence is an ordinary one. Both editors connect. The user types in the rich text editor. That clears the cached value. The next read sanitizes again, now using the plain editor's rules.

Configuration is now stored per editor. Both call sites already have the editor available. If an editor has no registered configuration, Lexxy falls back to the most recent one, which matches the old behaviour rather than allowing DOMPurify's defaults.

## 3. Images lost their alternative text and size

`alt`, `width` and `height` were not on the allowed list. An image inside attachment content came back as `<img src="..." class="...">`.

That left nothing for a screen reader to announce, and no dimensions, so the line moved as the image loaded.

`title` was already allowed, which suggests the omission was an oversight rather than a decision. `srcset` stays excluded on purpose, because it carries URLs and should be declared by the application that needs it.

`width` and `height` are allowed on `img` only. DOMPurify's allowed-attribute list is not per tag, so a general rule would also permit `<table width="100000">` inside attachment content.

## Tests

Two new test files, plus additions to existing ones.

The isolation tests check both directions against the real shared DOMPurify instance: Lexxy does not affect it, and it does not affect Lexxy. The multi-editor tests drive two real editors.

Each new test was checked against the unfixed code. Some pass in both cases on purpose: those are controls, and they show that two editors really do resolve different rules, and that the option under test is what produces the result.

One test passed at first against the unfixed code. A decorator node builds its DOM once, and the attachment had already rendered before a second configuration existed. It now sets content after both editors connect, and fails as it should.

Full suite passes. Lint and both builds pass.

## Known rough edge

Declaring an element by name alone allows the element without any of its attributes. `[ "bc-mention" ]` permits the tag but removes the `gid` attribute that records who the mention refers to.

This is how the option is meant to work, and the object form is the answer:

```js
[ { tag: "bc-mention", attributes: [ "gid" ] } ]
```

It is easy to get wrong. A test covers it. The documentation should mention it.
