### PR TITLE
Bump DOMPurify to ^3.4.0 to restore URI validation on attachment url

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@lexical/selection": "^0.44.0",
     "@lexical/table": "^0.44.0",
     "@lexical/utils": "^0.44.0",
-    "dompurify": "^3.3.0",
+    "dompurify": "^3.4.0",
     "lexical": "^0.44.0",
     "marked": "^16.4.1",
     "prismjs": "^1.30.0"

--- a/test/javascript/unit/config/sanitization.test.js
+++ b/test/javascript/unit/config/sanitization.test.js
@@ -1,0 +1,54 @@
+import { expect, test, describe, beforeEach } from "vitest"
+
+import { setSanitizerConfig, sanitize } from "src/helpers/sanitization_helper"
+import { ActionTextAttachmentNode } from "src/nodes/action_text_attachment_node"
+
+// Mirrors AttachmentsExtension#allowedElements (src/extensions/attachments_extension.js).
+const TAG = ActionTextAttachmentNode.TAG_NAME
+const ATTACHMENT_ATTRIBUTES = [ "alt", "caption", "content", "content-type", "data-direct-upload-id",
+  "data-sgid", "filename", "filesize", "height", "presentation", "previewable", "sgid", "url", "width" ]
+
+function sanitizeAttachment(html) {
+  setSanitizerConfig([ { tag: TAG, attributes: ATTACHMENT_ATTRIBUTES } ])
+  return sanitize(html)
+}
+
+// Regression coverage for GHSA-cjmm-f4jc-qw8r: DOMPurify's ADD_ATTR-predicate form
+// skipped URI validation, so a dangerous scheme in the attachment `url` attribute
+// survived sanitization. The attachment `url` is read into an <img src>, so a bumped,
+// URI-validating DOMPurify must reject javascript:/data: there while leaving legitimate
+// blob download URLs (absolute and relative) intact.
+describe("action-text-attachment url sanitization", () => {
+  beforeEach(() => {
+    setSanitizerConfig([ { tag: TAG, attributes: ATTACHMENT_ATTRIBUTES } ])
+  })
+
+  test("strips a javascript: scheme from the url attribute", () => {
+    const output = sanitizeAttachment(`<${TAG} url="javascript:alert(document.domain)" content-type="image/*"></${TAG}>`)
+    expect(output).not.toMatch(/javascript:/i)
+  })
+
+  test("strips a data:text/html scheme from the url attribute", () => {
+    const output = sanitizeAttachment(`<${TAG} url="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" content-type="image/*"></${TAG}>`)
+    expect(output).not.toMatch(/data:text\/html/i)
+  })
+
+  test("keeps a legitimate absolute https url", () => {
+    const url = "https://bc3-production.s3.amazonaws.com/blob/example.png"
+    const output = sanitizeAttachment(`<${TAG} url="${url}" content-type="image/*"></${TAG}>`)
+    expect(output).toContain(url)
+  })
+
+  test("keeps a legitimate relative ActiveStorage url", () => {
+    const url = "/rails/active_storage/blobs/redirect/abc123/example.png"
+    const output = sanitizeAttachment(`<${TAG} url="${url}" content-type="image/*"></${TAG}>`)
+    expect(output).toContain(url)
+  })
+
+  test("preserves the serialized-HTML content attribute", () => {
+    // The `content` attribute intentionally carries serialized HTML (SAFE_FOR_XML: false);
+    // it must survive sanitization here — it is scrubbed server-side, not by this pass.
+    const output = sanitizeAttachment(`<${TAG} content="&quot;&lt;b&gt;hi&lt;/b&gt;&quot;" content-type="text/html"></${TAG}>`)
+    expect(output).toMatch(/content=/)
+  })
+})

