### PR TITLE
Build dist on install so a branch or SHA can be depended on

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -25,7 +25,8 @@ task :default do
       MSG
     end
 
-    sh "yarn install --frozen-lockfile"
+    # Skip `prepare`: it builds the npm package, which the gem does not need.
+    sh "yarn install --frozen-lockfile --ignore-scripts"
     sh "yarn build"
   end
 end

--- a/home/docs/development.md
+++ b/home/docs/development.md
@@ -33,6 +33,31 @@ PORT=3200 bin/dev
 
 Use the matching URL for that worktree, for example `http://lexxy.localhost:3100/posts`.
 
+## Trying an unreleased change in another app
+
+To QA a branch or a commit before it is released, point the app's `package.json` at
+the git repo. A `prepare` script builds `dist/` on install, so a git install produces
+the same output a published package would.
+
+Use the full git URL, not the `basecamp/lexxy#<ref>` shorthand:
+
+```bash
+yarn add git+https://github.com/basecamp/lexxy.git#<sha>
+```
+
+Yarn 1 resolves the shorthand to a codeload tarball instead of cloning, so it never
+runs `prepare`. The install exits 0 with no warning, the package is a copy of the
+repo with no `dist/`, and the app only fails later, at bundle time, with
+`ERR_MODULE_NOT_FOUND`. npm handles every form, so the full URL is the one to write
+down.
+
+If you already tried the shorthand, run `yarn cache clean @37signals/lexxy` before
+switching. Yarn caches both forms under the same key and otherwise fails with
+`Incorrect hash when fetching from the cache`.
+
+`--ignore-scripts` skips `prepare` in both package managers, and likewise installs a
+`dist/`-less package with no warning.
+
 ## Tests
 
 CI runs the full suite on every pull request and push to `main` via GitHub Actions (see `.github/workflows/ci.yml`). It runs four jobs in parallel: lint, JS unit tests, Rails system tests, and Playwright browser tests (across Chromium, Firefox, and WebKit).

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:browser:webkit": "npx playwright test --config test/browser/playwright.config.js --project=webkit",
     "test:browser:headed": "npx playwright test --config test/browser/playwright.config.js --headed",
     "test:browser:debug": "npx playwright test --config test/browser/playwright.config.js --debug",
+    "prepare": "rollup -c rollup.config.npm.mjs",
     "prerelease": "yarn build:npm",
     "release": "yarn build:npm && yarn publish",
     "release:alpha": "yarn build:npm && yarn publish --tag alpha"


### PR DESCRIPTION
One line in `package.json`: a `prepare` script, so `yarn install` builds `dist/`.

Without it, `"@37signals/lexxy": "git+https://github.com/basecamp/lexxy.git#<sha>"`
installs a package with no built output and the import fails. With it, a consumer can
point at a branch or a commit to try a change before it is released — which is how the
rest of this series gets QA'd against bc3.

No effect on the published package: `dist/` is built by the release process either way.
`prepare` runs on `yarn install` from a git ref and on local installs; it does not run
for consumers installing from the registry.

## Depend on it with the full git URL, not the shorthand

`prepare` only fires when the package manager clones the repo. **Yarn 1 resolves the
`basecamp/lexxy#<ref>` shorthand to a codeload tarball instead**, so it never runs
`prepare` — and bc3 is on Yarn 1.

```bash
yarn add git+https://github.com/basecamp/lexxy.git#<sha>   # builds dist/
yarn add basecamp/lexxy#<sha>                              # silently does not
```

Verified on Yarn 1.22.22 against this branch, both exiting 0: the shorthand installs
529 files with no `dist/` and records `resolved "https://codeload.github.com/..."` in
the lockfile; `git+https://…` installs 8 files with `dist/`. npm builds from either
form, so the full URL is the one to write down. Failure mode of getting it wrong is
`ERR_MODULE_NOT_FOUND` at bundle time, with nothing at install time to hint at why.

Two related traps, now documented alongside it in `home/docs/development.md`:

- Switching from the shorthand to the full URL needs `yarn cache clean @37signals/lexxy`
  first. Yarn caches both forms under the same key and otherwise fails with `Incorrect
  hash when fetching from the cache`.
- `--ignore-scripts` skips `prepare` in both package managers, likewise installing a
  `dist/`-less package with no warning. Inherent to build-on-install.

## Keeping the gem's build off the npm build

`prepare` now also fires inside `ext/Rakefile`'s `yarn install`, which runs when the
gem is installed from git. That coupled `bundle install` to the npm packaging config:
appending garbage to `rollup.config.npm.mjs` makes `yarn install --frozen-lockfile`
exit 1, `sh` raises, and the extension build fails — where `yarn build`, the only build
the gem needs, still exits 0 and emits the assets. Installing with `--ignore-scripts`
keeps the two independent, verified from a cold `node_modules` so no dependency's own
install script is load-bearing.

Left alone deliberately: `npm install --omit=dev` exits 127 because `rollup` is a
devDependency (nothing here uses npm, and Yarn 1 skips `prepare` in production mode),
and CI's `yarn install --frozen-lockfile` still exercises the npm build — that one is
coverage, not coupling.

---

**Part of a series** re-filing #1227 at reviewable scope, after #1227 was reverted
from `main` in 8c64aa45. Merge order: **this** → #dompurify → #images → #instance →
#trusted-types → #1226. Nothing here is released.

*Draft: needs human review and a soak period before merging.*
