### PR TITLE
Credit @petitpois for the reported DOMPurify url bypass

### DIFF
--- a/src/helpers/sanitization_helper.js
+++ b/src/helpers/sanitization_helper.js
@@ -9,7 +9,8 @@ import Lexxy from "../config/lexxy"
 // Until 3.3.2 that never came up: attributes admitted by a *functional* ADD_ATTR
 // skipped URI validation entirely (GHSA-cjmm-f4jc-qw8r), which is how data:
 // URLs worked here — and, less happily, how `url="javascript:…"` survived too.
-// The fix restored validation for both.
+// The fix restored validation for both. The bypass was reported to us by
+// @petitpois via HackerOne.
 //
 // So `url` is marked URI-safe, which hands the decision to this hook. The hook
 // only ever removes an attribute — it never force-keeps one — so scoping stays


### PR DESCRIPTION
One-line follow-up to #1229. That PR shipped the DOMPurify 3.4.13 bump and the compensating attachment-`url` hook, and cites the advisory (`GHSA-cjmm-f4jc-qw8r`) in `sanitization_helper.js` — but it doesn't name the reporter.

The bypass was reported to us via HackerOne by **@petitpois** (report closed **Informative** — the attachment `url` is inert at our `img[src]` sink, so it isn't a working stored XSS in an in-scope app). On the H1 thread we promised to credit the DOMPurify finding in the fix, so this adds a credit line right beside the existing advisory citation.

Comment-only; no behavior change. The credit lives here rather than in a published GHSA deliberately — a lexxy advisory would over-assert a vulnerability the Informative close declined. Ready to fold into the next beta.

Closes the credit gap left by #1229; supersedes the credit line in #1238.