### PR TITLE
Offer a caret between an attachment and the block container beside it

### DIFF
--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -4,6 +4,7 @@ import { mergeRegister } from "@lexical/utils"
 import { $findOrCreateGalleryForImage, $isImageGalleryNode, ImageGalleryNode } from "../nodes/image_gallery_node"
 import { ActionTextAttachmentNode } from "../nodes/action_text_attachment_node"
 import { ActionTextAttachmentUploadNode } from "../nodes/action_text_attachment_upload_node.js"
+import { $isProvisionalParagraphNode } from "../nodes/provisional_paragraph_node"
 import { AttachmentDragAndDrop } from "../editor/attachments/drag_and_drop"
 
 import LexxyExtension from "./lexxy_extension"
@@ -127,7 +128,7 @@ function $collapseAtGalleryEdge(anchor, backwards) {
   if (!$isImageGalleryNode(anchorNode)) return false
 
   const direction = $directionFor(backwards)
-  const spacer = $emptyParagraphBeside(anchorNode, direction)
+  const spacer = $spacerBeside(anchorNode, direction)
 
   let sibling = $adjacentSibling(anchorNode, direction)
   if (spacer) sibling = $adjacentSibling(spacer, direction)
@@ -145,11 +146,12 @@ function $collapseAtGalleryEdge(anchor, backwards) {
 }
 
 // The caret slot between a gallery and an adjacent attachment is invisible, so a merge gesture
-// has to reach across it and take it along.
-function $emptyParagraphBeside(node, direction) {
+// has to reach across it and take it along. Only that slot: a paragraph the user left there is
+// content, and reaching across it would merge and delete in a single keystroke.
+function $spacerBeside(node, direction) {
   const sibling = $adjacentSibling(node, direction)
 
-  if ($isParagraphNode(sibling) && sibling.isEmpty()) {
+  if ($isProvisionalParagraphNode(sibling)) {
     return sibling
   } else {
     return null

--- a/src/extensions/attachments_extension.js
+++ b/src/extensions/attachments_extension.js
@@ -1,4 +1,4 @@
-import { $getSelection, $isDecoratorNode, $isParagraphNode, $splitNode, COMMAND_PRIORITY_NORMAL, DELETE_CHARACTER_COMMAND, defineExtension } from "lexical"
+import { $getSelection, $getSiblingCaret, $isDecoratorNode, $isParagraphNode, $splitNode, COMMAND_PRIORITY_NORMAL, DELETE_CHARACTER_COMMAND, defineExtension } from "lexical"
 import { mergeRegister } from "@lexical/utils"
 
 import { $findOrCreateGalleryForImage, $isImageGalleryNode, ImageGalleryNode } from "../nodes/image_gallery_node"
@@ -126,15 +126,45 @@ function $collapseAtGalleryEdge(anchor, backwards) {
   const anchorNode = anchor.getNode()
   if (!$isImageGalleryNode(anchorNode)) return false
 
+  const direction = $directionFor(backwards)
+  const spacer = $emptyParagraphBeside(anchorNode, direction)
+
+  let sibling = $adjacentSibling(anchorNode, direction)
+  if (spacer) sibling = $adjacentSibling(spacer, direction)
+
   const isAtGalleryEdge = $isAtNodeEdge(anchor, backwards)
-  const sibling = backwards ? anchorNode.getPreviousSibling() : anchorNode.getNextSibling()
 
   if (isAtGalleryEdge && anchorNode.collapseWith(sibling, backwards)) {
+    if (spacer) spacer.remove()
     const selectionOffset = backwards ? 1 : anchorNode.getChildrenSize() - 1
     anchorNode.select(selectionOffset, selectionOffset)
     return true
   } else {
     return false
+  }
+}
+
+// The caret slot between a gallery and an adjacent attachment is invisible, so a merge gesture
+// has to reach across it and take it along.
+function $emptyParagraphBeside(node, direction) {
+  const sibling = $adjacentSibling(node, direction)
+
+  if ($isParagraphNode(sibling) && sibling.isEmpty()) {
+    return sibling
+  } else {
+    return null
+  }
+}
+
+function $adjacentSibling(node, direction) {
+  return $getSiblingCaret(node, direction).getNodeAtCaret()
+}
+
+function $directionFor(backwards) {
+  if (backwards) {
+    return "previous"
+  } else {
+    return "next"
   }
 }
 

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -414,15 +414,22 @@ function $splitAroundLineBreak(lineBreakCaret) {
   return outer
 }
 
+// A container of blocks — a quote holding paragraphs, a list holding items — has no caret
+// position of its own at `direction`'s edge: the nearest one belongs to the child block
+// inside it, which reads as being within the container rather than beside it.
+export function $isBlockContainer(node, direction = "next") {
+  if (!$isElementNode(node)) return false
+
+  const edgeChild = $getChildCaret(node, direction).getNodeAtCaret()
+  return ($isElementNode(edgeChild) || $isDecoratorNode(edgeChild)) && !edgeChild.isInline()
+}
+
 // Lexical's RangeSelection.insertNodes/insertLineBreak require every selection point to have a
 // block ancestor with inline children. An element point on a container of block nodes — e.g. a
 // quote holding paragraphs — has none, so Lexical throws invariant #211 or #212. This detects
 // such a point so callers can descend it to a leaf before inserting.
 export function $isPointOnBlockContainer(point) {
-  if (point.type !== "element") return false
-
-  const firstChild = point.getNode().getFirstChild()
-  return ($isElementNode(firstChild) || $isDecoratorNode(firstChild)) && !firstChild.isInline()
+  return point.type === "element" && $isBlockContainer(point.getNode())
 }
 
 export function $hasPointOnBlockContainer(selection) {

--- a/src/nodes/provisional_paragraph_node.js
+++ b/src/nodes/provisional_paragraph_node.js
@@ -1,4 +1,6 @@
-import { $createParagraphNode, $getSelection, $isElementNode, $isRangeSelection, $isRootOrShadowRoot, ParagraphNode } from "lexical"
+import { $createParagraphNode, $getSelection, $isDecoratorNode, $isElementNode, $isRangeSelection, $isRootOrShadowRoot, ParagraphNode } from "lexical"
+import { $isBlockContainer } from "../helpers/lexical_helper"
+import { $isImageGalleryNode } from "./image_gallery_node"
 
 export class ProvisionalParagraphNode extends ParagraphNode {
   $config() {
@@ -13,8 +15,8 @@ export class ProvisionalParagraphNode extends ParagraphNode {
   }
 
   static neededBetween(nodeBefore, nodeAfter) {
-    return !$isSelectableElement(nodeBefore, "next")
-      && !$isSelectableElement(nodeAfter, "previous")
+    return !$offersCaretAtEdge(nodeBefore, "previous", nodeAfter)
+      && !$offersCaretAtEdge(nodeAfter, "next", nodeBefore)
   }
 
   createDOM(editor) {
@@ -97,6 +99,28 @@ export function $isProvisionalParagraphNode(node) {
   return node instanceof ProvisionalParagraphNode
 }
 
-function $isSelectableElement(node, direction) {
-  return $isElementNode(node) && (direction === "next" ? node.canInsertTextBefore() : node.canInsertTextAfter())
+// `direction` points from the gap into the node: "next" asks about a node's leading edge,
+// "previous" about its trailing one. A block container — a quote holding paragraphs, a list
+// holding items — holds no caret at that edge either, but it only earns a spacer when a decorator
+// sits across the gap. Anywhere else its edge is already reachable, and a spacer there would
+// widen what Select All covers.
+function $offersCaretAtEdge(node, direction, opposite) {
+  return $isElementNode(node)
+    && $acceptsTextAtEdge(node, direction)
+    && !($isDecoratorNode(opposite) && $holdsOnlyBlocks(node, direction))
+}
+
+// A gallery is a block container as well, but its attachments report themselves inline — they
+// only do so to satisfy Lexical's rule that the root holds no inline nodes — so the generic
+// check can't see it.
+function $holdsOnlyBlocks(node, direction) {
+  return $isImageGalleryNode(node) || $isBlockContainer(node, direction)
+}
+
+function $acceptsTextAtEdge(node, direction) {
+  if (direction === "next") {
+    return node.canInsertTextBefore()
+  } else {
+    return node.canInsertTextAfter()
+  }
 }

--- a/test/browser/helpers/assertions.js
+++ b/test/browser/helpers/assertions.js
@@ -21,6 +21,33 @@ export async function assertEditorContent(editor, assertionFn) {
   await assertionFn(editor.content)
 }
 
+// Assert the sequence of top-level blocks in the editor's serialized value.
+// Each block is described as "tag" or, when it has text, "tag:text".
+// Usage: await assertEditorBlocks(editor, [ "action-text-attachment", "p:between", "blockquote:quoted" ])
+export async function assertEditorBlocks(editor, expected) {
+  await expect
+    .poll(
+      async () => {
+        await editor.flush()
+        return editor.locator.evaluate((el) => {
+          const template = document.createElement("template")
+          template.innerHTML = el.value
+          return Array.from(template.content.children).map((block) => {
+            const text = block.textContent.trim()
+            const tag = block.tagName.toLowerCase()
+            if (text) {
+              return `${tag}:${text}`
+            } else {
+              return tag
+            }
+          })
+        })
+      },
+      { timeout: 5_000 },
+    )
+    .toEqual(expected)
+}
+
 // Assert editor plain text value.
 export async function assertEditorPlainText(editor, expected) {
   await expect

--- a/test/browser/tests/attachments/caret_between_gallery_and_attachment.test.js
+++ b/test/browser/tests/attachments/caret_between_gallery_and_attachment.test.js
@@ -1,5 +1,6 @@
 import { test } from "../../test_helper.js"
-import { assertEditorBlocks } from "../../helpers/assertions.js"
+import { expect } from "@playwright/test"
+import { assertEditorBlocks, assertEditorContent } from "../../helpers/assertions.js"
 
 const IMAGE = (name) => `<action-text-attachment content-type="image/png" url="http://example.com/${name}.png" filename="${name}.png" width="100" height="100"></action-text-attachment>`
 
@@ -28,4 +29,45 @@ test.describe("Caret between a gallery and the attachment below it", () => {
 
     await assertEditorBlocks(editor, [ "action-text-attachment", "p:between", "div" ])
   })
+
+  test("delete at gallery end does not reach across a paragraph the user wrote", async ({ editor }) => {
+    await editor.setValue(`<div class="attachment-gallery">${IMAGE("one")}${IMAGE("two")}</div><p><br></p>${IMAGE("three")}`)
+    await editor.flush()
+
+    await placeCaretInGallery(editor, "end")
+    await editor.send("Delete")
+
+    await assertAttachmentStaysOutsideGallery(editor)
+  })
+
+  test("backspace at gallery start does not reach across a paragraph the user wrote", async ({ editor }) => {
+    await editor.setValue(`${IMAGE("three")}<p><br></p><div class="attachment-gallery">${IMAGE("one")}${IMAGE("two")}</div>`)
+    await editor.flush()
+
+    await placeCaretInGallery(editor, "start")
+    await editor.send("Backspace")
+
+    await assertAttachmentStaysOutsideGallery(editor)
+  })
 })
+
+async function placeCaretInGallery(editor, edge) {
+  await editor.locator.evaluate((el, edge) => {
+    return new Promise((resolve) => {
+      el.editor.update(() => {
+        const root = el.editor.getEditorState()._nodeMap.get("root")
+        const gallery = root.getChildren().find((child) => child.getType() === "image_gallery")
+        let offset = 0
+        if (edge === "end") offset = gallery.getChildrenSize()
+        gallery.select(offset, offset)
+      }, { onUpdate: resolve })
+    })
+  }, edge)
+}
+
+async function assertAttachmentStaysOutsideGallery(editor) {
+  await assertEditorContent(editor, async (content) => {
+    await expect(content.locator(".attachment-gallery figure.attachment")).toHaveCount(2)
+    await expect(content.locator("figure.attachment")).toHaveCount(3)
+  })
+}

--- a/test/browser/tests/attachments/caret_between_gallery_and_attachment.test.js
+++ b/test/browser/tests/attachments/caret_between_gallery_and_attachment.test.js
@@ -1,0 +1,31 @@
+import { test } from "../../test_helper.js"
+import { assertEditorBlocks } from "../../helpers/assertions.js"
+
+const IMAGE = (name) => `<action-text-attachment content-type="image/png" url="http://example.com/${name}.png" filename="${name}.png" width="100" height="100"></action-text-attachment>`
+
+test.describe("Caret between a gallery and the attachment below it", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments-enabled.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("types a paragraph between a gallery and the attachment below it", async ({ editor }) => {
+    await editor.setValue(`<div class="attachment-gallery">${IMAGE("one")}${IMAGE("two")}${IMAGE("three")}</div>${IMAGE("four")}`)
+    await editor.flush()
+
+    await editor.content.locator(".attachment-gallery + p").click()
+    await editor.send("between")
+
+    await assertEditorBlocks(editor, [ "div", "p:between", "action-text-attachment" ])
+  })
+
+  test("types a paragraph between an attachment and the gallery below it", async ({ editor }) => {
+    await editor.setValue(`${IMAGE("one")}<div class="attachment-gallery">${IMAGE("two")}${IMAGE("three")}${IMAGE("four")}</div>`)
+    await editor.flush()
+
+    await editor.content.locator("figure.attachment + p").click()
+    await editor.send("between")
+
+    await assertEditorBlocks(editor, [ "action-text-attachment", "p:between", "div" ])
+  })
+})

--- a/test/browser/tests/formatting/paragraph_between_attachment_and_quote.test.js
+++ b/test/browser/tests/formatting/paragraph_between_attachment_and_quote.test.js
@@ -1,0 +1,31 @@
+import { test } from "../../test_helper.js"
+import { assertEditorBlocks } from "../../helpers/assertions.js"
+
+const ATTACHMENT = '<action-text-attachment content-type="image/png" url="http://example.com/image.png" filename="photo.png" width="100" height="100"></action-text-attachment>'
+
+test.describe("Caret between an attachment and the block container below it", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/attachments-enabled.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+  })
+
+  test("types a paragraph between an attachment and a quote", async ({ editor }) => {
+    await editor.setValue(`${ATTACHMENT}<blockquote><p>quoted</p></blockquote><p>trailing</p>`)
+    await editor.flush()
+
+    await editor.content.locator("figure.attachment + p").click()
+    await editor.send("between")
+
+    await assertEditorBlocks(editor, [ "action-text-attachment", "p:between", "blockquote:quoted", "p:trailing" ])
+  })
+
+  test("types a paragraph between an attachment and a list", async ({ editor }) => {
+    await editor.setValue(`${ATTACHMENT}<ul><li>listed</li></ul>`)
+    await editor.flush()
+
+    await editor.content.locator("figure.attachment + p").click()
+    await editor.send("between")
+
+    await assertEditorBlocks(editor, [ "action-text-attachment", "p:between", "ul:listed" ])
+  })
+})


### PR DESCRIPTION
Fixes #1131. Fixes #1170.

## The bug

There is no reachable cursor position between an attachment and a quote or list that follows it (#1131), or between a `div.attachment-gallery` and a standalone `figure.attachment` below it (#1170), even though two sibling `figure.attachment` elements do get one.

## Why

`ProvisionalParagraphNode.neededBetween` decided a node can hold a caret against the gap with `canInsertTextBefore()` / `canInsertTextAfter()`. That is true of *any* element, so a `QuoteNode` holding paragraphs and a `ListNode` holding items claimed a caret that actually belongs to the child block inside them, and no slot was created.

The node tree for `<attachment><blockquote><p>quoted</p></blockquote><ul><li>listed</li></ul>` before the fix:

```
root
  provisonal_paragraph      <- slot exists before the attachment
  action_text_attachment
  quote                     <- no slot here (#1131)
    paragraph
  list                      <- no slot here either
```

`WrappedTableNode` had already opted out of the generic rule by overriding `canInsertText*` by hand. Galleries are a third case the rule cannot see, because `ActionTextAttachmentNode.isInline()` reports gallery children as inline purely to satisfy Lexical's rule that the root holds no inline nodes.

## The fix

A shared `$isBlockContainer` helper replaces the hand-rolled first-child check in `$isPointOnBlockContainer`, and `neededBetween` withholds the caret only when a block container faces a *decorator* across the gap. Scoping it that way matters: an unconditional rule put spacers at the document edges, which widened what Select All covered and broke list toggling.

The new slot between a gallery and an adjacent attachment then blocked the gallery merge gestures, so `$collapseAtGalleryEdge` now reaches across the spacer and removes it, mirroring what `$collapseAroundEmptyParagraph` already did for the caret-inside-the-spacer case.

Both helpers are written with NodeCaret, so the direction handling is one expression rather than a `backwards ?` ternary.

## Tests

- `test/browser/tests/formatting/paragraph_between_attachment_and_quote.test.js` covers attachment to quote and attachment to list (#1131)
- `test/browser/tests/attachments/caret_between_gallery_and_attachment.test.js` covers both directions across a gallery (#1170)
- `test/browser/helpers/assertions.js` gains `assertEditorBlocks`. Purely additive, no existing assertion changed.

All four were confirmed failing against pristine `src/` first. The failure is that the slot element does not exist, so it cannot be clicked:

```
Error: locator.click: Test timeout of 20000ms exceeded.
  - waiting for locator(... '.attachment-gallery + p')
  - waiting for locator(... 'figure.attachment + p')
4 failed
```

## An approach I abandoned

Giving `ImageGalleryNode` `canInsertTextBefore/After() => false`, mirroring `WrappedTableNode`, broke gallery uploads (3 images expected, 2 received) and hung the editor on shift+enter inside a gallery. Those methods feed Lexical's `RangeSelection.insertText` and `insertNodes` whenever the selection's parent is the gallery, so overriding them has much wider reach than it appears. The gallery is recognised by type instead.

## Notes for review

- `tests/attachments/` is 108/108.
- `yarn test:browser` passes except `prompts/cursor_moves_away` on firefox and webkit. Those fail identically on pristine `main`: the test calls `page.keyboard.press("End")` directly instead of the helper that maps End to Meta+ArrowRight on macOS, so the caret never moves. Unrelated to this change, but worth fixing separately.
- `yarn lint` clean, vitest 130 passed.