### PR TITLE
Insert a dropped attachment above the block when the caret is at its start

### DIFF
--- a/src/editor/contents/node_inserter.js
+++ b/src/editor/contents/node_inserter.js
@@ -4,13 +4,15 @@ import ShadowRootNodeInserter from "./node_inserter/shadow_root_node_inserter"
 import NodeSelectionNodeInserter from "./node_inserter/node_selection_node_inserter"
 import ListItemNodeInserter from "./node_inserter/list_item_node_inserter"
 import BlockContainerNodeInserter from "./node_inserter/block_container_node_inserter"
+import BlockStartNodeInserter from "./node_inserter/block_start_node_inserter"
 
 const INSERTERS = [
   CodeNodeInserter,
   ShadowRootNodeInserter,
   NodeSelectionNodeInserter,
   ListItemNodeInserter,
-  BlockContainerNodeInserter
+  BlockContainerNodeInserter,
+  BlockStartNodeInserter
 ]
 
 // Defined here rather than on the base class so the base can stay free of any

--- a/src/editor/contents/node_inserter/block_start_node_inserter.js
+++ b/src/editor/contents/node_inserter/block_start_node_inserter.js
@@ -1,0 +1,40 @@
+import { $isElementNode, $isRangeSelection, $isRootNode } from "lexical"
+import { $findMatchingParent } from "@lexical/utils"
+import { $isBlockDecoratorNode } from "../../../helpers/lexical_helper"
+import BaseNodeInserter from "./base_node_inserter"
+
+// Lexical's RangeSelection.insertNodes holds on to the caret's block across its own call to
+// insertParagraph(), and HeadingNode.insertNewAfter swaps that block for a paragraph when the
+// caret is at offset 0. insertNodes then inserts after a node that has left the document and
+// Lexical throws invariant #66. An attachment dropped at the start of a block belongs above it
+// anyway, so place it there rather than splitting the block around the caret.
+export default class BlockStartNodeInserter extends BaseNodeInserter {
+  static handles(selection) {
+    return $isRangeSelection(selection) && selection.isCollapsed() && selection.anchor.offset === 0
+  }
+
+  insertNodes(nodes) {
+    const block = this.#blockAtCaret()
+
+    if (block && nodes.every($isBlockDecoratorNode)) {
+      for (const node of nodes) {
+        block.insertBefore(node)
+      }
+    } else {
+      this.selection.insertNodes(nodes)
+    }
+  }
+
+  #blockAtCaret() {
+    const block = $findMatchingParent(this.selection.anchor.getNode(), node =>
+      $isElementNode(node) && !node.isInline() && !$isRootNode(node)
+    )
+
+    // An empty block is already a usable insertion point, and inserting above it would strand it.
+    if (block && block.isEmpty()) {
+      return null
+    } else {
+      return block
+    }
+  }
+}

--- a/src/editor/contents/node_inserter/list_item_node_inserter.js
+++ b/src/editor/contents/node_inserter/list_item_node_inserter.js
@@ -1,7 +1,7 @@
-import { $isDecoratorNode, $isRangeSelection, $splitNode } from "lexical"
+import { $isRangeSelection, $splitNode } from "lexical"
 import { $isListItemNode, $isListNode, ListItemNode } from "@lexical/list"
 import { $getNearestNodeOfType } from "@lexical/utils"
-import { $isBlankNode } from "../../../helpers/lexical_helper"
+import { $isBlankNode, $isBlockDecoratorNode } from "../../../helpers/lexical_helper"
 import BaseNodeInserter from "./base_node_inserter"
 
 // A list item can only hold inline content, so a block node (such as an image
