### PR TITLE
Pasted plain text from Notepad turns into a code block

### DIFF
--- a/src/editor/clipboard.js
+++ b/src/editor/clipboard.js
@@ -1,4 +1,4 @@
-import { marked } from "marked"
+import { Marked } from "marked"
 import { isAutolinkableURL } from "../helpers/string_helper"
 import { nextFrame } from "../helpers/timing_helper"
 import { addBlockSpacing, dispatch, parseHtml } from "../helpers/html_helper"
@@ -8,6 +8,12 @@ import { $insertDataTransferForRichText } from "@lexical/clipboard"
 import { $createLinkNode, $isLinkNode, $toggleLink } from "@lexical/link"
 import { ListenerBin } from "../helpers/listener_helper"
 import NodeInserter from "./contents/node_inserter"
+
+// Markdown reads any line indented by a tab or four spaces as a code block. Pasted
+// plain text is full of incidental indentation — outlines, notes, logs — and nobody
+// indents a note meaning "this is code"; they fence it. Keep fences, drop the
+// indentation rule.
+const pastedMarkdown = new Marked({ breaks: true }).use({ tokenizer: { code: () => undefined } })
 
 export default class Clipboard {
   #listeners = new ListenerBin()
@@ -195,7 +201,7 @@ export default class Clipboard {
   }
 
   #pasteMarkdown(text) {
-    const html = marked(text, { breaks: true })
+    const html = pastedMarkdown.parse(text)
     const doc = parseHtml(html)
 
     if (this.#isPlainTextWithoutMarkdown(doc)) {

--- a/src/editor/contents.js
+++ b/src/editor/contents.js
@@ -52,7 +52,7 @@ export default class Contents {
   insertText(text, { tag } = {}) {
     this.editor.update(() => {
       const paragraph = $createParagraphNode()
-      text.split("\n").forEach((line, index) => {
+      text.split(/\r\n|\r|\n/).forEach((line, index) => {
         if (index > 0) paragraph.append($createLineBreakNode())
         paragraph.append($createTextNode(line))
       })

--- a/test/browser/tests/paste/windows_plain_text.test.js
+++ b/test/browser/tests/paste/windows_plain_text.test.js
@@ -1,0 +1,73 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+import { assertEditorContent, assertEditorHtml } from "../../helpers/assertions.js"
+
+// Notepad and other Windows editors put text/plain on the clipboard with CRLF
+// line endings and no text/html flavor at all.
+test.describe("Paste — Windows plain text", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/")
+    await editor.waitForConnected()
+  })
+
+  test("keeps CRLF line endings as single line breaks", async ({ editor }) => {
+    await editor.paste("first line\r\nsecond line")
+
+    await assertEditorHtml(editor, "<p>first line<br>second line</p>")
+  })
+
+  test("keeps an indented outline as text instead of a code block", async ({ editor }) => {
+    const outline = [
+      "\tBACKUPS",
+      "\t\tContinued optimizations.",
+      "CYBERSECURITY",
+      "\tHIBP",
+    ].join("\r\n")
+
+    await editor.paste(outline)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toHaveCount(0)
+    })
+    expect(await editor.plainTextValue()).toBe(outline.replaceAll("\r\n", "\n"))
+  })
+
+  test("keeps a space-indented outline as text instead of a code block", async ({ editor }) => {
+    const outline = "REQUESTS\r\n    NAC\r\n        FLOYD"
+
+    await editor.paste(outline)
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toHaveCount(0)
+    })
+    expect(await editor.plainTextValue()).toBe(outline.replaceAll("\r\n", "\n"))
+  })
+
+  test("keeps an indented paragraph after a blank line out of a code block", async ({ editor }) => {
+    await editor.paste("CYBERSECURITY\r\n\r\n\tGENERAL\r\n\t\tARC")
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toHaveCount(0)
+      await expect(content).toContainText("GENERAL")
+      await expect(content).toContainText("ARC")
+    })
+  })
+
+  test("still converts a fenced code block", async ({ editor }) => {
+    await editor.paste("```\r\nputs 'hello'\r\n```")
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("code")).toHaveCount(1)
+      await expect(content.locator("code")).toContainText("puts 'hello'")
+    })
+  })
+
+  test("still converts an indented nested list", async ({ editor }) => {
+    await editor.paste("- one\r\n    - nested\r\n- two")
+
+    await assertEditorContent(editor, async (content) => {
+      await expect(content.locator("ul ul li")).toHaveText([ "nested" ])
+      await expect(content.locator("code")).toHaveCount(0)
+    })
+  })
+})


### PR DESCRIPTION
Pasting plain text copied from Notepad into a Basecamp editor mangles it two ways: an indented outline turns into a syntax-highlighted code block, and every line break doubles.

Notepad puts `text/plain` on the clipboard with CRLF line endings and no `text/html` flavor at all, so the paste goes through `#pasteMarkdown`.

**Indentation read as code.** Markdown treats any line indented by a tab or four spaces as a code block, and `marked` obliged — an outline of indented notes came back as `<pre><code>`. Pasted plain text is full of incidental indentation (outlines, notes, logs) and nobody indents a note meaning "this is code"; they fence it. So this drops `marked`'s indented-code tokenizer for pasted text. Fenced blocks and indented nested lists still convert.

**CRLF doubled every line break.** `Contents#insertText` — the verbatim path taken when the text carries no markdown — split on `\n` alone, leaving a stray `\r` at the end of each text node that rendered as a second line break. It now splits on all three line-ending forms.

Reported against Ping/check-in answers on Windows 10 / Chrome, where the customer's indented notes pasted as a code block and switching the block's language to Plain Text didn't bring them back.
