### PR TITLE
Allow <s> and <u> tags in Action Text sanitization

### DIFF
--- a/lib/lexxy/engine.rb
+++ b/lib/lexxy/engine.rb
@@ -52,7 +52,7 @@ module Lexxy
     initializer "lexxy.sanitization" do |app|
       ActiveSupport.on_load(:action_text_content) do
         default_allowed_tags = Class.new.include(ActionText::ContentHelper).new.sanitizer_allowed_tags
-        ActionText::ContentHelper.allowed_tags = default_allowed_tags + %w[ video audio source embed table tbody tr th td ]
+        ActionText::ContentHelper.allowed_tags = default_allowed_tags + %w[ s u video audio source embed table tbody tr th td ]
 
         default_allowed_attributes = Class.new.include(ActionText::ContentHelper).new.sanitizer_allowed_attributes
         ActionText::ContentHelper.allowed_attributes = default_allowed_attributes + %w[ controls poster data-language style value start ]

--- a/test/system/inline_formatting_round_trip_test.rb
+++ b/test/system/inline_formatting_round_trip_test.rb
@@ -1,0 +1,25 @@
+require "application_system_test_case"
+
+class InlineFormattingRoundTripTest < ApplicationSystemTestCase
+  test "strikethrough and underline round-trip through edit, save, show, and re-edit" do
+    visit edit_post_path(posts(:hello_world))
+    wait_for_editor
+
+    find_editor.select "everyone"
+    find_editor.toggle_command "strikethrough"
+    find_editor.toggle_command "underline"
+
+    assert_editor_html "<p>Hello <u><s>everyone</s></u></p>"
+
+    click_on "Update Post"
+
+    within "article.post" do
+      assert_selector "u s", text: "everyone"
+    end
+
+    click_on "Edit this post"
+    wait_for_editor
+
+    assert_editor_html "<p>Hello <u><s>everyone</s></u></p>"
+  end
+end


### PR DESCRIPTION
The toolbar's strikethrough and underline buttons are exported by Lexical as `<s>` and `<u>` tags respectively.  Neither tag is in the allowlist the `lexxy.sanitization` initializer sets, so both buttons produce formatting that saves fine and then gets stripped when the HTML is rendered.

Apps can create an initializer to update this themselves, but there is no documentation that this is a required step.
