### PR TITLE
Resolve the link under a caret sitting at its trailing edge

### DIFF
--- a/src/editor/command_dispatcher.js
+++ b/src/editor/command_dispatcher.js
@@ -102,6 +102,8 @@ export class CommandDispatcher {
 
   dispatchLink(url) {
     this.editor.update(() => {
+      this.selection.placeCursorInsideAdjacentLink()
+
       const selection = $getSelection()
       if (!$isRangeSelection(selection)) return
 
@@ -125,6 +127,7 @@ export class CommandDispatcher {
         return
       }
 
+      this.selection.placeCursorInsideAdjacentLink()
       $toggleLink(null)
     })
   }

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -11,7 +11,7 @@ import { CodeNode } from "@lexical/code"
 import { isSelectionHighlighted } from "../helpers/format_helper"
 import { getNonce } from "../helpers/csp_helper"
 import { $createNodeSelectionWith, $isListItemStructurallyEmpty, getListType } from "../helpers/lexical_helper"
-import { LinkNode } from "@lexical/link"
+import { $isLinkNode, LinkNode } from "@lexical/link"
 import { $isHeadingNode, $isQuoteNode, QuoteNode } from "@lexical/rich-text"
 import { $isActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 import { ListenerBin, handlingDefault, registerEventListener } from "../helpers/listener_helper"
@@ -118,6 +118,14 @@ export default class Selection {
   nearestNodeOfType(nodeType) {
     const anchorNode = $getSelection()?.anchor?.getNode()
     return $getNearestNodeOfType(anchorNode, nodeType)
+  }
+
+  get linkUrl() {
+    return this.#linkAtCursor()?.getURL() ?? null
+  }
+
+  placeCursorInsideAdjacentLink() {
+    this.#linkEndingAtCursor()?.selectEnd()
   }
 
   get hasSelectedWordsInSingleLine() {
@@ -271,6 +279,26 @@ export default class Selection {
     this.previouslySelectedKeys = null
 
     this.#listeners.dispose()
+  }
+
+  #linkAtCursor() {
+    const anchorNode = $getSelection()?.anchor?.getNode()
+    return $getNearestNodeOfType(anchorNode, LinkNode) ?? this.#linkEndingAtCursor()
+  }
+
+  // Lexical resolves a caret sitting at a link's trailing edge to the start of the
+  // node that follows it, so a cursor that looks like it's on the link lands outside.
+  #linkEndingAtCursor() {
+    const selection = $getSelection()
+    if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null
+
+    const { anchor } = selection
+    if (anchor.type !== "text" || anchor.offset !== 0) return null
+
+    const previousSibling = anchor.getNode().getPreviousSibling()
+    if (!$isLinkNode(previousSibling)) return null
+
+    return previousSibling
   }
 
   // When all inline code text is deleted, Lexical's selection retains the stale

--- a/src/elements/dropdown/link.js
+++ b/src/elements/dropdown/link.js
@@ -1,4 +1,3 @@
-import { LinkNode } from "@lexical/link"
 import { ToolbarDropdown } from "../toolbar_dropdown"
 import { registerEventListener } from "../../helpers/listener_helper"
 
@@ -54,10 +53,7 @@ export class LinkDropdown extends ToolbarDropdown {
   }
 
   get #selectedLinkUrl() {
-    return this.editor.getEditorState().read(() => {
-      const linkNode = this.editorElement.selection.nearestNodeOfType(LinkNode)
-      return linkNode?.getURL() ?? ""
-    })
+    return this.editor.read(() => this.editorElement.selection.linkUrl ?? "")
   }
 }
 

--- a/test/browser/tests/formatting/block_formatting.test.js
+++ b/test/browser/tests/formatting/block_formatting.test.js
@@ -508,6 +508,94 @@ test.describe("Block formatting", () => {
     await expect(input).toHaveValue("https://37signals.com")
   })
 