--- a/test/system/attachment_url_sanitization_test.rb
+++ b/test/system/attachment_url_sanitization_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+# Regression coverage for GHSA-cjmm-f4jc-qw8r. DOMPurify's ADD_ATTR-predicate form
+# (used by buildConfig for per-tag attribute allowlisting) skipped URI validation, so a
+# javascript: scheme in an action-text-attachment `url` — which is read into an <img src>
+# — survived sanitization. This exercises the full Action Text round-trip
+# (editor -> save -> render -> re-edit) and asserts the dangerous scheme is stripped at
+# every stage while a legitimate image url survives.
+class AttachmentUrlSanitizationTest < ApplicationSystemTestCase
+  SAFE_URL = "https://example.com/safe.png".freeze
+  UNSAFE_URL = "javascript:alert(document.domain)".freeze
+
+  setup do
+    # Injecting a javascript: url makes the browser log ERR_UNKNOWN_URL_SCHEME when it
+    # fails to *load* the <img src> (which is exactly why it is inert), and the placeholder
+    # https image 404s — both are expected console noise for this test.
+    allow_console_messages
+    visit edit_post_path(posts(:empty))
+    wait_for_editor
+  end
+
+  test "strips a javascript: attachment url across save/render/re-edit while a safe url survives" do
+    find_editor.value = <<~HTML.gsub("\n", "")
+      <p>before</p>
+      <action-text-attachment content-type="image/png" url="#{SAFE_URL}"></action-text-attachment>
+      <action-text-attachment content-type="image/png" url="#{UNSAFE_URL}"></action-text-attachment>
+      <p>after</p>
+    HTML
+
+    click_on "Update Post"
+
+    # Wait for the show page (only it carries "Edit this post"), then assert on the rendered body.
+    assert_link "Edit this post"
+    rendered = find("article.post")["innerHTML"]
+    assert_includes rendered, SAFE_URL, "the legitimate image url should survive to the rendered page"
+    refute_match(/javascript:/i, rendered, "no javascript: scheme should reach the rendered page")
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    reedited = find_editor.value
+    assert_includes reedited, SAFE_URL, "the legitimate image url should survive re-edit"
+    refute_match(/javascript:/i, reedited, "no javascript: scheme should survive into the re-opened editor")
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dompurify@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.0.tgz#aaaadbb83d87e1c2fbb066452416359e5b62ec97"
-  integrity sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==
+dompurify@^3.4.0:
+  version "3.4.13"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
+  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## What

Bumps DOMPurify `^3.3.0` → `^3.4.0` (resolves to 3.4.13) and adds a sanitizer regression test.

## Why

DOMPurify 3.3.0 is affected by **GHSA-cjmm-f4jc-qw8r** ("ADD_ATTR predicate skips URI validation", patched in 3.3.2 / 3.4.0 / 3.4.2). `buildConfig` passes `ADD_ATTR` as a **predicate function** for per-tag attribute allowlisting:

```js
ADD_ATTR: (attribute, tag) => tagAttributes[tag]?.includes(attribute),
```

In 3.3.0, `_isValidAttribute` short-circuits at the predicate branch and returns `true` **before** the `IS_ALLOWED_URI` check, so a `javascript:` / `data:text/html` value in an allowlisted URI attribute survives `sanitize()`. In practice this means a `<action-text-attachment url="javascript:…">` keeps its dangerous `url`, which is read into an `<img src>` (`action_text_attachment_node.js`).

On our own render paths this is inert (a `javascript:` URL in `<img src>` doesn't execute), but it's a genuine sanitizer bypass and would be exposed for any consumer that routes the attachment `url` to a navigable sink. Fixing the flagged dependency is the right resolution rather than papering over the one sink.

## The fix

Bumping to the patched line makes predicate-allowed attributes run URI validation again:

- `javascript:` / `data:text/html` are **stripped** from `url`.
- Legitimate **absolute** (`https://…`) and **relative** (`/rails/active_storage/…`) blob URLs pass unchanged.
- `caption` / `filename` remain in `ADD_URI_SAFE_ATTR` — they're display strings, not URL sinks, so they're intentionally not URI-validated and are unaffected.
- The `content` attribute (serialized HTML, `SAFE_FOR_XML: false`) is preserved.

## Verification

- New unit test `test/javascript/unit/config/sanitization.test.js` covers all five cases above.
- Full `yarn vitest run` suite green (132 tests).
- `yarn build` compiles clean with 3.4.13.

The browser suite (`yarn test:browser`) isn't run here — CI should exercise it, since the bump changes URI-validation behavior for predicate-allowlisted attributes on custom elements (attachment paste/import/export paths worth a look).

## Credit

Reported via HackerOne by **@petitpois**. Advisory: [GHSA-cjmm-f4jc-qw8r](https://github.com/advisories/GHSA-cjmm-f4jc-qw8r).

🤖 Generated with [Claude Code](https://claude.com/claude-code)