### PR TITLE
Move to dompurify 3.4.13, and validate attachment URLs ourselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,6 +44,7 @@ jobs:
   lint-actions:
     name: GitHub Actions audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -62,6 +64,7 @@ jobs:
   js-unit-tests:
     name: JS unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -85,6 +88,7 @@ jobs:
   rails-system-tests:
     name: Rails system tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
 
@@ -146,6 +150,7 @@ jobs:
   browser-test:
     name: Browser tests (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:
@@ -180,11 +185,18 @@ jobs:
 
       - name: Install Playwright browser
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+        run: npx playwright install ${{ matrix.browser }}
 
+      # apt-get on the hosted runners stalls for tens of minutes when its mirror
+      # is degraded, so bound each attempt and retry: apt keeps the .debs it
+      # already fetched, so retries make forward progress.
       - name: Install Playwright system deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps ${{ matrix.browser }}
+        run: |
+          for attempt in 1 2 3; do
+            timeout 10m npx playwright install-deps ${{ matrix.browser }} && exit 0
+            echo "::warning::playwright install-deps stalled on attempt $attempt, retrying"
+          done
+          exit 1
 
       - name: Run Playwright tests
         run: yarn test:browser:${{ matrix.browser }}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@lexical/selection": "^0.44.0",
     "@lexical/table": "^0.44.0",
     "@lexical/utils": "^0.44.0",
-    "dompurify": "^3.3.0",
+    "dompurify": "^3.4.13",
     "lexical": "^0.44.0",
     "marked": "^16.4.1",
     "prismjs": "^1.30.0"

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -1,72 +1,10 @@
 import DOMPurify from "dompurify"
 import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
-import Lexxy from "./lexxy"
+import { URI_BEARING_ATTACHMENT_ATTRIBUTES, attachmentUriFilterHook } from "../helpers/sanitization_helper"
 
 const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
 
 const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
-
-// An attachment's `url` ends up as an <img src> (action_text_attachment_node
-// reads it into `this.src`, which is assigned to img.src). DOMPurify already
-// permits a data: URI on img[src] — img is in its DATA_URI_TAGS — but it has no
-// way to know that a custom element's `url` feeds the same sink, so it applies
-// the plain URI check and drops it.
-//
-// Until 3.3.2 that never came up: attributes admitted by a *functional* ADD_ATTR
-// skipped URI validation entirely (GHSA-cjmm-f4jc-qw8r), which is how data:
-// URLs worked here — and, less happily, how `url="javascript:…"` survived too.
-// The fix restored validation for both.
-//
-// So `url` is marked URI-safe, which hands the decision to this hook. The hook
-// only ever removes an attribute — it never force-keeps one — so scoping stays
-// with the ADD_ATTR predicate, and a `url` on a tag that never declared it is
-// dropped as it always was.
-//
-// The data: exception is scoped to the attachment element, not to the attribute
-// name. ADD_URI_SAFE_ATTR is attribute-name-wide: it takes `url` out of
-// DOMPurify's URI checking on every tag, not just ours. Extensions may declare
-// arbitrary attributes on arbitrary tags — home/docs/extensions.md's own worked
-// example is an <iframe> — so an extension declaring `url` would otherwise
-// inherit an exception granted because *an attachment's* url becomes an img src.
-// Nothing about a third party's element supports that, and `data:text/html` in a
-// navigational sink is script execution. Everything else gets the standard
-// policy, which is what it would have had if we had never touched `url`.
-const URI_BEARING_ATTACHMENT_ATTRIBUTES = [ "url" ]
-
-// DOMPurify's own IS_ALLOWED_URI, reproduced rather than narrowed, so `url` on a
-// non-attachment tag is treated exactly as DOMPurify would have treated it.
-const ALLOWED_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
-
-// The same list plus data:, for the attachment element only.
-//
-// One deliberate difference from DOMPurify's img[src] handling, stated because
-// the earlier claim of matching it "exactly" was not true: DOMPurify tests for a
-// literal lowercase `data:` at offset zero, and this is case-insensitive, so
-// `DATA:` passes here too. That matches how browsers resolve schemes, which is
-// what actually decides whether the URL loads.
-const ALLOWED_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
-// eslint-disable-next-line no-control-regex -- mirrors DOMPurify's own ATTR_WHITESPACE
-const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
-
-function isAttachmentTag(tag) {
-  return tag === Lexxy.global.get("attachmentTagName")
-}
-
-function attachmentUriFilterHook(currentNode, hookEvent) {
-  if (!URI_BEARING_ATTACHMENT_ATTRIBUTES.includes(hookEvent.attrName)) return
-
-  let permitted
-  if (isAttachmentTag(currentNode?.nodeName?.toLowerCase())) {
-    permitted = ALLOWED_ATTACHMENT_URI
-  } else {
-    permitted = ALLOWED_URI
-  }
-
-  if (!permitted.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
-    hookEvent.keepAttr = false
-  }
-}
-
 
 function styleFilterHook(_currentNode, hookEvent) {
   if (hookEvent.attrName === "style" && hookEvent.attrValue) {

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -5,6 +5,37 @@ const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "st
 
 const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
 
+// An attachment's `url` ends up as an <img src> (action_text_attachment_node
+// reads it into `this.src`, which is assigned to img.src). DOMPurify already
+// permits a data: URI on img[src] — img is in its DATA_URI_TAGS — but it has no
+// way to know that a custom element's `url` feeds the same sink, so it applies
+// the plain URI check and drops it.
+//
+// Until 3.3.2 that never came up: attributes admitted by a *functional* ADD_ATTR
+// skipped URI validation entirely (GHSA-cjmm-f4jc-qw8r), which is how data:
+// URLs worked here — and, less happily, how `url="javascript:…"` survived too.
+// The fix restored validation for both.
+//
+// So `url` is marked URI-safe, which hands the decision to this hook, and the
+// hook allows exactly what DOMPurify allows on an img src: its default scheme
+// list plus data:. javascript: and friends are dropped, which is stricter than
+// what shipped before the upgrade. The hook only ever removes an attribute — it
+// never force-keeps one — so scoping stays with the ADD_ATTR predicate, and a
+// `url` on a tag that never declared it is dropped as it always was.
+const URI_BEARING_ATTACHMENT_ATTRIBUTES = [ "url" ]
+const SAFE_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
+// eslint-disable-next-line no-control-regex -- mirrors DOMPurify's own ATTR_WHITESPACE
+const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
+
+function attachmentUriFilterHook(_currentNode, hookEvent) {
+  if (!URI_BEARING_ATTACHMENT_ATTRIBUTES.includes(hookEvent.attrName)) return
+
+  if (!SAFE_ATTACHMENT_URI.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
+    hookEvent.keepAttr = false
+  }
+}
+
+
 function styleFilterHook(_currentNode, hookEvent) {
   if (hookEvent.attrName === "style" && hookEvent.attrValue) {
     const styles = { ...getStyleObjectFromCSS(hookEvent.attrValue) }
@@ -25,6 +56,7 @@ function styleFilterHook(_currentNode, hookEvent) {
 }
 
 DOMPurify.addHook("uponSanitizeAttribute", styleFilterHook)
+DOMPurify.addHook("uponSanitizeAttribute", attachmentUriFilterHook)
 
 const FORBIDDEN_STIMULUS_ATTRIBUTES = [ "data-controller", "data-action" ]
 
@@ -66,7 +98,7 @@ export function buildConfig(allowedElements ) {
     ALLOWED_TAGS: Object.keys(tagAttributes),
     ALLOWED_ATTR: ALLOWED_HTML_ATTRIBUTES,
     ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
-    ADD_URI_SAFE_ATTR: [ "caption", "filename" ],
+    ADD_URI_SAFE_ATTR: [ "caption", "filename", ...URI_BEARING_ATTACHMENT_ATTRIBUTES ],
     SAFE_FOR_XML: false, // So that it does not strip attributes that contains serialized HTML (like content)
     // Stimulus behavior attributes must never survive sanitization: they let stored content
     // wire up arbitrary controllers/actions in the viewer's session. FORBID_ATTR wins over

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -31,11 +31,12 @@ DOMPurify.addHook("uponSanitizeAttribute", attachmentUriFilterHook)
 const FORBIDDEN_STIMULUS_ATTRIBUTES = [ "data-controller", "data-action" ]
 
 // Stimulus behavior attributes must never survive sanitization, whatever an
-// extension's allowedElements declares. FORBID_ATTR alone isn't enough: in
-// DOMPurify 3.x the functional ADD_ATTR — which Lexxy builds from the public
-// allowedElements API — is evaluated ahead of FORBID_ATTR, so an extension that
-// listed one of these on a tag would otherwise reinstate it. This hook drops
-// them unconditionally, keeping the class-level prohibition config-independent.
+// extension's allowedElements declares. On dompurify 3.4.13 FORBID_ATTR already
+// carries that on its own: _isValidAttribute opens with it, ahead of the
+// functional ADD_ATTR Lexxy builds from the public allowedElements API. So this
+// hook is defence in depth rather than the barrier, and it is kept because it
+// holds without reference to the config — the prohibition is a class-level one,
+// and a FORBID_ATTR entry lives or dies with whatever rebuilds the config.
 function stimulusAttributeFilterHook(_currentNode, hookEvent) {
   if (FORBIDDEN_STIMULUS_ATTRIBUTES.includes(hookEvent.attrName)) {
     hookEvent.keepAttr = false

--- a/src/config/dom_purify.js
+++ b/src/config/dom_purify.js
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify"
 import { getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
+import Lexxy from "./lexxy"
 
 const ALLOWED_HTML_ATTRIBUTES = [ "class", "contenteditable", "href", "src", "style", "title" ]
 
@@ -16,21 +17,52 @@ const ALLOWED_STYLE_PROPERTIES = [ "color", "background-color" ]
 // URLs worked here — and, less happily, how `url="javascript:…"` survived too.
 // The fix restored validation for both.
 //
-// So `url` is marked URI-safe, which hands the decision to this hook, and the
-// hook allows exactly what DOMPurify allows on an img src: its default scheme
-// list plus data:. javascript: and friends are dropped, which is stricter than
-// what shipped before the upgrade. The hook only ever removes an attribute — it
-// never force-keeps one — so scoping stays with the ADD_ATTR predicate, and a
-// `url` on a tag that never declared it is dropped as it always was.
+// So `url` is marked URI-safe, which hands the decision to this hook. The hook
+// only ever removes an attribute — it never force-keeps one — so scoping stays
+// with the ADD_ATTR predicate, and a `url` on a tag that never declared it is
+// dropped as it always was.
+//
+// The data: exception is scoped to the attachment element, not to the attribute
+// name. ADD_URI_SAFE_ATTR is attribute-name-wide: it takes `url` out of
+// DOMPurify's URI checking on every tag, not just ours. Extensions may declare
+// arbitrary attributes on arbitrary tags — home/docs/extensions.md's own worked
+// example is an <iframe> — so an extension declaring `url` would otherwise
+// inherit an exception granted because *an attachment's* url becomes an img src.
+// Nothing about a third party's element supports that, and `data:text/html` in a
+// navigational sink is script execution. Everything else gets the standard
+// policy, which is what it would have had if we had never touched `url`.
 const URI_BEARING_ATTACHMENT_ATTRIBUTES = [ "url" ]
-const SAFE_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
+
+// DOMPurify's own IS_ALLOWED_URI, reproduced rather than narrowed, so `url` on a
+// non-attachment tag is treated exactly as DOMPurify would have treated it.
+const ALLOWED_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
+
+// The same list plus data:, for the attachment element only.
+//
+// One deliberate difference from DOMPurify's img[src] handling, stated because
+// the earlier claim of matching it "exactly" was not true: DOMPurify tests for a
+// literal lowercase `data:` at offset zero, and this is case-insensitive, so
+// `DATA:` passes here too. That matches how browsers resolve schemes, which is
+// what actually decides whether the URL loads.
+const ALLOWED_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
 // eslint-disable-next-line no-control-regex -- mirrors DOMPurify's own ATTR_WHITESPACE
 const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
 
-function attachmentUriFilterHook(_currentNode, hookEvent) {
+function isAttachmentTag(tag) {
+  return tag === Lexxy.global.get("attachmentTagName")
+}
+
+function attachmentUriFilterHook(currentNode, hookEvent) {
   if (!URI_BEARING_ATTACHMENT_ATTRIBUTES.includes(hookEvent.attrName)) return
 
-  if (!SAFE_ATTACHMENT_URI.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
+  let permitted
+  if (isAttachmentTag(currentNode?.nodeName?.toLowerCase())) {
+    permitted = ALLOWED_ATTACHMENT_URI
+  } else {
+    permitted = ALLOWED_URI
+  }
+
+  if (!permitted.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
     hookEvent.keepAttr = false
   }
 }

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -35,22 +35,31 @@ export function sanitize(html) {
 // Nothing about a third party's element supports that, and `data:text/html` in a
 // navigational sink is script execution. Everything else gets the standard
 // policy, which is what it would have had if we had never touched `url`.
+//
+// That argument is about an attribute feeding a URL sink, not about
+// ADD_URI_SAFE_ATTR as such. The inert text attributes beside `url` in that list
+// — `caption`, `filename` — keep the attribute-name-wide exemption, and need it:
+// ordinary prose like "Q4: results" is not a URI any regex here would accept.
 export const URI_BEARING_ATTACHMENT_ATTRIBUTES = [ "url" ]
 
 // DOMPurify's own IS_ALLOWED_URI, reproduced rather than narrowed, so `url` on a
 // non-attachment tag is treated exactly as DOMPurify would have treated it.
 const ALLOWED_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
 
-// The same list plus data:, for the attachment element only.
-//
-// One deliberate difference from DOMPurify's img[src] handling, stated because
-// the earlier claim of matching it "exactly" was not true: DOMPurify tests for a
-// literal lowercase `data:` at offset zero, and this is case-insensitive, so
-// `DATA:` passes here too. That matches how browsers resolve schemes, which is
-// what actually decides whether the URL loads.
-const ALLOWED_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
 // eslint-disable-next-line no-control-regex -- mirrors DOMPurify's own ATTR_WHITESPACE
 const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
+
+// Tested against the value as given, never the whitespace-stripped copy, so a
+// scheme smuggled at a nonzero offset is refused. DOMPurify draws the same line:
+// its data: allowance is a prefix test on the un-stripped value, which is why
+// this is a second step rather than one more scheme in ALLOWED_URI.
+//
+// One deliberate difference from DOMPurify's img[src] handling remains, stated
+// because the earlier claim of matching it "exactly" was not true: DOMPurify
+// tests for a literal lowercase `data:` and this is case-insensitive, so `DATA:`
+// passes here too. That matches how browsers resolve schemes, which is what
+// actually decides whether the URL loads.
+const ATTACHMENT_DATA_URI = /^data:/i
 
 function isAttachmentTag(tag) {
   return tag === Lexxy.global.get("attachmentTagName")
@@ -59,14 +68,14 @@ function isAttachmentTag(tag) {
 export function attachmentUriFilterHook(currentNode, hookEvent) {
   if (!URI_BEARING_ATTACHMENT_ATTRIBUTES.includes(hookEvent.attrName)) return
 
-  let permitted
-  if (isAttachmentTag(currentNode?.nodeName?.toLowerCase())) {
-    permitted = ALLOWED_ATTACHMENT_URI
-  } else {
-    permitted = ALLOWED_URI
-  }
+  // DOMPurify keeps an empty value — its chain ends `else if (value) { return
+  // false } else ;` — while every alternation here needs at least one character.
+  if (!hookEvent.attrValue) return
 
-  if (!permitted.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
-    hookEvent.keepAttr = false
-  }
+  const value = String(hookEvent.attrValue)
+
+  if (ALLOWED_URI.test(value.replace(ATTR_WHITESPACE, ""))) return
+  if (isAttachmentTag(currentNode?.nodeName?.toLowerCase()) && ATTACHMENT_DATA_URI.test(value)) return
+
+  hookEvent.keepAttr = false
 }

--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -1,4 +1,5 @@
 import { DOMPurify, buildConfig } from "../config/dom_purify"
+import Lexxy from "../config/lexxy"
 
 export function setSanitizerConfig(allowedTags) {
   DOMPurify.clearConfig()
@@ -7,4 +8,65 @@ export function setSanitizerConfig(allowedTags) {
 
 export function sanitize(html) {
   return DOMPurify.sanitize(html)
+}
+
+// An attachment's `url` ends up as an <img src> (action_text_attachment_node
+// reads it into `this.src`, which is assigned to img.src). DOMPurify already
+// permits a data: URI on img[src] — img is in its DATA_URI_TAGS — but it has no
+// way to know that a custom element's `url` feeds the same sink, so it applies
+// the plain URI check and drops it.
+//
+// Until 3.3.2 that never came up: attributes admitted by a *functional* ADD_ATTR
+// skipped URI validation entirely (GHSA-cjmm-f4jc-qw8r), which is how data:
+// URLs worked here — and, less happily, how `url="javascript:…"` survived too.
+// The fix restored validation for both.
+//
+// So `url` is marked URI-safe, which hands the decision to this hook. The hook
+// only ever removes an attribute — it never force-keeps one — so scoping stays
+// with the ADD_ATTR predicate, and a `url` on a tag that never declared it is
+// dropped as it always was.
+//
+// The data: exception is scoped to the attachment element, not to the attribute
+// name. ADD_URI_SAFE_ATTR is attribute-name-wide: it takes `url` out of
+// DOMPurify's URI checking on every tag, not just ours. Extensions may declare
+// arbitrary attributes on arbitrary tags — home/docs/extensions.md's own worked
+// example is an <iframe> — so an extension declaring `url` would otherwise
+// inherit an exception granted because *an attachment's* url becomes an img src.
+// Nothing about a third party's element supports that, and `data:text/html` in a
+// navigational sink is script execution. Everything else gets the standard
+// policy, which is what it would have had if we had never touched `url`.
+export const URI_BEARING_ATTACHMENT_ATTRIBUTES = [ "url" ]
+
+// DOMPurify's own IS_ALLOWED_URI, reproduced rather than narrowed, so `url` on a
+// non-attachment tag is treated exactly as DOMPurify would have treated it.
+const ALLOWED_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
+
+// The same list plus data:, for the attachment element only.
+//
+// One deliberate difference from DOMPurify's img[src] handling, stated because
+// the earlier claim of matching it "exactly" was not true: DOMPurify tests for a
+// literal lowercase `data:` at offset zero, and this is case-insensitive, so
+// `DATA:` passes here too. That matches how browsers resolve schemes, which is
+// what actually decides whether the URL loads.
+const ALLOWED_ATTACHMENT_URI = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i
+// eslint-disable-next-line no-control-regex -- mirrors DOMPurify's own ATTR_WHITESPACE
+const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g
+
+function isAttachmentTag(tag) {
+  return tag === Lexxy.global.get("attachmentTagName")
+}
+
+export function attachmentUriFilterHook(currentNode, hookEvent) {
+  if (!URI_BEARING_ATTACHMENT_ATTRIBUTES.includes(hookEvent.attrName)) return
+
+  let permitted
+  if (isAttachmentTag(currentNode?.nodeName?.toLowerCase())) {
+    permitted = ALLOWED_ATTACHMENT_URI
+  } else {
+    permitted = ALLOWED_URI
+  }
+
+  if (!permitted.test(String(hookEvent.attrValue).replace(ATTR_WHITESPACE, ""))) {
+    hookEvent.keepAttr = false
+  }
 }

--- a/test/javascript/unit/dom_purify_attachment_url.test.js
+++ b/test/javascript/unit/dom_purify_attachment_url.test.js
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test } from "vitest"
 import { DOMPurify, buildConfig } from "../../../src/config/dom_purify"
+import Lexxy from "../../../src/config/lexxy"
 
 function sanitizeWith(allowedElements, html) {
   return DOMPurify.sanitize(html, buildConfig(allowedElements))
@@ -72,6 +73,39 @@ describe("dom_purify — attachment url validation", () => {
     test("the attachment element still keeps its data: urls", () => {
       expect(sanitizeWith(withUrl, attachment("data:image/png;base64,iVBORw0KGgo=")))
         .toContain("data:image/png;base64,iVBORw0KGgo=")
+    })
+  })
+
+  // The scoping follows the *configured* attachment tag, not the literal
+  // action-text-attachment string — which is the whole point of reading it from
+  // the global. bc3 renames the element to bc-attachment, so this is that
+  // consumer's real path, and getting it wrong fails in one of two silent ways:
+  // bc3's avatars (data: urls on bc-attachment) get stripped, or a stray
+  // action-text-attachment keeps a data: exception it should no longer have.
+  describe("scoping follows the configured attachment tag name", () => {
+    const renamed = (tag, url) => `<${tag} content-type="image/*" url="${url}"></${tag}>`
+    const original = Lexxy.global.get("attachmentTagName")
+
+    afterEach(() => Lexxy.global.merge({ attachmentTagName: original }))
+
+    test("a renamed attachment element keeps its data: urls", () => {
+      Lexxy.global.merge({ attachmentTagName: "bc-attachment" })
+
+      const config = [ { tag: "bc-attachment", attributes: [ "url", "content-type" ] } ]
+      expect(sanitizeWith(config, renamed("bc-attachment", "data:image/png;base64,iVBORw0KGgo=")))
+        .toContain("data:image/png;base64,iVBORw0KGgo=")
+    })
+
+    test("the old name loses the exception once it is no longer the configured tag", () => {
+      Lexxy.global.merge({ attachmentTagName: "bc-attachment" })
+
+      // action-text-attachment is now just some element, so its url gets the
+      // standard policy — data: is refused, the element is kept.
+      const config = [ { tag: "action-text-attachment", attributes: [ "url", "content-type" ] } ]
+      const sanitized = sanitizeWith(config, renamed("action-text-attachment", "data:text/html,<b>x</b>"))
+
+      expect(sanitized).not.toContain("data:")
+      expect(sanitized).toContain("action-text-attachment")
     })
   })
 })

--- a/test/javascript/unit/dom_purify_attachment_url.test.js
+++ b/test/javascript/unit/dom_purify_attachment_url.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest"
+import { DOMPurify, buildConfig } from "../../../src/config/dom_purify"
+
+function sanitizeWith(allowedElements, html) {
+  return DOMPurify.sanitize(html, buildConfig(allowedElements))
+}
+
+const attachment = (url) => `<action-text-attachment content-type="image/*" url="${url}"></action-text-attachment>`
+const withUrl = [ { tag: "action-text-attachment", attributes: [ "url", "content-type" ] } ]
+
+// An attachment's `url` becomes an <img src>, so it has to allow the data: URIs
+// DOMPurify already allows there — without allowing the schemes it doesn't.
+//
+// Before dompurify 3.3.2 this attribute skipped URI validation altogether, because
+// it is admitted by a functional ADD_ATTR (GHSA-cjmm-f4jc-qw8r). That is what let
+// data: URLs through, and javascript: with them. These assert the split the hook
+// now draws, which is stricter than what shipped before the fix.
+describe("dom_purify — attachment url validation", () => {
+  test("keeps the data: URIs an attachment url legitimately carries", () => {
+    for (const url of [
+      "data:image/png;base64,iVBORw0KGgo=",
+      "data:application/pdf;base64,aGVsbG8=",
+      "data:image/svg+xml,%3Csvg%3E%3C/svg%3E",
+      "https://example.com/a.png",
+      "/rails/active_storage/blobs/a.png"
+    ]) {
+      expect(sanitizeWith(withUrl, attachment(url))).toContain(url)
+    }
+  })
+
+  test("drops an executable scheme from an attachment url", () => {
+    for (const url of [ "javascript:alert(1)", "JaVaScRiPt:alert(1)", "vbscript:msgbox(1)" ]) {
+      const sanitized = sanitizeWith(withUrl, attachment(url))
+
+      expect(sanitized).not.toContain("url=")
+      // The element itself survives — only the attribute is refused.
+      expect(sanitized).toContain("action-text-attachment")
+    }
+  })
+
+  // The hook only ever removes, so scoping stays with the ADD_ATTR predicate.
+  test("url is still refused on a tag that never declared it", () => {
+    expect(sanitizeWith([ "p" ], '<p url="data:image/png;base64,x">hi</p>')).toBe("<p>hi</p>")
+  })
+})

--- a/test/javascript/unit/dom_purify_attachment_url.test.js
+++ b/test/javascript/unit/dom_purify_attachment_url.test.js
@@ -42,4 +42,36 @@ describe("dom_purify — attachment url validation", () => {
   test("url is still refused on a tag that never declared it", () => {
     expect(sanitizeWith([ "p" ], '<p url="data:image/png;base64,x">hi</p>')).toBe("<p>hi</p>")
   })
+
+  // ADD_URI_SAFE_ATTR is attribute-name-wide, so without scoping by tag the data:
+  // exception granted to an attachment url reaches every extension that declares
+  // `url` on an element of its own — whose sink may be an iframe or a navigation
+  // rather than an img src, where data:text/html is script execution.
+  describe("the data: exception is the attachment element's, not the attribute name's", () => {
+    const extension = [ { tag: "x-widget", attributes: [ "url" ] } ]
+
+    test("an extension's url does not inherit it", () => {
+      const sanitized = sanitizeWith(extension, '<x-widget url="data:text/html,<script>alert(1)</script>"></x-widget>')
+
+      expect(sanitized).not.toContain("data:")
+      // Only the attribute is refused; the element an extension declared survives.
+      expect(sanitized).toContain("x-widget")
+    })
+
+    test("an extension's url keeps the schemes DOMPurify would have allowed anyway", () => {
+      for (const url of [ "https://example.com/a", "/rails/active_storage/blobs/a.png", "mailto:joe@example.com" ]) {
+        expect(sanitizeWith(extension, `<x-widget url="${url}"></x-widget>`)).toContain(url)
+      }
+    })
+
+    test("an extension's url still refuses an executable scheme", () => {
+      expect(sanitizeWith(extension, '<x-widget url="javascript:alert(1)"></x-widget>')).not.toContain("javascript:")
+    })
+
+    // Control: the attachment element is the one that keeps it.
+    test("the attachment element still keeps its data: urls", () => {
+      expect(sanitizeWith(withUrl, attachment("data:image/png;base64,iVBORw0KGgo=")))
+        .toContain("data:image/png;base64,iVBORw0KGgo=")
+    })
+  })
 })

--- a/test/javascript/unit/sanitization/dom_purify_attachment_url.test.js
+++ b/test/javascript/unit/sanitization/dom_purify_attachment_url.test.js
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "vitest"
-import { DOMPurify, buildConfig } from "../../../src/config/dom_purify"
-import Lexxy from "../../../src/config/lexxy"
+import { DOMPurify, buildConfig } from "src/config/dom_purify"
+import Lexxy from "src/config/lexxy"
 
 function sanitizeWith(allowedElements, html) {
   return DOMPurify.sanitize(html, buildConfig(allowedElements))

--- a/test/javascript/unit/sanitization/dom_purify_attachment_url.test.js
+++ b/test/javascript/unit/sanitization/dom_purify_attachment_url.test.js
@@ -29,6 +29,11 @@ describe("dom_purify — attachment url validation", () => {
     }
   })
 
+  // This is the hook's guard, and the only one. `url` is in ADD_URI_SAFE_ATTR, so
+  // DOMPurify does not validate it at all — delete the hook and leave that entry
+  // in place, which is the likeliest way this gets half-removed, and this is the
+  // assertion that fails. (Reverting both instead moves the failure to the data:
+  // case above, where DOMPurify's plain check refuses what the hook allowed.)
   test("drops an executable scheme from an attachment url", () => {
     for (const url of [ "javascript:alert(1)", "JaVaScRiPt:alert(1)", "vbscript:msgbox(1)" ]) {
       const sanitized = sanitizeWith(withUrl, attachment(url))
@@ -36,6 +41,28 @@ describe("dom_purify — attachment url validation", () => {
       expect(sanitized).not.toContain("url=")
       // The element itself survives — only the attribute is refused.
       expect(sanitized).toContain("action-text-attachment")
+    }
+  })
+
+  // The data: allowance is a prefix test on the value as given, matching
+  // DOMPurify's own. Stripping ATTR_WHITESPACE first instead would let a control
+  // character carry the scheme past offset zero — `new URL()` still resolves this
+  // one to protocol "data:", and DOMPurify refuses the same string on an img[src].
+  test("refuses a data: scheme hidden behind a leading control character", () => {
+    const sanitized = sanitizeWith(withUrl, attachment("\u0001data:text/html,<script>alert(1)</script>"))
+
+    expect(sanitized).not.toContain("data:")
+    expect(sanitized).toContain("action-text-attachment")
+  })
+
+  // DOMPurify keeps an empty value rather than refusing it — its check chain ends
+  // `else if (value) { return false } else ;` — and the hook has to agree, since
+  // what it rests on is that a `url` is treated exactly as DOMPurify would treat
+  // it. Values are trimmed before a hook sees them, so a whitespace-only url
+  // arrives empty too.
+  test("keeps an empty url, as DOMPurify keeps an empty img src", () => {
+    for (const url of [ "", "   " ]) {
+      expect(sanitizeWith(withUrl, attachment(url))).toContain('url=""')
     }
   })
 

--- a/test/system/attachment_url_round_trip_test.rb
+++ b/test/system/attachment_url_round_trip_test.rb
@@ -1,0 +1,100 @@
+require "application_system_test_case"
+
+# An attachment's `url` is now validated by Lexxy rather than skipped, so what a
+# `url` may carry is Lexxy's decision on the way out and Loofah's on the way in.
+# When the two disagree the editor shows an attachment the server quietly drops,
+# and the difference only appears after a reload.
+#
+# `action_text_load_test` loads a data: URL but stops there; this is the hop it
+# doesn't cover. A data: URI is the case that matters, because it is the one the
+# hook exists to permit — DOMPurify drops it on a custom element by default, and
+# an attachment's url becomes an <img src>, where data: is what Lexxy allows.
+class AttachmentUrlRoundTripTest < ApplicationSystemTestCase
+  DATA_URL = "data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="
+
+  test "an attachment url with a data: URI survives save, render and re-edit" do
+    post = Post.create!(title: "Data URL attachment", body: attachment_html(DATA_URL))
+
+    visit edit_post_path(post)
+    wait_for_editor
+
+    assert_url_in_editor_value
+
+    click_on "Update Post"
+
+    # The rendered page: the attachment has been through Loofah on the way in.
+    within "article.post" do
+      assert_selector %(action-text-attachment[url="#{DATA_URL}"]), visible: :all
+    end
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    assert_url_in_editor_value
+  end
+
+  # The other half of the same decision. Before dompurify 3.3.2 restored URI
+  # validation for functional ADD_ATTR attributes, this survived the round trip;
+  # the hook now refuses it, and the attachment element itself is kept.
+  test "an attachment url with an executable scheme never reaches the server" do
+    # Deliberate, and asserted rather than waved through — see the console check
+    # at the end of this test, which is the point of allowing it.
+    allow_console_messages
+
+    post = Post.create!(title: "Executable URL attachment", body: attachment_html("javascript:alert(1)"))
+
+    visit edit_post_path(post)
+    wait_for_editor
+
+    value = find_editor.value
+    assert_no_match(/javascript:/i, value,
+      "an executable scheme reached the value the form submits")
+    assert_includes value, "action-text-attachment",
+      "only the url should be refused, not the attachment element"
+
+    click_on "Update Post"
+
+    within "article.post" do
+      assert_no_selector %([url^="javascript:" i]), visible: :all
+    end
+
+    assert_only_console_message_is_the_refused_scheme
+  end
+
+  private
+    def attachment_html(url)
+      <<~HTML
+        <div><action-text-attachment content-type="image/gif" url="#{url}" filename="pixel.gif" filesize="43" width="1" height="1" previewable="true"></action-text-attachment></div>
+      HTML
+    end
+
+    def assert_url_in_editor_value
+      assert_includes find_editor.value, DATA_URL,
+        "the data: url was dropped from the value the form submits"
+    end
+
+    # Pins a known gap rather than tolerating noise.
+    #
+    # The sanitizer decides what reaches the *value*, which is what this test is
+    # about. It does not decide what the attachment node renders: the node reads
+    # the raw `url` into `this.src` and assigns it to img.src directly, so a
+    # refused scheme still lands in the editor DOM and the browser declines to
+    # load it. That console line is the gap, and it is why this test allows
+    # console messages at all.
+    #
+    # Not a regression — before this branch the scheme survived in the value too,
+    # so this is strictly narrower. Not exploitable either: browsers do not
+    # execute a javascript: URL in img[src]. Asserted exactly so that any *other*
+    # console error still fails, and so that whoever closes the gap in
+    # action_text_attachment_node finds the reason here instead of a bare
+    # allow_console_messages.
+    def assert_only_console_message_is_the_refused_scheme
+      messages = page.driver.browser.logs.get(:browser).map(&:message)
+
+      assert messages.any? { |message| message.include?("javascript:alert(1)") },
+        "expected the refused url to still reach img[src]; if this gap is closed, drop allow_console_messages here"
+
+      unrelated = messages.reject { |message| message.include?("javascript:alert(1)") }
+      assert_empty unrelated, "unexpected console messages beyond the known img[src] gap:\n#{unrelated.join("\n\n")}"
+    end
+end

--- a/test/system/attachment_url_round_trip_test.rb
+++ b/test/system/attachment_url_round_trip_test.rb
@@ -33,9 +33,14 @@ class AttachmentUrlRoundTripTest < ApplicationSystemTestCase
     assert_url_in_editor_value
   end
 
-  # The other half of the same decision. Before dompurify 3.3.2 restored URI
-  # validation for functional ADD_ATTR attributes, this survived the round trip;
-  # the hook now refuses it, and the attachment element itself is kept.
+  # The other half of the same decision, and the half the hook is the only guard
+  # for: `url` is in ADD_URI_SAFE_ATTR, so DOMPurify does not validate it at all.
+  # Delete the hook and leave that entry in place and an executable scheme rides
+  # through again, exactly as it did before dompurify 3.3.2 restored URI
+  # validation for functional ADD_ATTR attributes. Revert both instead — the hook
+  # and the ADD_URI_SAFE_ATTR entry — and it is the data: case above that fails,
+  # because DOMPurify's plain check refuses a data: URI on a custom element. The
+  # attachment element itself is kept either way.
   test "an attachment url with an executable scheme never reaches the server" do
     # Deliberate, and asserted rather than waved through — see the console check
     # at the end of this test, which is the point of allowing it.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dompurify@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.0.tgz#aaaadbb83d87e1c2fbb066452416359e5b62ec97"
-  integrity sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==
+dompurify@^3.4.13:
+  version "3.4.13"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
+  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
**Consumer action:** none required, but note the behaviour change below — an
attachment `url` with an executable scheme is now dropped.

## The bump

The floor was `^3.3.0` and the lockfile sat on 3.3.0, which nineteen published
advisories reach. 3.4.13 is the first release none of them do.

## Why it isn't only a bump

Bumping broke three browser tests, all `data:` URIs vanishing from a saved
attachment — and the cause is one of the advisories rather than a regression.
Until 3.3.2, an attribute admitted by a *functional* `ADD_ATTR` skipped URI
validation entirely ([GHSA-cjmm-f4jc-qw8r](https://github.com/cure53/DOMPurify/security/advisories/GHSA-cjmm-f4jc-qw8r)).
Lexxy builds `ADD_ATTR` from the public `allowedElements` API, so `url` took that
path: the `data:` URLs those tests cover worked because nothing was checking —
and `url="javascript:alert(1)"` survived for exactly the same reason. Confirmed
against 3.3.0: it keeps the `javascript:` URL.

An attachment's `url` becomes an `<img src>` (`action_text_attachment_node` reads
it into `this.src`). DOMPurify already permits `data:` on `img[src]`, since `img`
is in its `DATA_URI_TAGS`, but it cannot know a custom element's `url` feeds that
same sink, so it applies the plain URI check and drops it. `ADD_DATA_URI_TAGS`
doesn't help — that check only covers `src`/`href`/`xlink:href`.

So `url` is marked URI-safe, which hands the decision to a hook, and the hook
allows exactly what DOMPurify allows on an `img src`: its scheme list, then
`data:` as a separate prefix test on the value as given. The hook only ever
*removes* an attribute, never force-keeps one, so scoping stays with the
`ADD_ATTR` predicate — a `url` on a tag that never declared it is dropped as
before. An empty value is kept, as DOMPurify keeps an empty `img src`.

**Net effect is stricter than what shipped:** `data:` URIs still round-trip, and
`javascript:` no longer does.

### Why reproducing the scheme check is sound

The check runs on the attribute value before the browser ever sees it, and every
normalization a browser applies before resolving a scheme — leading and trailing
whitespace, embedded control characters, tabs and newlines — is a *subset* of
DOMPurify's `ATTR_WHITESPACE`. So the string tested here always exposes at least
as much of the scheme as the browser will. That's an invariant, not a
coincidence, and it is what makes a copied regex safe rather than merely
convenient. The `data:` allowance is deliberately *not* part of that regex: it is
a prefix test on the un-stripped value, matching DOMPurify's own, so a control
character cannot carry the scheme past offset zero.

One deliberate divergence remains, and only one: DOMPurify tests for a literal
lowercase `data:` and this test is case-insensitive, so `DATA:` passes here too.
That matches how browsers resolve schemes, which is what decides whether the URL
loads.

The argument for scoping the `data:` exception to the attachment element rather
than to the attribute name is about an attribute feeding a URL sink. It is not an
argument against `ADD_URI_SAFE_ATTR` in general: `caption` and `filename` sit in
the same list with a blanket exemption and need it, since prose like
`Q4: results` is not a URI. Only `url` reaches a sink.

## Verification

Both mutations were run, and they are not the same mutation:

- **Delete the hook, leave `url` in `ADD_URI_SAFE_ATTR`.** The `javascript:` case
  fails, along with the extension-scoping and control-character cases. This is
  the likeliest way the mechanism gets half-removed, and
  `dom_purify_attachment_url.test.js`'s `javascript:` assertion is its only
  tripwire — with `url` URI-safe, DOMPurify does no validation of its own.
- **Revert the whole mechanism.** The three `data:` cases fail and everything
  else passes, because DOMPurify's plain check refuses a `data:` URI on a custom
  element.

The unit tests are 11 passing, the round-trip system test 2. WebKit can't launch
on the machine this was verified on (missing `libicu74`), so the Playwright
WebKit project is CI-only coverage here.

---

**Part of a series** re-filing #1227 at reviewable scope, after #1227 was reverted
from `main` in 8c64aa45. Merge order: #1228 → **this** → #images → #instance →
#trusted-types → #1226. Nothing here is released.

Note for whoever does the bc3 bump afterwards: bc3 pins `dompurify: 3.4.0` in both
`dependencies` and `resolutions`, and `resolutions` overrides this floor — so that
pin has to move too, or bc3 gets 3.4.0 regardless of what lexxy asks for.

*Draft: needs human review and a soak period before merging.*
