### PR TITLE
Preserve links inside code blocks through retokenization and rendering

### DIFF
--- a/src/elements/editor.js
+++ b/src/elements/editor.js
@@ -33,7 +33,7 @@ import { getHighlightStyles } from "../helpers/format_helper"
 import { styleResolverRoot } from "../helpers/style_resolver_root"
 
 import { CustomActionTextAttachmentNode } from "../nodes/custom_action_text_attachment_node"
-import { exportTextNodeDOM } from "../helpers/text_node_export_helper"
+import { exportCodeHighlightNodeDOM, exportTextNodeDOM } from "../helpers/text_node_export_helper"
 import { ProvisionalParagraphExtension } from "../extensions/provisional_paragraph_extension"
 import { CodeHighlightingExtension } from "../extensions/code_highlighting_extension"
 import { HighlightExtension } from "../extensions/highlight_extension"
@@ -427,7 +427,7 @@ export class LexicalEditorElement extends HTMLElement {
       theme: theme,
       nodes: this.#lexicalNodes,
       html: {
-        export: new Map([ [ TextNode, exportTextNodeDOM ], [ CodeHighlightNode, exportTextNodeDOM ] ])
+        export: new Map([ [ TextNode, exportTextNodeDOM ], [ CodeHighlightNode, exportCodeHighlightNodeDOM ] ])
       },
       $initialEditorState: (editor) => {
         this.#configureSanitizer(editor)

--- a/src/extensions/code_highlighting_extension.js
+++ b/src/extensions/code_highlighting_extension.js
@@ -1,6 +1,7 @@
 import { defineExtension } from "lexical"
-import { registerCodeHighlighting } from "@lexical/code"
-import { buildHighlightPreservingTokenizer } from "./highlight_extension"
+import { PrismTokenizer, registerCodeHighlighting } from "@lexical/code"
+import { $applyHighlightRangesToTokens, $takeHighlightRanges } from "./highlight_extension"
+import { $applyLinkRangesToTokens, $extractLinkRangesFromCodeNode } from "../helpers/code_link_helper"
 import LexxyExtension from "./lexxy_extension"
 
 // Registers code highlighting through the extension system so its node
@@ -17,8 +18,30 @@ export class CodeHighlightingExtension extends LexxyExtension {
     return defineExtension({
       name: "lexxy/code-highlighting",
       register(editor) {
-        return registerCodeHighlighting(editor, buildHighlightPreservingTokenizer(editor))
+        return registerCodeHighlighting(editor, buildMarkupPreservingTokenizer(editor))
       }
     })
+  }
+}
+
+// The code retokenizer replaces a code block's children with freshly created
+// tokens that carry no styles or links, which would drop color highlights and
+// hyperlinks on every edit. This tokenizer wraps the stock Prism tokenizer to
+// restore both: it recovers the block's highlight and link ranges — staged
+// during HTML import, or read from the children the fresh tokens are about to
+// replace — and reapplies them to the fresh tokens before the retokenizer
+// splices them in.
+function buildMarkupPreservingTokenizer(editor) {
+  return {
+    defaultLanguage: PrismTokenizer.defaultLanguage,
+    tokenize(code, language) {
+      return PrismTokenizer.tokenize(code, language)
+    },
+    $tokenize(codeNode, language) {
+      const linkRanges = $extractLinkRangesFromCodeNode(codeNode)
+      const highlightRanges = $takeHighlightRanges(editor, codeNode)
+      const tokens = PrismTokenizer.$tokenize(codeNode, language)
+      return $applyLinkRangesToTokens($applyHighlightRangesToTokens(tokens, highlightRanges), linkRanges)
+    }
   }
 }

--- a/src/extensions/highlight_extension.js
+++ b/src/extensions/highlight_extension.js
@@ -1,8 +1,9 @@
-import { $getNodeByKey, $getState, $hasUpdateTag, $isTextNode, $setState, COMMAND_PRIORITY_NORMAL, PASTE_TAG, TextNode, createCommand, createState, defineExtension } from "lexical"
+import { $getNodeByKey, $getState, $hasUpdateTag, $isElementNode, $isTextNode, $setState, COMMAND_PRIORITY_NORMAL, PASTE_TAG, TextNode, createCommand, createState, defineExtension } from "lexical"
 import { $getSelection, $isRangeSelection } from "lexical"
 import { $getSelectionStyleValueForProperty, $patchStyleText, getCSSFromStyleObject, getStyleObjectFromCSS } from "@lexical/selection"
-import { $createCodeHighlightNode, $createCodeNode, $isCodeHighlightNode, $isCodeNode, CodeHighlightNode, PrismTokenizer } from "@lexical/code"
+import { $createCodeHighlightNode, $createCodeNode, $isCodeHighlightNode, $isCodeNode, CodeHighlightNode } from "@lexical/code"
 import { extendTextNodeConversion } from "../helpers/lexical_helper"
+import { segmentTextByRanges } from "../helpers/text_range_helper"
 import { StyleCanonicalizer, applyCanonicalizers, hasHighlightStyles } from "../helpers/format_helper"
 import { RichTextExtension } from "@lexical/rich-text"
 import LexxyExtension from "./lexxy_extension"
@@ -178,27 +179,10 @@ function extractHighlightStyleFromElement(element) {
   return css.length > 0 ? css : null
 }
 
-// The code retokenizer replaces a code block's children with freshly created
-// tokens that carry no styles, which would drop color highlights on every
-// edit. This tokenizer wraps the stock Prism tokenizer to restore them: it
-// recovers the block's highlight ranges — staged during HTML import, or read
-// from the children the fresh tokens are about to replace — and reapplies
-// them to the fresh tokens before the retokenizer splices them in.
-export function buildHighlightPreservingTokenizer(editor) {
-  return {
-    defaultLanguage: PrismTokenizer.defaultLanguage,
-    tokenize(code, language) {
-      return PrismTokenizer.tokenize(code, language)
-    },
-    $tokenize(codeNode, language) {
-      const tokens = PrismTokenizer.$tokenize(codeNode, language)
-      const highlights = $takeHighlightRanges(editor, codeNode)
-      return $applyHighlightRangesToTokens(tokens, highlights)
-    }
-  }
-}
-
-function $takeHighlightRanges(editor, codeNode) {
+// Recover the highlight ranges to reapply after a retokenization: the ranges
+// staged during HTML import, or the ones read from the children the fresh
+// tokens are about to replace.
+export function $takeHighlightRanges(editor, codeNode) {
   const pending = $getPendingHighlights(editor)
   const key = codeNode.getKey()
 
@@ -216,7 +200,7 @@ function $takeHighlightRanges(editor, codeNode) {
   }
 }
 
-function $applyHighlightRangesToTokens(tokens, highlights) {
+export function $applyHighlightRangesToTokens(tokens, highlights) {
   if (highlights.length === 0) return tokens
 
   const styledTokens = []
@@ -239,50 +223,23 @@ function $applyHighlightRangesToTokens(tokens, highlights) {
 // attached to the tree yet, so we create CodeHighlightNode replacements.
 function $splitTokenAtHighlightBoundaries(token, tokenStart, highlights) {
   const text = token.getTextContent()
-  const segments = segmentTextByHighlights(text, tokenStart, highlights)
+  const segments = segmentTextByRanges(text, tokenStart, highlights)
 
   if (segments.length === 1) {
     const [ segment ] = segments
-    if (segment.style) {
-      $applyHighlightStyleToToken(token, segment.style)
+    if (segment.range) {
+      $applyHighlightStyleToToken(token, segment.range.style)
     }
     return [ token ]
   } else {
     return segments.map((segment) => {
       const segmentToken = $createCodeHighlightNode(text.slice(segment.start, segment.end), token.getHighlightType())
-      if (segment.style) {
-        $applyHighlightStyleToToken(segmentToken, segment.style)
+      if (segment.range) {
+        $applyHighlightStyleToToken(segmentToken, segment.range.style)
       }
       return segmentToken
     })
   }
-}
-
-// Partition a token's text into consecutive { start, end, style } segments,
-// where offsets are relative to the token and style is null for the stretches
-// no highlight covers.
-function segmentTextByHighlights(text, tokenStart, highlights) {
-  const segments = []
-  let cursor = 0
-
-  for (const { start, end, style } of highlights) {
-    const from = Math.max(start - tokenStart, cursor)
-    const to = Math.min(end - tokenStart, text.length)
-
-    if (from < to) {
-      if (from > cursor) {
-        segments.push({ start: cursor, end: from, style: null })
-      }
-      segments.push({ start: from, end: to, style })
-      cursor = to
-    }
-  }
-
-  if (cursor < text.length) {
-    segments.push({ start: cursor, end: text.length, style: null })
-  }
-
-  return segments
 }
 
 function $applyHighlightStyleToToken(token, style) {
@@ -294,16 +251,23 @@ function $buildChildRanges(codeNode) {
   const childRanges = []
   let charOffset = 0
 
-  for (const child of codeNode.getChildren()) {
-    if ($isCodeHighlightNode(child) || $isTextNode(child)) {
-      const text = child.getTextContent()
-      childRanges.push({ node: child, start: charOffset, end: charOffset + text.length })
-      charOffset += text.length
-    } else {
-      // LineBreakNode, TabNode - count as 1 character each (\n, \t)
-      charOffset += 1
+  function walk(node) {
+    for (const child of node.getChildren()) {
+      if ($isElementNode(child)) {
+        // e.g. a LinkNode awaiting its first retokenization
+        walk(child)
+      } else if ($isCodeHighlightNode(child) || $isTextNode(child)) {
+        const text = child.getTextContent()
+        childRanges.push({ node: child, start: charOffset, end: charOffset + text.length })
+        charOffset += text.length
+      } else {
+        // LineBreakNode - counts as 1 character (\n)
+        charOffset += 1
+      }
     }
   }
+
+  walk(codeNode)
 
   return childRanges
 }

--- a/src/helpers/code_highlighting_helper.js
+++ b/src/helpers/code_highlighting_helper.js
@@ -16,12 +16,13 @@ export function highlightElement(preElement) {
   const grammar = Prism.languages?.[language]
   if (!grammar) return
 
-  // Read the source text and <mark> ranges in a single walk, before Prism
-  // rewrites the element. Sharing one traversal keeps the highlight offsets
-  // aligned with the code string and preserves leading whitespace — deriving
-  // either of them separately (e.g. textContent through DOMParser) collapses
-  // leading whitespace and shifts every range, re-indenting the rendered block.
-  const { code, highlights } = extractCodeAndHighlights(preElement)
+  // Read the source text and the <mark> and <a> ranges in a single walk,
+  // before Prism rewrites the element. Sharing one traversal keeps the range
+  // offsets aligned with the code string and preserves leading whitespace —
+  // deriving either of them separately (e.g. textContent through DOMParser)
+  // collapses leading whitespace and shifts every range, re-indenting the
+  // rendered block.
+  const { code, highlights, links } = extractCodeAndMarkup(preElement)
 
   const highlightedHtml = Prism.highlight(code, grammar, language)
   preElement.innerHTML = highlightedHtml
@@ -30,18 +31,24 @@ export function highlightElement(preElement) {
     applyHighlightRanges(preElement, highlights)
   }
 
+  if (links.length > 0) {
+    applyLinkRanges(preElement, links)
+  }
+
   preElement.dataset.highlighted = "true"
 }
 
-// Walk the <pre> once, building Prism's source text and the <mark> ranges
-// together: a text node contributes its text verbatim, a <br> contributes a
-// newline, and a <mark> records the slice of code it covers. Because both
-// outputs come from the same walk, every range offset is just a position in
-// `code` — so the highlights can't drift out of sync with the source, and the
-// block's leading whitespace survives (HTML parsing would collapse it).
-function extractCodeAndHighlights(preElement) {
+// Walk the <pre> once, building Prism's source text and the <mark> and <a>
+// ranges together: a text node contributes its text verbatim, a <br>
+// contributes a newline, and a <mark> or <a> records the slice of code it
+// covers. Because all outputs come from the same walk, every range offset is
+// just a position in `code` — so the markup can't drift out of sync with the
+// source, and the block's leading whitespace survives (HTML parsing would
+// collapse it).
+function extractCodeAndMarkup(preElement) {
   const root = preElement.querySelector("code") || preElement
   const highlights = []
+  const links = []
   let code = ""
 
   function walk(node) {
@@ -59,6 +66,12 @@ function extractCodeAndHighlights(preElement) {
         if (style) {
           highlights.push({ start, end: code.length, style })
         }
+      } else if (node.tagName === "A" && node.getAttribute("href")) {
+        const start = code.length
+        for (const child of node.childNodes) {
+          walk(child)
+        }
+        links.push({ start, end: code.length, attributes: linkAttributes(node) })
       } else {
         for (const child of node.childNodes) {
           walk(child)
@@ -71,7 +84,17 @@ function extractCodeAndHighlights(preElement) {
     walk(child)
   }
 
-  return { code, highlights }
+  return { code, highlights, links }
+}
+
+function linkAttributes(element) {
+  const attributes = { href: element.getAttribute("href") }
+  for (const name of [ "target", "rel", "title" ]) {
+    if (element.getAttribute(name)) {
+      attributes[name] = element.getAttribute(name)
+    }
+  }
+  return attributes
 }
 
 function extractStyle(element) {
@@ -81,16 +104,32 @@ function extractStyle(element) {
   return parts.length > 0 ? parts.join(" ") : null
 }
 
-// Wrap character ranges in <mark> elements within a Prism-highlighted DOM tree.
-// Each range is applied independently, re-collecting text nodes each time to
-// account for splits from previous ranges.
+// Wrap character ranges in <mark> or <a> elements within a Prism-highlighted
+// DOM tree. Each range is applied independently, re-collecting text nodes
+// each time to account for splits from previous ranges.
 function applyHighlightRanges(element, highlights) {
   for (const { start, end, style } of highlights) {
-    wrapRange(element, start, end, style)
+    wrapRange(element, start, end, () => {
+      const mark = document.createElement("mark")
+      mark.setAttribute("style", style)
+      return mark
+    })
   }
 }
 
-function wrapRange(container, rangeStart, rangeEnd, style) {
+function applyLinkRanges(element, links) {
+  for (const { start, end, attributes } of links) {
+    wrapRange(element, start, end, () => {
+      const anchor = document.createElement("a")
+      for (const [ name, value ] of Object.entries(attributes)) {
+        anchor.setAttribute(name, value)
+      }
+      return anchor
+    })
+  }
+}
+
+function wrapRange(container, rangeStart, rangeEnd, createWrapper) {
   const textNodes = collectTextNodes(container)
 
   // Process in reverse so DOM mutations don't shift earlier text node offsets
@@ -105,14 +144,13 @@ function wrapRange(container, rangeStart, rangeEnd, style) {
     const text = node.textContent
     const parent = node.parentNode
 
-    const mark = document.createElement("mark")
-    mark.setAttribute("style", style)
-    mark.textContent = text.slice(relStart, relEnd)
+    const wrapper = createWrapper()
+    wrapper.textContent = text.slice(relStart, relEnd)
 
     if (relEnd < text.length) {
       parent.insertBefore(document.createTextNode(text.slice(relEnd)), node.nextSibling)
     }
-    parent.insertBefore(mark, node.nextSibling)
+    parent.insertBefore(wrapper, node.nextSibling)
 
     if (relStart > 0) {
       node.textContent = text.slice(0, relStart)

--- a/src/helpers/code_link_helper.js
+++ b/src/helpers/code_link_helper.js
@@ -1,0 +1,132 @@
+import { $getState, $isElementNode, $isTextNode, $setState, createState } from "lexical"
+import { $createCodeHighlightNode, $isCodeHighlightNode } from "@lexical/code"
+import { $isLinkNode } from "@lexical/link"
+import { segmentTextByRanges } from "./text_range_helper"
+
+// The code retokenizer only knows CodeHighlightNode, LineBreakNode and
+// TabNode, so a LinkNode inside a code block — Trix-authored documents allow
+// links in code — is destroyed on the first retokenization. Links survive as
+// state on the tokens instead: this state records the link attributes on each
+// CodeHighlightNode the link covers, the extraction below reads it (or a
+// still-untokenized LinkNode) back into ranges before every retokenization,
+// and the tokenizer reapplies it to the fresh tokens.
+const codeLinkState = createState("codeLink", {
+  parse: (value) => (value && typeof value.url === "string" ? value : null)
+})
+
+export function $getCodeLink(node) {
+  return $getState(node, codeLinkState)
+}
+
+export function $setCodeLink(node, link) {
+  $setState(node, codeLinkState, link)
+}
+
+// Build the list of { start, end, link } ranges covering every link in a code
+// block, with offsets into the block's text content. Links appear either as
+// LinkNode descendants (imported or just created, before their first
+// retokenization) or as link state on tokens (after it). The walk recurses
+// through nested elements because `<pre><code>` imports of multi-line content
+// briefly produce a CodeNode nested inside another before the outer one's
+// retokenization flattens them.
+export function $extractLinkRangesFromCodeNode(codeNode) {
+  const ranges = []
+  let offset = 0
+
+  function walk(node) {
+    for (const child of node.getChildren()) {
+      if ($isLinkNode(child)) {
+        const size = child.getTextContent().length
+        appendRange(ranges, { start: offset, end: offset + size, link: linkAttributesFrom(child) })
+        offset += size
+      } else if ($isElementNode(child)) {
+        walk(child)
+      } else {
+        const size = child.getTextContent().length
+        if ($isTextNode(child)) {
+          const link = $getCodeLink(child)
+          if (link) {
+            appendRange(ranges, { start: offset, end: offset + size, link })
+          }
+        }
+        offset += size
+      }
+    }
+  }
+
+  walk(codeNode)
+
+  return ranges
+}
+
+export function $applyLinkRangesToTokens(tokens, ranges) {
+  if (ranges.length === 0) return tokens
+
+  const linkedTokens = []
+  let offset = 0
+
+  for (const token of tokens) {
+    if ($isCodeHighlightNode(token)) {
+      linkedTokens.push(...$splitTokenAtLinkBoundaries(token, offset, ranges))
+    } else {
+      linkedTokens.push(token)
+    }
+    offset += token.getTextContentSize()
+  }
+
+  return linkedTokens
+}
+
+function $splitTokenAtLinkBoundaries(token, tokenStart, ranges) {
+  const text = token.getTextContent()
+  const segments = segmentTextByRanges(text, tokenStart, ranges)
+
+  if (segments.length === 1) {
+    const [ segment ] = segments
+    if (segment.range) {
+      $setCodeLink(token, segment.range.link)
+    }
+    return [ token ]
+  } else {
+    return segments.map((segment) => {
+      const segmentToken = $cloneTokenSlice(token, text.slice(segment.start, segment.end))
+      if (segment.range) {
+        $setCodeLink(segmentToken, segment.range.link)
+      }
+      return segmentToken
+    })
+  }
+}
+
+function $cloneTokenSlice(token, text) {
+  const segmentToken = $createCodeHighlightNode(text, token.getHighlightType())
+  segmentToken.setStyle(token.getStyle())
+  // CodeHighlightNode.setFormat is a no-op, so carry the format over directly
+  segmentToken.getWritable().__format = token.getFormat()
+  return segmentToken
+}
+
+// Consecutive children carrying the same link merge into a single range, so a
+// link split across tokens by an earlier retokenization keeps covering fresh
+// tokens as one contiguous stretch however they retokenize.
+function appendRange(ranges, range) {
+  const previous = ranges[ranges.length - 1]
+
+  if (previous && previous.end === range.start && sameLink(previous.link, range.link)) {
+    previous.end = range.end
+  } else {
+    ranges.push(range)
+  }
+}
+
+function sameLink(a, b) {
+  return a.url === b.url && a.target === b.target && a.rel === b.rel && a.title === b.title
+}
+
+function linkAttributesFrom(linkNode) {
+  const link = { url: linkNode.getURL() }
+  if (linkNode.getTarget()) link.target = linkNode.getTarget()
+  if (linkNode.getRel()) link.rel = linkNode.getRel()
+  if (linkNode.getTitle()) link.title = linkNode.getTitle()
+  return link
+}

--- a/src/helpers/text_node_export_helper.js
+++ b/src/helpers/text_node_export_helper.js
@@ -1,3 +1,5 @@
+import { $getCodeLink } from "./code_link_helper"
+
 // Custom TextNode exportDOM that avoids redundant wrapping.
 //
 // Lexical's built-in TextNode.exportDOM() calls createDOM() which produces semantic tags
@@ -11,6 +13,30 @@
 //
 // Any <span> elements produced by createDOM() are unwrapped, since they only carry
 // editor classes that aren't meaningful in exported HTML.
+
+// A CodeHighlightNode exports like any other text node, plus an <a> wrapper
+// when it carries link state — that's how a link survives inside a code
+// block, whose retokenizer would destroy an actual LinkNode child.
+export function exportCodeHighlightNodeDOM(editor, codeHighlightNode) {
+  const output = exportTextNodeDOM(editor, codeHighlightNode)
+  const link = $getCodeLink(codeHighlightNode)
+
+  if (link) {
+    return { element: wrapWithAnchor(output.element, link) }
+  } else {
+    return output
+  }
+}
+
+function wrapWithAnchor(element, link) {
+  const anchor = document.createElement("a")
+  anchor.setAttribute("href", link.url)
+  if (link.target) anchor.setAttribute("target", link.target)
+  if (link.rel) anchor.setAttribute("rel", link.rel)
+  if (link.title) anchor.setAttribute("title", link.title)
+  anchor.appendChild(element)
+  return anchor
+}
 
 export function exportTextNodeDOM(editor, textNode) {
   const element = textNode.createDOM(editor._config, editor)

--- a/src/helpers/text_range_helper.js
+++ b/src/helpers/text_range_helper.js
@@ -1,0 +1,27 @@
+// Partition a stretch of text into consecutive { start, end, range } segments,
+// where offsets are relative to the text and range is the covering source
+// range — expressed in outer coordinates as { start, end, ... } — or null for
+// the stretches no range covers. Ranges must be sorted and non-overlapping.
+export function segmentTextByRanges(text, textStart, ranges) {
+  const segments = []
+  let cursor = 0
+
+  for (const range of ranges) {
+    const from = Math.max(range.start - textStart, cursor)
+    const to = Math.min(range.end - textStart, text.length)
+
+    if (from < to) {
+      if (from > cursor) {
+        segments.push({ start: cursor, end: from, range: null })
+      }
+      segments.push({ start: from, end: to, range })
+      cursor = to
+    }
+  }
+
+  if (cursor < text.length) {
+    segments.push({ start: cursor, end: text.length, range: null })
+  }
+
+  return segments
+}

--- a/test/browser/tests/code_highlighting.test.js
+++ b/test/browser/tests/code_highlighting.test.js
@@ -28,6 +28,41 @@ test.describe("Code highlighting", () => {
   })
 })
 
+test.describe("Code block links survive editing", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await page.waitForSelector("lexxy-editor[connected]")
+    await page.waitForSelector("lexxy-toolbar[connected]")
+  })
+
+  test("a link survives typing elsewhere in the code block", async ({ editor }) => {
+    await editor.setValue('<pre data-language="plain"><code>see <a href="https://example.com/">the docs</a> here</code></pre>')
+    await editor.flush()
+
+    await editor.select("here")
+    await editor.send("there")
+    await editor.flush()
+
+    const savedHtml = await editor.value()
+    expect(savedHtml).toContain("see ")
+    expect(savedHtml).toContain("there")
+    expect(savedHtml).toMatch(/<a href="https:\/\/example\.com\/"[^>]*>the docs<\/a>/)
+  })
+
+  test("a link survives typing inside highlighted javascript code", async ({ editor }) => {
+    await editor.setValue('<pre data-language="javascript"><code>const a = 1\n<a href="https://example.com/">docs</a></code></pre>')
+    await editor.flush()
+
+    await editor.select("1")
+    await editor.send("2")
+    await editor.flush()
+
+    const savedHtml = await editor.value()
+    expect(savedHtml).toContain("const a = 2")
+    expect(savedHtml).toMatch(/<a href="https:\/\/example\.com\/"[^>]*>docs<\/a>/)
+  })
+})
+
 test.describe("Code block color highlights survive editing", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/")

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -9,3 +9,9 @@ hello_james:
   name: body
   body:
     <p>Hello <%= ActionText::FixtureSet.attachment("people", :james) %></p>
+
+linked_code:
+  record: linked_code (Post)
+  name: body
+  body:
+    <pre data-language="javascript">const a = 1<br>see <a href="https://example.com/">the docs</a> here</pre>

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -6,3 +6,6 @@ hello_world:
 
 hello_james:
   title: "Hello James"
+
+linked_code:
+  title: "Linked code"

--- a/test/javascript/unit/editor/code_block_links.test.js
+++ b/test/javascript/unit/editor/code_block_links.test.js
@@ -1,0 +1,98 @@
+import { afterEach, expect, test } from "vitest"
+import { $getRoot, $isElementNode } from "lexical"
+import { $isCodeNode } from "@lexical/code"
+import { createTestEditor, destroyTestEditor, tick } from "../helpers/editor_helper"
+
+let editor
+
+afterEach(async () => {
+  if (editor) {
+    await destroyTestEditor(editor)
+    editor = null
+  }
+  document.body.innerHTML = ""
+})
+
+async function loadEditorWithValue(value) {
+  editor = await createTestEditor({ value })
+  await tick()
+  await tick()
+  return editor
+}
+
+function linksIn(value, url) {
+  const container = document.createElement("div")
+  container.innerHTML = value
+  return Array.from(container.querySelectorAll(`pre a[href="${url}"]`))
+}
+
+test("a link inside a code block survives loading and reading the value", async () => {
+  await loadEditorWithValue('<pre data-language="plain"><code>see <a href="https://example.com/">docs</a> here</code></pre>')
+
+  const anchors = linksIn(editor.value, "https://example.com/")
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("docs")
+  expect(editor.value).toContain("see ")
+  expect(editor.value).toContain(" here")
+})
+
+test("a link inside a code block survives an edit elsewhere in the block", async () => {
+  await loadEditorWithValue('<pre data-language="plain"><code>see <a href="https://example.com/">docs</a> here</code></pre>')
+
+  editor.editor.update(() => {
+    const codeNode = $getRoot().getChildren().find($isCodeNode)
+    codeNode.getFirstChild().spliceText(0, 0, "please ")
+  }, { discrete: true })
+  await tick()
+  await tick()
+
+  const anchors = linksIn(editor.value, "https://example.com/")
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("docs")
+  expect(editor.value).toContain("please see ")
+})
+
+test("a link and a highlight coexist inside a code block", async () => {
+  await loadEditorWithValue('<pre data-language="plain"><code>see <a href="https://example.com/">docs</a> and <mark style="background-color: rgb(255, 255, 0);">notes</mark> here</code></pre>')
+
+  const anchors = linksIn(editor.value, "https://example.com/")
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("docs")
+  expect(editor.value).toMatch(/<mark[^>]*>notes<\/mark>/)
+})
+
+test("multiple links inside a code block all survive", async () => {
+  await loadEditorWithValue('<pre data-language="plain"><code><a href="https://one.example.com/">one</a> and <a href="https://two.example.com/">two</a></code></pre>')
+
+  expect(linksIn(editor.value, "https://one.example.com/").map((anchor) => anchor.textContent).join("")).toBe("one")
+  expect(linksIn(editor.value, "https://two.example.com/").map((anchor) => anchor.textContent).join("")).toBe("two")
+})
+
+test("a link inside a Trix-authored code block survives along with its language", async () => {
+  await loadEditorWithValue('<pre language="ruby"><code>require <a href="https://rubygems.org/">gems</a></code></pre>')
+
+  expect(editor.value).toContain('data-language="ruby"')
+  const anchors = linksIn(editor.value, "https://rubygems.org/")
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("gems")
+})
+
+test("a link spanning highlighted syntax tokens survives retokenization", async () => {
+  await loadEditorWithValue('<pre data-language="javascript"><code>const a = 1\n<a href="https://example.com/">const b = 2</a></code></pre>')
+
+  const anchors = linksIn(editor.value, "https://example.com/")
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("const b = 2")
+})
+
+// A link spanning a line break fragments into one anchor per line — the
+// tokens on each side carry the link state, the line break between them
+// can't — but every covered character keeps its link.
+test("a link spanning a line break survives as one anchor per line", async () => {
+  await loadEditorWithValue('<pre data-language="plain"><code><a href="https://example.com/">one\ntwo</a></code></pre>')
+
+  const anchors = linksIn(editor.value, "https://example.com/")
+  expect(anchors.map((anchor) => anchor.textContent)).toEqual([ "one", "two" ])
+})
+
+test("text without links round-trips unchanged", async () => {
+  await loadEditorWithValue('<pre data-language="plain"><code>plain code</code></pre>')
+
+  expect(editor.value).not.toContain("<a")
+  expect(editor.value).toContain("plain code")
+})

--- a/test/javascript/unit/helpers/code_highlighting_helper.test.js
+++ b/test/javascript/unit/helpers/code_highlighting_helper.test.js
@@ -121,6 +121,28 @@ test("highlightElement keeps color highlights on the right text when code is ind
   expect(mark.getAttribute("style")).toContain("background-color: yellow")
 })
 
+test("highlightElement keeps links on the right text", () => {
+  const pre = appendPre("linked", "javascript", "const a = 1<br>see <a href=\"https://example.com/\">the docs</a> here")
+  document.body.appendChild(pre)
+
+  highlightElement(pre)
+
+  const anchors = Array.from(pre.querySelectorAll("a[href='https://example.com/']"))
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("the docs")
+  expect(pre.textContent).toBe("const a = 1\nsee the docs here")
+})
+
+test("highlightElement keeps a link overlapping a color highlight", () => {
+  const pre = appendPre("linkmark", "ruby", "def <a href=\"https://example.com/\"><mark style=\"background-color: yellow;\">hello</mark></a>")
+  document.body.appendChild(pre)
+
+  highlightElement(pre)
+
+  const anchors = Array.from(pre.querySelectorAll("a[href='https://example.com/']"))
+  expect(anchors.map((anchor) => anchor.textContent).join("")).toBe("hello")
+  expect(pre.querySelector("mark").textContent).toBe("hello")
+})
+
 function appendPre(id, language, code) {
   const pre = document.createElement("pre")
   pre.id = id

--- a/test/system/code_block_links_test.rb
+++ b/test/system/code_block_links_test.rb
@@ -1,0 +1,35 @@
+require "application_system_test_case"
+
+class CodeBlockLinksTest < ApplicationSystemTestCase
+  test "links inside a code block survive editing, saving, and rendering" do
+    visit edit_post_path(posts(:linked_code))
+
+    assert_selector "code", text: "see the docs here"
+
+    # Editing the code block retokenizes it. Before the fix the fresh tokens
+    # dropped the link; it must now survive the edit, the save, and the
+    # Prism rewrite of the rendered view.
+    find_editor.place_cursor_at_end
+    find_editor.send "s"
+    assert_selector "code", text: "see the docs heres"
+
+    click_on "Update Post"
+
+    assert_selector "pre[data-language='javascript']"
+    assert_selector "pre a[href='https://example.com/']", text: "the docs"
+  end
+
+  test "links inside a code block survive a re-edit round-trip" do
+    visit edit_post_path(posts(:linked_code))
+    find_editor.place_cursor_at_end
+    find_editor.send "s"
+    click_on "Update Post"
+
+    visit edit_post_path(posts(:linked_code))
+    find_editor.place_cursor_at_end
+    find_editor.send "s"
+    click_on "Update Post"
+
+    assert_selector "pre a[href='https://example.com/']", text: "the docs"
+  end
+end


### PR DESCRIPTION
Editing a document whose code blocks contain hyperlinks silently destroyed those links: they vanished from the saved document after any edit, even one made elsewhere in the document. Content imported from Trix commonly has them — Trix allowed links inside code-formatted text.

### Root cause

Two independent surfaces drop the `<a>` elements:

1. **The editor.** `@lexical/code`'s retokenizer rebuilds a code block's children as fresh `CodeHighlightNode` tokens on every edit, and its node diffing (`getDiffRange`/`isEqual`) treats anything that isn't a `CodeHighlightNode`/`TabNode`/`LineBreakNode` as unequal — so a `LinkNode` child is spliced away on the block's first tokenization, which happens the moment the document loads. #894 already worked around this class of loss for `<mark>` color highlights by snapshotting `{ start, end, style }` ranges and reapplying them to the fresh tokens as style + format, which the diffing ignores. Links had no such path.

2. **The rendered view.** `highlightElement()` rewrites `pre.innerHTML` from `Prism.highlight()` output and re-applied only the `<mark>` ranges it extracted beforehand, so any `<a>` in served content was also lost whenever the block's grammar is loaded.

### Fix

Generalize the highlight-preserving tokenizer into a markup-preserving one:

- Before each retokenization, capture every link as a `{ start, end, link }` range over the block's text — read from `LinkNode` children awaiting their first tokenization, or from link state left on tokens by a previous one. Extraction recurses through nested elements because `<pre><code>` imports of multi-line content briefly produce a `CodeNode` nested inside another before the outer one's retokenization flattens them.
- Reapply the ranges to the fresh tokens as Lexical NodeState, splitting tokens at link boundaries (carrying over the style/format the highlight pass set). State is invisible to the retokenizer's `isEqual`, so the transform converges exactly as the highlight mechanism does.
- Export tokens carrying link state with an `<a>` wrapper (via the existing `html.export` override for `CodeHighlightNode`), so the editor's value round-trips.
- Teach `highlightElement()` to record `<a>` ranges alongside `<mark>` ranges in its single pre-rewrite walk and re-wrap them after the Prism rewrite, parametrizing `wrapRange` over the wrapper element.

The highlight fallback extraction gets the same recursive walk so its offsets stay aligned when a link sits among highlighted text.

### Known limitations

- Inside the editor, a preserved link renders as plain code text (the state has no visual affordance); it survives the round-trip and renders as a link in the saved document. Giving it an in-editor affordance would need a `CodeHighlightNode` replacement or the experimental editor DOM config, which felt out of proportion here.
- A link spanning multiple syntax tokens or line breaks exports as adjacent anchors sharing an href — contiguous and clickable, just fragmented markup. Pinned by a unit test.
- `target`/`rel` are captured and exported but stripped by the existing DOMPurify allowlist, which doesn't permit them on `<a>` today. Widening that allowlist is a separate (security-sensitive) decision; `href` and `title` round-trip.

### Tests

- `test/javascript/unit/editor/code_block_links.test.js`: import → value round-trips through load, edits, Trix-style `<pre language>`, links spanning highlighted tokens and line breaks, link + highlight coexistence. All fail on `main` (the link is dropped); the no-link control passes.
- `test/javascript/unit/helpers/code_highlighting_helper.test.js`: `highlightElement()` keeps links on the right text, including a link overlapping a color highlight.
- `test/system/code_block_links_test.rb`: full Action Text round-trip — edit a seeded document with a link in a JavaScript code block, save, assert the rendered view keeps the anchor; plus a re-edit round-trip. Both fail against `main`'s build.

Full suite green: vitest, Rails `test:all` (system tests included), Playwright chromium.