@@ -16,7 +16,8 @@ export default class ListItemNodeInserter extends BaseNodeInserter {
   }
 
   insertNodes(nodes) {
-    if (nodes.some(node => this.#isBlockDecorator(node))) {
+    // Pasted element blocks (paragraphs, quotes) keep Lexical's own list-escape semantics.
+    if (nodes.some($isBlockDecoratorNode)) {
       this.#insertAroundList(nodes)
     } else {
       this.selection.insertNodes(nodes)
@@ -64,12 +65,5 @@ export default class ListItemNodeInserter extends BaseNodeInserter {
 
   #removeEmptyList(list) {
     if ($isListNode(list) && list.isEmpty()) list.remove()
-  }
-
-  // Only block decorator nodes (image/file attachments) are intercepted. A list
-  // item cannot hold them, so they must break out. Pasted element blocks
-  // (paragraphs, quotes) keep Lexical's own list-escape semantics.
-  #isBlockDecorator(node) {
-    return $isDecoratorNode(node) && !node.isInline()
   }
 }

--- a/src/helpers/lexical_helper.js
+++ b/src/helpers/lexical_helper.js
@@ -25,6 +25,10 @@ export function $isShadowRoot(node) {
   return $isElementNode(node) && $isRootOrShadowRoot(node) && !$isRootNode(node)
 }
 
+export function $isBlockDecoratorNode(node) {
+  return $isDecoratorNode(node) && !node.isInline()
+}
+
 export function $isSafeForRoot(node) {
   return ($isElementNode(node) || $isDecoratorNode(node)) && !node.isParentRequired()
 }

--- a/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
+++ b/test/browser/tests/attachments/upload_into_unsupported_selection.test.js
@@ -179,4 +179,48 @@ test.describe("Uploading into an unsupported selection", () => {
     expect(errors).toEqual([])
     await expect(editor.content.locator("figure.attachment")).toHaveCount(1, { timeout: 10_000 })
   })
+  // "Expected node to have a parent": RangeSelection.insertNodes holds on to the caret's block
+  // across its own insertParagraph(), and HeadingNode.insertNewAfter replaces that block when the
+  // caret is at offset 0, so insertNodes went on to insert after a node that had left the document.
+  test("uploading a file with the caret at the start of a heading lands it above the heading", async ({ page, editor }) => {
+    await editor.setValue("<h2>Design system</h2>")
+    await editor.flush()
+    await editor.placeCaretInside("Design system", 0)
+
+    const errorMessage = await uploadDroppedPdf(page)
+
+    expect(errorMessage).toBeNull()
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(1, { timeout: 10_000 })
+    await expect(editor.content.locator("h2")).toHaveText("Design system")
+    const blocks = await editor.content.evaluate((element) =>
+      Array.from(element.children).map((child) => child.tagName.toLowerCase())
+    )
+    expect(blocks.indexOf("figure")).toBeLessThan(blocks.indexOf("h2"))
+  })
+
+  test("uploading a file with the caret inside a heading splits the heading around it", async ({ page, editor }) => {
+    await editor.setValue("<h2>Design system</h2>")
+    await editor.flush()
+    await editor.placeCaretInside("Design system", 6)
+
+    const errorMessage = await uploadDroppedPdf(page)
+
+    expect(errorMessage).toBeNull()
+    await expect(editor.content.locator("figure.attachment")).toHaveCount(1, { timeout: 10_000 })
+    await expect(editor.content.locator("h2")).toHaveCount(2)
+  })
 })
+
+// Contents#uploadFiles is the entry point a document-level drop zone relays dropped files through.
+async function uploadDroppedPdf(page) {
+  return page.evaluate(() => {
+    const editorElement = document.querySelector("lexxy-editor")
+    const file = new File([ "%PDF-1.4 dummy" ], "dropped.pdf", { type: "application/pdf" })
+    try {
+      editorElement.contents.uploadFiles([ file ])
+      return null
+    } catch (error) {
+      return error.message
+    }
+  })
+}


### PR DESCRIPTION
Dropping a file with the caret at the very start of a heading throws Lexical invariant #66 ("Expected node to have a parent") and the file is lost. The editor is left inconsistent, so a Backspace straight after throws invariant #75.

RangeSelection.insertNodes keeps a reference to the caret's block while it calls insertParagraph(). HeadingNode.insertNewAfter replaces that block with a paragraph when the caret is at offset 0, so insertNodes goes on to insert after a node that has already left the document.

Lexical fixed this on their side in 0.47.0, by re-resolving firstBlock when it is no longer attached. Lexxy pins ^0.44.0, which under npm's 0.x caret can never reach that. I tried the bump instead of this change: lexical 0.49.0 does fix the crash with no source change, but it fails six existing tests here:

- formatting/block_formatting.test.js > toggle nested bullet list off
- formatting/list_in_quote.test.js > backspace after clearing the first bullet's text removes the blank line
- formatting/list_in_quote.test.js > backspace on a blank first list item merges the gap instead of stranding a paragraph
- formatting/list_item_deletion.test.js > deleting empty middle list item keeps cursor in the list
- paste/paste_into_quote.test.js > pasting multi-line content into a quote started via the markdown shortcut keeps every line inside the quote
- paste/paste_into_quote.test.js > the QuoteNode transform does not re-wrap toolbar-button quote children

So this adds BlockStartNodeInserter, which places a dropped attachment above the block when the caret sits at its start rather than splitting the block around the caret. Empty blocks are left to Lexical, since they are already a usable insertion point. It puts the attachment in the same place lexical 0.47 does, so it can be dropped whenever the bump happens.

It also moves the block-decorator check out of ListItemNodeInserter into $isBlockDecoratorNode, now that two inserters need it.

- reproduces on lexical 0.38.2 through 0.46.0, driven through Contents#uploadFiles the way a document-level drop zone does
- the new test fails on main and passes with the change
- yarn lint clean, yarn test green, yarn test:browser green on chromium, firefox and webkit, apart from tables/toolbar.test.js which already fails on main