### PR TITLE
fix: heading dropdown applying H1 instead of H4/H5/H6 on click

### DIFF
--- a/src/elements/dropdown/heading.js
+++ b/src/elements/dropdown/heading.js
@@ -106,7 +106,6 @@ export class HeadingDropdown extends HTMLElement {
     const button = document.createElement("button")
     button.type = "button"
     button.dataset.heading = tag
-    button.dataset.command = HeadingDropdown.commandFor(index)
     button.classList.add("lexxy-heading-button")
     button.name = name
     button.title = label
@@ -116,12 +115,12 @@ export class HeadingDropdown extends HTMLElement {
   }
 
   #registerButtonHandlers() {
-    this.#headingButtons.forEach(button => {
+    this.#headingButtons.forEach((button, index) => {
       this.#listeners.track(registerEventListener(button, "click", (event) => {
         if (!this.#editor) return
 
         event.preventDefault()
-        this.#editor.dispatchCommand(button.dataset.command, button.dataset.heading)
+        this.#editor.dispatchCommand(HeadingDropdown.commandFor(index), button.dataset.heading)
         this.#editor.focus()
       }))
     })

--- a/test/browser/tests/formatting/heading_format.test.js
+++ b/test/browser/tests/formatting/heading_format.test.js
@@ -133,6 +133,17 @@ test.describe("Heading format", () => {
     await assertEditorHtml(editor, "<h3>Lexxy</h3>")
   })
 
+  test("clicking a heading beyond the built-in presets applies its own tag", async ({ page, editor }) => {
+    await recreateEditorWithHeadings(page, [ "h1", "h2", "h3", "h4", "h5", "h6" ])
+    await editor.waitForConnected()
+
+    await editor.setValue("<p>Lexxy</p>")
+    await editor.select("Lexxy")
+
+    await clickToolbarButton(page, "heading-6")
+    await assertEditorHtml(editor, "<h6>Lexxy</h6>")
+  })
+
   test("heading inside blockquote shows heading button as active, not paragraph", async ({ page, editor }) => {
     await editor.setValue("<p>Lexxy</p>")
     await editor.select("Lexxy")


### PR DESCRIPTION
# Problem
Clicking H4, H5, or H6 in the heading dropdown silently applies H1 instead. H1/H2/H3 (the three built-in presets) work fine.

Every heading button fires two dispatchCommand calls per click, because of an event-bubbling collision between two independent listeners:

1. HeadingDropdown#registerButtonHandlers (src/elements/dropdown/heading.js) attaches a click listener directly on each heading button, dispatching with the correct payload (button.dataset.heading, e.g. "h6").
2. That same button also carried a data-command attribute, so the click bubbled up into the toolbar's own generic delegated listener (LexicalToolbarElement#bindButtons / #dispatchButtonCommand in src/elements/toolbar.js), which matches [data-command] and re-dispatches the same command — but reads dataset.payload instead of dataset.heading. Heading buttons never set data-payload, so this second dispatch passes undefined.

For H1–H3 the command is one of the three dedicated presets (setFormatHeadingLarge/Medium/Small), whose handler ignores its argument — so the redundant second dispatch is harmless. For H4–H6 the command is the shared applyHeadingFormat, whose handler uses the payload directly via $createHeadingNode(tag), which defaults headingTag to "h1" — so the second, payload-less dispatch silently overwrites the just-applied heading with H1.

# Solution
HeadingDropdown already owns dispatch for its own buttons end-to-end, so data-command on those buttons was never needed — it only existed to (accidentally) feed the toolbar's generic delegated dispatch. Other dropdowns with their own click handlers (HighlightDropdown, LinkDropdown) already avoid data-command for this same reason.

This PR removes data-command from heading buttons and has #registerButtonHandlers resolve the command from the button's index directly, so the click never reaches the toolbar's [data-command] listener.

# Testing
- Added a Playwright regression test (clicking a heading beyond the built-in presets applies its own tag) that configures 6 heading levels and does a real toolbar click on H6, asserting `<h6>` lands. Confirmed it fails against the old code (produces `<h1>`) and passes with the fix.
- yarn lint — clean.
- yarn test:browser (full suite, all 3 browser projects) — 1308 passed, 0 failures on chromium/firefox. All ~90 webkit failures are browserType.launch errors from missing system libraries in my sandbox, unrelated to this change (confirmed by reproducing one directly). 4 flaky (attachment drag/drop tests, unrelated, passed on retry).