### PR TITLE
Keep the editor mounted when Turbo caches without navigating

### DIFF
--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -283,7 +283,7 @@ export default class Contents {
   }
 
   uploadFiles(files, { selectLast } = {}) {
-    if (!this.editorElement) return // Disposed (e.g. on turbo:before-cache); a late drop can still land here
+    if (!this.editorElement) return // Disposed (e.g. on disconnect); a late drop can still land here
 
     if (!this.editorElement.supportsAttachments) {
       console.warn("This editor does not supports attachments (it's configured with [attachments=false])")

--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -401,7 +401,6 @@ export class LexicalEditorElement extends HTMLElement {
     this.#registerFileAcceptFilter()
     this.#attachDebugHooks()
     this.#attachToolbar()
-    this.#resetBeforeTurboCaches()
 
     this.#setInternalFormValue(this.value, { suppressEvent: true })
     this.#synchronizeWithChanges()
@@ -418,7 +417,7 @@ export class LexicalEditorElement extends HTMLElement {
   }
 
   #createEditor() {
-    this.editorContentElement ||= this.#createEditorContentElement()
+    this.editorContentElement ||= this.#findOrCreateEditorContentElement()
     this.appendChild(this.editorContentElement)
 
     const editor = buildEditorFromExtensions({
@@ -466,6 +465,11 @@ export class LexicalEditorElement extends HTMLElement {
     }
 
     return nodes
+  }
+
+  // A restored Turbo snapshot already carries the content element; Lexical empties it on mount.
+  #findOrCreateEditorContentElement() {
+    return this.querySelector(":scope > .lexxy-editor__content") ?? this.#createEditorContentElement()
   }
 
   #createEditorContentElement() {
@@ -530,18 +534,6 @@ export class LexicalEditorElement extends HTMLElement {
       .clear()
       .selectEnd()
       .insertNodes(this.#parseHtmlIntoLexicalNodes(html, { editor }))
-  }
-
-  #resetBeforeTurboCaches() {
-    this.#listeners.track(
-      registerEventListener(document, "turbo:before-cache", this.#handleTurboBeforeCache)
-    )
-  }
-
-  #handleTurboBeforeCache = (event) => {
-    if (!this.closest("[data-turbo-permanent]")) {
-      this.#reset()
-    }
   }
 
   #synchronizeWithChanges() {

--- a/test/browser/tests/attachments/upload_after_editor_disposed.test.js
+++ b/test/browser/tests/attachments/upload_after_editor_disposed.test.js
@@ -11,18 +11,16 @@ test.describe("Uploading after the editor is disposed", () => {
   })
 
   // "Cannot read properties of null (reading 'supportsAttachments')":
-  // turbo:before-cache disposes the editor in place (Contents#editorElement becomes null)
-  // while the element stays in the DOM, so a late drop relayed by a document-level drop zone
-  // still calls Contents#uploadFiles on the disposed instance. It must be a no-op, not a crash.
-  test("uploading after turbo:before-cache disposes the editor is a no-op", async ({ page, editor }) => {
+  // disconnecting disposes the editor (Contents#editorElement becomes null), so a late drop
+  // relayed by a document-level drop zone still calls Contents#uploadFiles on the disposed
+  // instance. It must be a no-op, not a crash.
+  test("uploading after the editor is disposed is a no-op", async ({ page, editor }) => {
     await editor.setValue("<p>hello</p>")
     await editor.flush()
 
     const errorMessage = await page.evaluate(() => {
       const editorElement = document.querySelector("lexxy-editor")
-
-      // Turbo caches the page on every navigation; lexxy resets the editor in place.
-      document.dispatchEvent(new Event("turbo:before-cache"))
+      editorElement.remove()
 
       const file = new File([ "x" ], "late-drop.png", { type: "image/png" })
       try {

--- a/test/browser/tests/attachments/upload_survives_teardown.test.js
+++ b/test/browser/tests/attachments/upload_survives_teardown.test.js
@@ -3,9 +3,9 @@ import { expect } from "@playwright/test"
 import { mockActiveStorageUploads } from "../../helpers/active_storage_mock.js"
 
 // An in-flight direct upload can outlive the editor: teardown runs on
-// disconnect and on every turbo:before-cache, but the upload's ActiveStorage
-// callbacks still fire afterwards — #forgetUploadRequest when the store PUT
-// completes, #rememberUploadRequest when blob creation resolves — and both
+// disconnect, but the upload's ActiveStorage callbacks still fire afterwards
+// — #forgetUploadRequest when the store PUT completes,
+// #rememberUploadRequest when blob creation resolves — and both
 // dereference #editorElement on a torn-down editor.
 // Sentry: BC3-JS-N8HN, BC3-JS-N8HP.
 test.describe("Upload outliving editor teardown", () => {

--- a/test/browser/tests/editor/turbo_caching.test.js
+++ b/test/browser/tests/editor/turbo_caching.test.js
@@ -1,0 +1,37 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+// Turbo clones the DOM one event loop tick after dispatching `turbo:before-cache`,
+// so the snapshot carries whatever the editor has built by then.
+const cacheAndRestoreSnapshot = (page) => page.evaluate(async () => {
+  document.dispatchEvent(new Event("turbo:before-cache"))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  const snapshot = document.body.cloneNode(true)
+  document.body.replaceWith(snapshot)
+})
+
+test.describe("Turbo caching", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("restoring a cached snapshot rebuilds a single, editable editor", async ({ page, editor }) => {
+    await editor.focus()
+    await editor.send("Hello")
+
+    await cacheAndRestoreSnapshot(page)
+
+    const editorElement = page.locator("lexxy-editor")
+    await expect(editorElement.locator(".lexxy-editor__content[data-lexical-editor]")).toHaveCount(1)
+    await expect(editorElement.locator("lexxy-toolbar")).toHaveCount(1)
+    await expect(editorElement.locator("lexxy-table-tools")).toHaveCount(1)
+    await expect(editorElement.locator("lexxy-code-language-picker")).toHaveCount(1)
+
+    await editor.focus()
+    await editor.send("Restored")
+
+    expect(await editor.plainTextValue()).toEqual("Restored")
+  })
+})

--- a/test/system/turbo_caching_test.rb
+++ b/test/system/turbo_caching_test.rb
@@ -1,0 +1,39 @@
+require "application_system_test_case"
+
+class TurboCachingTest < ApplicationSystemTestCase
+  # A same-document fragment navigation fires a native popstate with no Turbo state,
+  # which makes Turbo cache the page without ever navigating away from it.
+  test "editor survives an in-page anchor navigation" do
+    visit edit_post_path(posts(:empty))
+    assert_mounted_editor
+
+    find_editor.send "Hello"
+    page.execute_script("window.location.hash = 'comments'")
+
+    assert_mounted_editor
+    find_editor.send " world"
+    assert_editor_plain_text "Hello world"
+  end
+
+  test "editor is restored intact from the Turbo page cache" do
+    visit edit_post_path(posts(:empty))
+    assert_mounted_editor
+
+    find_editor.send "Hello"
+
+    click_on "← Back to posts"
+    assert_selector "h1", text: "Posts"
+
+    page.go_back
+    assert_mounted_editor
+
+    find_editor.send "Restored"
+    assert_editor_plain_text "Restored"
+  end
+
+  private
+    def assert_mounted_editor
+      wait_for_editor
+      assert_css "lexxy-editor .lexxy-editor__content[data-lexical-editor]", count: 1
+    end
+end


### PR DESCRIPTION
Fixes #1200.

## The bug

`#handleTurboBeforeCache` removes the content element and nulls the field, assuming a `connectedCallback` will follow. Turbo dispatches `turbo:before-cache` from `historyPoppedWithEmptyState` for any same-document popstate carrying no Turbo state, such as clicking an in-page anchor. Nothing reconnects, so the contenteditable body is gone until a full reload, leaving only the toolbar.

Confirmed against Turbo's current source: `history.js#onPopState` falls through to `historyPoppedWithEmptyState` when `event.state` has no `turbo` key, and that method is `this.history.replace(location); this.view.lastRenderedLocation = location; this.view.cacheSnapshot()`.

**One correction to the issue:** this does not require Turbo Drive to be disabled. My probe on the dummy app recorded `driveEnabled => true` and still reproduced.

## The fix

The reset was added in 371f16ad to stop the toolbar and contents duplicating on snapshot restore. But `#findOrCreateDefaultToolbar`, `lexxy-table-tools` and `lexxy-code-language-picker` are all looked up before being created, so they never duplicated. Only `editorContentElement` was created unconditionally.

Looking it up the same way removes the need for the handler entirely, so this deletes more than it adds. Lexical's `resetEditor` does `nextRootElement.textContent = ''` before mounting, so adopting a snapshot's content element with stale children is safe.

I did not take the self-healing re-mount option. Turbo's `PageView#cacheSnapshot` dispatches the event synchronously, then `await nextEventLoopTick()` before cloning, so a `requestAnimationFrame` or `setTimeout(0)` re-mount queued from our handler lands before the clone and reintroduces the duplication the reset existed to prevent. Getting it right would mean double-deferring to land after Turbo's internal tick.

## Tests

- `test/system/turbo_caching_test.rb` is the reproduction, using real Turbo. `window.location.hash = 'comments'` is what clicking `<a href="#comments">` does. Confirmed failing on original source. Its second test covers the real Drive cache and restore path.
- `test/browser/tests/editor/turbo_caching.test.js` is a guard, not a reproduction, and to be plain about it: **it passes on `main`.** It covers the half of the fix the system test cannot see, cloning the body while still attached, which is what the `historyPoppedWithEmptyState` path does. It fails with the adoption change reverted.

## Two existing tests changed

`upload_after_editor_disposed.test.js` protects the invariant that `Contents#uploadFiles` is a no-op when the editor is disposed. That invariant and its guard are untouched; only the trigger it used to reach that state changed. I verified the rewrite is not hiding a regression:

| | original test | rewritten test |
|---|---|---|
| fix, guard present | passed | passed |
| fix, guard removed from `contents.js` | passed (vacuous) | failed |

The original still passes against the fix, so it was not edited to turn a red test green, but it now passes for the wrong reason. The rewrite genuinely retains the protection.

`upload_survives_teardown.test.js` is a comment-only change: the header claimed teardown runs on every `turbo:before-cache`, which is no longer true.

## Notes for review

- Snapshots now cache the editor's built DOM rather than a stripped one. On restore, stale content is visible for one frame before Lexical reconciles from the `value` attribute, where previously it rebuilt from empty. Arguably a less jarring restore, but it is a real behavioral difference and your call.
- `data-turbo-permanent` editors are unaffected; the removed handler already skipped them.
- Morph recovery never depended on this reset. It runs through the `connected` attribute being stripped by idiomorph, which triggers `connectedChangedCallback`. `test/system/page_refreshes_test.rb` passes.
- `src/elements/prompt.js` keeps its own `turbo:before-cache` listener, which tears down a popover it appends and does not touch the editor lifecycle.
- `bin/rails test:all` 0 failures. `yarn test:browser` passes except `prompts/cursor_moves_away` on firefox and webkit, which fail identically on `main`. `yarn lint`, `bin/rubocop` and `yarn test` all clean.