### PR TITLE
Keep the caption focused when Enter arrives during IME composition

### DIFF
--- a/src/nodes/action_text_attachment_node.js
+++ b/src/nodes/action_text_attachment_node.js
@@ -438,7 +438,10 @@ export class ActionTextAttachmentNode extends DecoratorNode {
   }
 
   #handleCaptionInputKeydown(event) {
-    if (event.key === "Enter") {
+    // IME confirmation (Korean/Japanese/Chinese) sends Enter with isComposing
+    // and/or keyCode 229 ("Processing"). Stay in the caption until composition
+    // finishes, and don't preventDefault so the IME can commit the syllable.
+    if (event.key === "Enter" && !event.isComposing && event.keyCode !== 229) {
       event.preventDefault()
       event.target.blur()
 

--- a/test/browser/tests/attachments/attachments.test.js
+++ b/test/browser/tests/attachments/attachments.test.js
@@ -143,6 +143,40 @@ test.describe("Attachments", () => {
     await assertEditorValueContains(editor, 'caption="My caption"')
   })
 
+  test("Enter during IME composition stays in the caption", async ({ page, editor }) => {
+    await editor.setValue(
+      '<action-text-attachment content-type="image/png" url="http://example.com/image.png" filename="photo.png"></action-text-attachment>',
+    )
+    await editor.flush()
+
+    const caption = page.locator("figure.attachment figcaption textarea")
+    await expect(caption).toBeVisible()
+
+    await caption.click()
+    await caption.pressSequentially("한글")
+
+    await caption.evaluate((textarea) => {
+      textarea.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 229,
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      }))
+    })
+    await editor.flush()
+
+    const captionHasFocus = await caption.evaluate((textarea) => document.activeElement === textarea)
+    expect(captionHasFocus).toBe(true)
+    await expect(caption).toHaveValue("한글")
+    expect(await editor.value()).not.toContain("<p>한글</p>")
+
+    await caption.press("Enter")
+    await assertEditorHasFocus(editor)
+    await assertEditorValueContains(editor, 'caption="한글"')
+  })
+
   test("caption saves and editor has focus after click", async ({ page, editor }) => {
     await mockActiveStorageUploads(page)
     await editor.uploadFile("test/fixtures/files/example.png")

--- a/test/browser/tests/attachments/attachments.test.js
+++ b/test/browser/tests/attachments/attachments.test.js
@@ -155,16 +155,17 @@ test.describe("Attachments", () => {
     await caption.click()
     await caption.pressSequentially("한글")
 
-    await caption.evaluate((textarea) => {
-      textarea.dispatchEvent(new KeyboardEvent("keydown", {
-        key: "Enter",
-        code: "Enter",
-        keyCode: 229,
-        isComposing: true,
-        bubbles: true,
-        cancelable: true,
-      }))
-    })
+    for (const compositionIndicator of [ { isComposing: true }, { keyCode: 229 } ]) {
+      await caption.evaluate((textarea, indicator) => {
+        textarea.dispatchEvent(new KeyboardEvent("keydown", {
+          key: "Enter",
+          code: "Enter",
+          bubbles: true,
+          cancelable: true,
+          ...indicator,
+        }))
+      }, compositionIndicator)
+    }
     await editor.flush()
 
     const captionHasFocus = await caption.evaluate((textarea) => document.activeElement === textarea)


### PR DESCRIPTION
Fixes #1246

When a user writes Korean text in an image caption and presses Enter to confirm the last syllable, that syllable also appears below the image. `#handleCaptionInputKeydown` treated every Enter as a caption commit: it blurred the textarea and moved the selection into the editor. The blur interrupted the IME composition, and the IME committed the pending syllable into the editor content.

Now the handler ignores an Enter that arrives during composition, detected with `event.isComposing` and `keyCode` 229 ("Processing"). The next Enter, after the composition ends, saves the caption and moves focus to the editor.

A new Playwright test dispatches a synthetic Enter with `isComposing: true` and `keyCode: 229`, because Playwright cannot drive a real IME. The test fails without the guard and passes with it. Note: Chrome sometimes delivers `compositionend` before the keydown. In that case `isComposing` is already false, and the `keyCode === 229` check covers it.


### Before the fix

https://github.com/user-attachments/assets/b3e7032f-ba2a-454c-9b9c-dd7c90f5d489

### After the fix


https://github.com/user-attachments/assets/eee48b13-f138-4d0d-9a17-3c34c1e74155