+  test("editing an existing link with a collapsed caret replaces its URL", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      '<p>Hello <a href="https://37signals.com">everyone</a></p>',
+    )
+    await editor.placeCaretInside("everyone", 4)
+    await editor.flush()
+
+    await openToolbarDropdown(page, "link")
+
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
+    await expect(input).toHaveValue("https://37signals.com")
+    await input.fill("https://example.com")
+    await page
+      .locator("lexxy-link-dropdown [data-dropdown-panel] button[value='link']")
+      .first()
+      .click()
+
+    await assertEditorHtml(
+      editor,
+      '<p>Hello <a href="https://example.com">everyone</a></p>',
+    )
+  })
+
+  test("editing an existing link with the caret at its trailing edge replaces its URL", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      '<p>Hello <a href="https://37signals.com">everyone</a> bye</p>',
+    )
+    await editor.placeCaretInside("everyone", "everyone".length)
+    await editor.flush()
+
+    await openToolbarDropdown(page, "link")
+
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
+    await expect(input).toBeVisible({ timeout: 2_000 })
+    await input.fill("https://example.com")
+    await page
+      .locator("lexxy-link-dropdown [data-dropdown-panel] button[value='link']")
+      .first()
+      .click()
+
+    await assertEditorHtml(
+      editor,
+      '<p>Hello <a href="https://example.com">everyone</a> bye</p>',
+    )
+  })
+
+  test("unlinking with the caret at a link's trailing edge removes the link", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      '<p>Hello <a href="https://37signals.com">everyone</a> bye</p>',
+    )
+    await editor.placeCaretInside("everyone", "everyone".length)
+    await editor.flush()
+
+    await openToolbarDropdown(page, "link")
+    await page
+      .locator("lexxy-link-dropdown [data-dropdown-panel] button[value='unlink']")
+      .first()
+      .click()
+
+    await assertEditorHtml(editor, "<p>Hello everyone bye</p>")
+  })
+
+  test("link dialog shows existing URL when the caret is at the link's trailing edge", async ({
+    page,
+    editor,
+  }) => {
+    await editor.setValue(
+      '<p>Hello <a href="https://37signals.com">everyone</a> bye</p>',
+    )
+    await editor.placeCaretInside("everyone", "everyone".length)
+    await editor.flush()
+
+    await openToolbarDropdown(page, "link")
+
+    const input = page.locator("lexxy-link-dropdown [data-dropdown-panel] input[type='url']").first()
+    await expect(input).toBeVisible({ timeout: 2_000 })
+    await expect(input).toHaveValue("https://37signals.com")
+  })
+
   test("link dialog shows empty input when no link is selected", async ({
     page,
     editor,


### PR DESCRIPTION
Fixes #922.

## The bug

Put the caret in an existing link, press Cmd+K, change the URL, confirm. Instead of updating the href, a new link is inserted using the URL as its own text, and the original link is split in two.

## Why

Lexical normalizes a collapsed point at a link's trailing edge out of the `LinkNode` and onto offset 0 of the text node that follows it. A selection probe with the caret at offset 8 of `everyone` in `Hello <a>everyone</a> bye`:

```
{"type":"text","offset":0,"chain":["text#8:\" bye\"","paragraph#4","root"]}
```

while offsets 0 and 4 stay on `["text#7:\"everyone\"","link#6",...]`.

So the guard in `dispatchLink` sees no link, takes the `$createAutoLinkNode` branch, and inserts. The same normalization is why `LinkDropdown` opened with an empty URL field, and why `$toggleLink(null)` in `dispatchUnlink` silently did nothing at that position. One cause, three symptoms.

## The fix

Normalize the caret back into the link before link and unlink run, and route the dialog's prefill through the same lookup. The existing guard is then correct as written, so `command_dispatcher.js` is a three-line addition with its imports untouched.

## Tests

Four cases in `test/browser/tests/formatting/block_formatting.test.js`, alongside the existing link-dropdown tests. All four were confirmed failing against unmodified `main` first; the reproduction case produced the issue's output verbatim:

```
Received: "<p>Hello <a href="https://37signals.com">everyone</a><a href="https://example.com">https://example.com</a> bye</p>"
```

## Notes for review

- **Known remaining inconsistency:** the toolbar Link button still does not highlight when the caret is at a link's trailing edge, even though the dialog now prefills and editing works there. A one-line change to `getFormat().isInLink` fixes it, but no test required it so it is not in this PR. Happy to add it with a test if you would prefer it here.
- Boundary handling is deliberately limited to a text anchor at offset 0 whose previous sibling is a link, which is the shape Lexical actually produces. A caret at offset 0 of text nested inside a following inline element is not covered; I left it rather than add speculative traversal.
- `yarn test:browser` passes except `prompts/cursor_moves_away` on firefox and webkit, which fail identically on `main`. That test calls `page.keyboard.press("End")` directly instead of the helper that maps End to Meta+ArrowRight on macOS, so the caret never moves. Unrelated to this change and left alone.
- `yarn lint` clean.