### PR TITLE
Don't delete an attachment dropped onto one that can't form a gallery

### DIFF
--- a/src/editor/attachments/drag_and_drop.js
+++ b/src/editor/attachments/drag_and_drop.js
@@ -277,15 +277,18 @@ export class AttachmentDragAndDrop {
     if (!targetNode || !$isActionTextAttachmentNode(targetNode)) return
     if (draggedNode.is(targetNode)) return
 
+    // Resolve the gallery before detaching: the drop target matches any
+    // previewable attachment, but galleries only accept images, so removing
+    // first deleted PDFs and videos dropped onto another attachment.
+    const gallery = $findOrCreateGalleryForImage(targetNode)
+    if (!gallery) return
+
     draggedNode.remove()
 
-    const gallery = $findOrCreateGalleryForImage(targetNode)
-    if (gallery) {
-      if (position === "before") {
-        targetNode.insertBefore(draggedNode)
-      } else {
-        targetNode.insertAfter(draggedNode)
-      }
+    if (position === "before") {
+      targetNode.insertBefore(draggedNode)
+    } else {
+      targetNode.insertAfter(draggedNode)
     }
   }
 

--- a/test/browser/tests/attachments/attachment_drag_and_drop.test.js
+++ b/test/browser/tests/attachments/attachment_drag_and_drop.test.js
@@ -146,6 +146,22 @@ test.describe("Attachment Drag and Drop", () => {
 
       await assertGalleryWithImages(editor, 3)
     })
+
+    test("drag a previewable non-image onto another keeps both", async ({ page, editor }) => {
+      await editor.uploadFile("test/fixtures/files/dummy.pdf")
+      await editor.send("Enter")
+      await editor.uploadFile("test/fixtures/files/dummy.pdf")
+      await waitForUploadsComplete(page, editor)
+      await expect(page.locator("figure.attachment")).toHaveCount(2)
+
+      await simulateDragByIndex(page, 1, 0, "onto")
+      await editor.flush()
+
+      // Galleries only take images, so this drop cannot be honoured. It should
+      // leave the document alone rather than swallow the dragged attachment.
+      await assertNoGallery(page)
+      await expect(page.locator("figure.attachment")).toHaveCount(2)
+    })
   })
 
   test.describe("Within-gallery reorder", () => {


### PR DESCRIPTION
Fixes #1235.

`#dropOntoImage` removed the dragged node before working out whether a gallery could take it, and re-inserted it only when `$findOrCreateGalleryForImage` returned one. Dropping a PDF or a video onto another attachment therefore deleted it: the drop target is resolved in the DOM against `figure.attachment--preview`, which matches any previewable attachment, while `ImageGalleryNode.isValidChild` gates on `isPreviewableImage` and admits only raster images. When the two disagreed, the node was removed and never put back.

Resolving the gallery before mutating anything makes an unsupported drop a no-op.

## Test

Adds a regression test under "Gallery creation": two PDFs, drag one onto the other, assert both survive and no gallery is created. It fails on `main` with `toHaveCount(2)` receiving `1`, and passes here.

The rest of `attachment_drag_and_drop.test.js`, `drop_in_gallery.test.js` and `gallery.test.js` still pass, 40 tests in Chromium.

## Not addressed here

Two related things, deliberately left out to keep this to the data-loss fix:

- The gallery drop markers still appear over a target that cannot accept the drop, because the DOM-level `attachment--preview` check is broader than `isValidChild`. The drop is now harmless, but the affordance is still misleading.
- Whether galleries should accept previewable PDFs at all is a separate question, which I'll raise on its own.
