### PR TITLE
Fix selection-navigation crashes on stale node selections

### DIFF
--- a/src/editor/contents/node_inserter/list_item_node_inserter.js
+++ b/src/editor/contents/node_inserter/list_item_node_inserter.js
@@ -31,15 +31,18 @@ export default class ListItemNodeInserter extends BaseNodeInserter {
     // very corruption we are avoiding. The block must land at the list's level.
     const anchorNode = this.selection.anchor.getNode()
     const outerList = this.#outermostList(anchorNode)
-    const topItem = this.#topLevelItemFor(anchorNode, outerList)
 
-    // A blank top-level bullet is just the insertion point (e.g. the user pressed
-    // Enter to leave the list); break out of it entirely. A bullet with content —
-    // including one wrapping a nested list — splits so its content stays in the list.
-    const splitAfterItem = $isBlankNode(topItem) ? topItem.getPreviousSibling() : topItem
-    const splitIndex = splitAfterItem ? splitAfterItem.getIndexWithinParent() + 1 : 0
-    const [ listBefore, listAfter ] = $splitNode(outerList, splitIndex)
-    if ($isBlankNode(topItem)) { topItem.remove() }
+    // removeText() can relocate the anchor before we read it back — clean out
+    // of the list when the removed range spanned it. With no list left to
+    // split, default insertion applies.
+    if (!outerList) {
+      this.selection.insertNodes(nodes)
+      return
+    }
+
+    const topItem = this.#topLevelItemFor(anchorNode, outerList)
+    const [ listBefore, listAfter ] = $splitNode(outerList, this.#splitIndexFor(topItem))
+    if (topItem && $isBlankNode(topItem)) { topItem.remove() }
 
     let anchor = listBefore ?? listAfter
     for (const node of nodes) {
@@ -50,6 +53,18 @@ export default class ListItemNodeInserter extends BaseNodeInserter {
     this.#removeEmptyList(listBefore)
     this.#removeEmptyList(listAfter)
     nodes.at(-1).selectNext()
+  }
+
+  // A blank top-level bullet is just the insertion point (e.g. the user pressed
+  // Enter to leave the list); break out of it entirely. A bullet with content —
+  // including one wrapping a nested list — splits so its content stays in the
+  // list. With no top-level bullet at all — removeText() relocated the anchor
+  // onto the list node itself — the anchor offset is the boundary between items.
+  #splitIndexFor(topItem) {
+    if (!topItem) return this.selection.anchor.offset
+
+    const splitAfterItem = $isBlankNode(topItem) ? topItem.getPreviousSibling() : topItem
+    return splitAfterItem ? splitAfterItem.getIndexWithinParent() + 1 : 0
   }
 
   #outermostList(node) {

--- a/src/editor/selection.js
+++ b/src/editor/selection.js
@@ -503,10 +503,17 @@ export default class Selection {
       || this.#selectInLexical(this.topLevelNodeAfterCursor)
   }
 
+  // hasNodeSelection reads the committed state, while $getSelection() resolves
+  // against the pending one — so the selection here can be missing, no longer a
+  // NodeSelection, or reference a node that no longer exists (empty editor,
+  // just-deleted node, decorator boundary). Only invoke the callback when a
+  // node actually resolves; returning false lets the callers fall back —
+  // #selectInLexical for plain arrows, native pass-through for shift-arrows.
   #withCurrentNodeSelectionNode(fn) {
-    if (this.hasNodeSelection) {
-      return fn($getSelection().getNodes()[0])
-    }
+    const selection = this.hasNodeSelection ? $getSelection() : null
+    const currentNode = $isNodeSelection(selection) ? selection.getNodes()[0] : undefined
+
+    return currentNode ? fn(currentNode) : false
   }
 
   #rangeSelectDecorator(node, direction = "forward") {

--- a/test/browser/fixtures/stale-node-selection.html
+++ b/test/browser/fixtures/stale-node-selection.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lexxy Test — Stale Node Selection</title>
+  <link rel="stylesheet" href="/styles.css">
+  <script type="module">
+    import { $createNodeSelection, $setSelection } from "lexical"
+    window.__lex = { $createNodeSelection, $setSelection }
+  </script>
+</head>
+<body>
+  <form>
+    <div class="body">
+      <lexxy-editor class="lexxy-content" placeholder="Write something..."></lexxy-editor>
+    </div>
+  </form>
+
+  <script type="module" src="/editor.js"></script>
+</body>
+</html>

--- a/test/browser/tests/editor/stale_node_selection_navigation.test.js
+++ b/test/browser/tests/editor/stale_node_selection_navigation.test.js
@@ -1,0 +1,47 @@
+import { test } from "../../test_helper.js"
+import { expect } from "@playwright/test"
+
+// A committed NodeSelection can outlive the node it references (empty editor,
+// just-deleted node, decorator boundary). Selection#withCurrentNodeSelectionNode
+// used to hand that unresolved node (undefined) straight to the arrow-key
+// handlers, crashing on currentNode.selectPrevious / selectNext /
+// getTopLevelElement (Sentry BC3-JS-N8HQ / N8HR / N8HS).
+test.describe("Arrow navigation with a stale node selection", () => {
+  test.beforeEach(async ({ page, editor }) => {
+    await page.goto("/stale-node-selection.html")
+    await page.waitForSelector("lexxy-editor[connected]")
+
+    await editor.setValue("<p>Hello</p><p>World</p>")
+    await editor.focus()
+
+    // Commit the stale state: a NodeSelection whose key no longer resolves to
+    // a node, so getNodes() comes back empty.
+    await page.evaluate(() => {
+      const element = document.querySelector("lexxy-editor")
+      element.editor.update(() => {
+        const selection = window.__lex.$createNodeSelection()
+        selection.add("9999")
+        window.__lex.$setSelection(selection)
+      }, { discrete: true })
+    })
+  })
+
+  test("arrow keys do not crash when the selected node no longer resolves", async ({ page, editor }) => {
+    const errors = []
+    page.on("pageerror", (error) => errors.push(error.message))
+
+    await editor.content.press("ArrowRight")
+    await editor.content.press("ArrowLeft")
+    await editor.content.press("ArrowUp")
+    await editor.content.press("ArrowDown")
+    await editor.flush()
+
+    expect(errors).toHaveLength(0)
+
+    // The editor remains usable: clicking back in restores a caret and typing works
+    await editor.placeCaretInside("World", 5)
+    await editor.send("!")
+    await editor.flush()
+    expect(await editor.value()).toContain("World!")
+  })
+})

--- a/test/javascript/unit/editor/list_item_node_inserter.test.js
+++ b/test/javascript/unit/editor/list_item_node_inserter.test.js
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { $createRangeSelection, $getRoot, $setSelection } from "lexical"
+import { createTestEditor, destroyTestEditor, setContent } from "../helpers/editor_helper"
+import NodeInserter from "src/editor/contents/node_inserter"
+import ListItemNodeInserter from "src/editor/contents/node_inserter/list_item_node_inserter"
+import { ActionTextAttachmentNode } from "src/nodes/action_text_attachment_node"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+// The inserter is chosen while the selection anchor sits inside a list item,
+// but #insertAroundList calls removeText() before reading the anchor back —
+// and the removal can relocate it onto the list node itself, or clean out of
+// the list. That used to crash in $isBlankNode(undefined) (Sentry BC3-JS-N8G0).
+describe("ListItemNodeInserter with a relocated anchor", () => {
+  function insertAttachment(selectionFor) {
+    editorElement.editor.update(() => {
+      const selection = selectionFor()
+      $setSelection(selection)
+      const attachment = new ActionTextAttachmentNode({ contentType: "image/png", fileName: "photo.png" })
+      NodeInserter.for(selection).insertNodes([ attachment ])
+    }, { discrete: true })
+  }
+
+  test("splits at the anchor offset when removeText() collapses onto the list node", async () => {
+    editorElement = await createTestEditor()
+    await setContent(editorElement, "<ul><li>One</li><li>Two</li><li>Three</li></ul>")
+
+    // Anchoring inside the second item with the focus at the list's element
+    // point selects ListItemNodeInserter, then removeText() collapses the
+    // selection onto the list node itself — no top-level item resolves.
+    const insert = () => insertAttachment(() => {
+      const list = $getRoot().getFirstChild()
+      const secondItemText = list.getChildAtIndex(1).getFirstChild()
+      const selection = $createRangeSelection()
+      selection.anchor.set(secondItemText.getKey(), 0, "text")
+      selection.focus.set(list.getKey(), 1, "element")
+      return selection
+    })
+
+    expect(insert).not.toThrow()
+    expect(editorElement.value).toMatch(
+      /^<ul><li[^>]*>One<\/li><\/ul><action-text-attachment[^>]*><\/action-text-attachment><ul><li[^>]*>Two<\/li><li[^>]*>Three<\/li><\/ul>$/
+    )
+  })
+
+  test("falls back to default insertion when the anchor left the list entirely", async () => {
+    editorElement = await createTestEditor()
+    await setContent(editorElement, "<ul><li>One</li></ul><p>After</p>")
+
+    // Constructed directly: this is the post-removeText() shape where the
+    // inserter was already chosen but the anchor no longer sits in any list,
+    // which NodeInserter.for would no longer route here.
+    editorElement.editor.update(() => {
+      const paragraph = $getRoot().getLastChild()
+      const selection = $createRangeSelection()
+      selection.anchor.set(paragraph.getKey(), 0, "element")
+      selection.focus.set(paragraph.getKey(), 0, "element")
+
+      const attachment = new ActionTextAttachmentNode({ contentType: "image/png", fileName: "photo.png" })
+      new ListItemNodeInserter(selection).insertNodes([ attachment ])
+    }, { discrete: true })
+
+    expect(editorElement.value).toMatch(
+      /^<ul><li[^>]*>One<\/li><\/ul><p[^>]*>After<\/p><action-text-attachment[^>]*><\/action-text-attachment><p[^>]*>(<br>)?<\/p>$/
+    )
+  })
+})

--- a/test/javascript/unit/editor/stale_node_selection_navigation.test.js
+++ b/test/javascript/unit/editor/stale_node_selection_navigation.test.js
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "vitest"
+import {
+  $createNodeSelection, $createParagraphNode, $getNodeByKey, $getRoot, $setSelection,
+  KEY_ARROW_DOWN_COMMAND, KEY_ARROW_LEFT_COMMAND, KEY_ARROW_RIGHT_COMMAND, KEY_ARROW_UP_COMMAND
+} from "lexical"
+import { createTestEditor, destroyTestEditor, setContent } from "../helpers/editor_helper"
+
+let editorElement
+
+afterEach(async () => {
+  await destroyTestEditor(editorElement)
+})
+
+const ARROWS = [
+  [ "ArrowRight", KEY_ARROW_RIGHT_COMMAND ],
+  [ "ArrowLeft", KEY_ARROW_LEFT_COMMAND ],
+  [ "ArrowUp", KEY_ARROW_UP_COMMAND ],
+  [ "ArrowDown", KEY_ARROW_DOWN_COMMAND ]
+]
+
+function pressArrow(command, key) {
+  editorElement.editor.dispatchCommand(command, new KeyboardEvent("keydown", { key, cancelable: true }))
+}
+
+// A committed NodeSelection can outlive the node it references (empty editor,
+// just-deleted node, decorator boundary): hasNodeSelection reads the committed
+// state while $getSelection() resolves against the pending one, so the pending
+// selection's getNodes() can come back empty. The arrow-key handlers used to
+// receive that unresolved node (undefined) and crash on selectPrevious /
+// selectNext / getTopLevelElement (Sentry BC3-JS-N8HQ / N8HR / N8HS).
+describe("arrow navigation with a stale node selection", () => {
+  describe.each(ARROWS)("%s", (key, command) => {
+    test("does not crash when the pending selection no longer resolves the node", async () => {
+      editorElement = await createTestEditor()
+      await setContent(editorElement, "<p>Hello</p><p>World</p>")
+
+      // Commit a valid NodeSelection…
+      let selectedKey
+      editorElement.editor.update(() => {
+        selectedKey = $getRoot().getLastChild().getKey()
+        const selection = $createNodeSelection()
+        selection.add(selectedKey)
+        $setSelection(selection)
+      }, { discrete: true })
+
+      // …then schedule (non-discrete) a replacement, so the committed state
+      // still resolves the node while the pending NodeSelection does not.
+      editorElement.editor.update(() => {
+        $getNodeByKey(selectedKey).replace($createParagraphNode())
+      })
+
+      expect(() => pressArrow(command, key)).not.toThrow()
+    })
+
+    test("does not crash when the committed selection references a node that never resolves", async () => {
+      editorElement = await createTestEditor()
+      await setContent(editorElement, "<p>Hello</p><p>World</p>")
+
+      editorElement.editor.update(() => {
+        const selection = $createNodeSelection()
+        selection.add("9999")
+        $setSelection(selection)
+      }, { discrete: true })
+
+      expect(() => pressArrow(command, key)).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Fixes selection-navigation crashes when the editor holds a NodeSelection whose node no longer resolves (empty editor, just-deleted attachment, decorator boundary). Regression first shipped in 0.9.19, from the 06-03 arrow-key refactor.

## Root cause

**Arrow-key navigation:** `Selection#withCurrentNodeSelectionNode` called `fn($getSelection().getNodes()[0])` whenever `hasNodeSelection` was true. But `hasNodeSelection` reads the *committed* editor state while `$getSelection()` resolves against the *pending* one — so a NodeSelection referencing a just-deleted or replaced node yields `getNodes() === []`, and the arrow/backspace navigation handlers crash on `undefined.selectPrevious` / `.selectNext` / `.getTopLevelElement`. Regression from the 06-03 arrow-key refactor (1650e665, 19de4455), first shipped in 0.9.19.

**List inserter:** `ListItemNodeInserter#insertAroundList` calls `removeText()` and then re-reads `this.selection.anchor` — the removal can relocate the anchor onto the list node itself (or clean out of the list), so no top-level list item resolves and `$isBlankNode(undefined)` crashes on `getTextContent`. Introduced by 7a180710 (#1123).

## Fix

- `#withCurrentNodeSelectionNode` only invokes the callback when the live selection is a NodeSelection whose first node resolves; returning `false` otherwise lets the callers' existing fallbacks engage (`#selectInLexical` for plain arrows, native pass-through for shift-arrows).
- `#insertAroundList` splits at the anchor's element offset when the anchor sits on the list node (the offset *is* the boundary between items), and falls back to default insertion when the anchor left the list entirely.

## Reproduction & verification

Reproduced in a real browser (Playwright WebKit against the `test/browser` vite harness): committing a NodeSelection whose key no longer resolves, then pressing arrow keys, produces the crash (`undefined is not an object (evaluating 'currentNode.selectNext')`, `…'currentNode.getTopLevelElement'`) from `onKeyDown → triggerCommandListeners`. With the fix, the same sequence is clean and the editor stays usable.

- New unit tests cover all four arrow commands under both stale shapes (committed-resolves/pending-empty via `replace()`, and a never-resolving key) plus both inserter anchor shapes with exact-placement assertions — all fail on `main` with the same error messages, pass with the fix.
- New Playwright test arms the stale NodeSelection and presses real arrow keys on chromium/firefox/webkit.
- Full vitest suite (192) and full Playwright suites green on all three browsers.
